### PR TITLE
エンジン設定の比較ダイアログでゼロ値の表示が省略される問題を修正

### DIFF
--- a/src/renderer/view/dialog/USIEngineMergeDialog.vue
+++ b/src/renderer/view/dialog/USIEngineMergeDialog.vue
@@ -36,7 +36,7 @@
             <div class="row">
               <div class="engine-column">
                 <input
-                  v-if="option.leftValue"
+                  v-if="option.leftValue !== undefined"
                   class="option-value"
                   readonly
                   :value="option.leftValue"
@@ -44,7 +44,7 @@
               </div>
               <div class="engine-column">
                 <input
-                  v-if="option.rightValue"
+                  v-if="option.rightValue !== undefined"
                   class="option-value"
                   readonly
                   :value="option.rightValue"


### PR DESCRIPTION
# 説明 / Description

エンジン設定を比較するときにゼロと undefined を区別していなかったため、ゼロ値の場合に値自体を表示していなかったので修正する。
比較相手の数値の表示やマージ機能自体に問題は無かった。

### 修正前

最大ノード数の左側の値が表示されていない。
![スクリーンショット 2024-11-17 180752](https://github.com/user-attachments/assets/b3697b5a-f506-45d7-9ab8-3890deda2129)


### 修正後
![スクリーンショット 2024-11-17 180852](https://github.com/user-attachments/assets/f000283f-f458-42e4-8459-48aa7f0066e5)

# チェックリスト / Checklist

- MUST
  - [ ] `npm test` passed
  - [ ] `npm run lint` was applied without warnings
  - [ ] changes of `/docs/webapp` not included (except release branch)
  - [ ] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n
