### PR TITLE
Update electron

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5809,9 +5809,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "33.0.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-33.0.2.tgz",
-      "integrity": "sha512-C2WksfP0COsMHbYXSJG68j6S3TjuGDrw/YT42B526yXalIlNQZ2GeAYKryg6AEMkIp3p8TUfDRD0+HyiyCt/nw==",
+      "version": "33.2.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-33.2.0.tgz",
+      "integrity": "sha512-PVw1ICAQDPsnnsmpNFX/b1i/49h67pbSPxuIENd9K9WpGO1tsRaQt+K2bmXqTuoMJsbzIc75Ce8zqtuwBPqawA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/src/background/window/security.ts
+++ b/src/background/window/security.ts
@@ -8,7 +8,15 @@ const allowedIPCSenders = [
   { protocol: "file:", host: /^$/ },
 ];
 
-export function validateIPCSender(frame: WebFrameMain) {
+export function validateIPCSender(frame: WebFrameMain | null) {
+  if (!frame) {
+    // TODO:
+    //   electron 33.0.2 から 33.2.0 へのアップデートで frame が null になる可能性が生じるようになった。
+    //   ただし、null になるのはナビゲーション中やフレーム破棄後であるとされ、ここに null が渡されるケースは無いと思われる。
+    //   null の場合に例外を投げるようにしても良いが、十分な検証ができるまではエラーログの出力に留める。
+    getAppLogger().error("validateIPCSender: frame is null");
+    return;
+  }
   const u = new URL(frame.url);
   for (const allowed of allowedIPCSenders) {
     if (u.protocol === allowed.protocol && allowed.host.test(u.host)) {

--- a/src/tests/background/window/security.spec.ts
+++ b/src/tests/background/window/security.spec.ts
@@ -7,6 +7,7 @@ describe("security", () => {
     validateIPCSender({
       url: "file:///home/shogi/apps/shogihome/assets.asr",
     } as any);
+    validateIPCSender(null);
   });
 
   it("validateIPCSender/notAllowed", () => {


### PR DESCRIPTION
# 説明 / Description

electron のアップデートにより webFrame が `WebFrameMain  | null` に変わったので対応する。
null になるのは navigation や destroyed なときらしいので、基本的には発生しないと理解している。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for null values in the IPC sender validation process, preventing potential issues when the frame is null.

- **Refactor**
	- Updated the method signature to allow for null values, enhancing the robustness of the function.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->