### PR TITLE
エンジンのファイルを差し替える機能

### DIFF
--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -335,6 +335,7 @@ export const en: Texts = {
   earlyPonder: "Early Pondering",
   enginePath: "Engine Path",
   openDirectory: "Open Directory",
+  replaceEnginePath: "Replace Engine Path",
   displayName: "Display Name",
   invoke: "Invoke",
   resetToEngineDefaultValues: "Reset to default values",
@@ -659,6 +660,8 @@ export const en: Texts = {
   sourceDirectoryNotSet: "Source directory is not set.",
   minPlyMustBeLessThanMaxPly: "Min ply must be less than max ply.",
   playerNameNotSet: "Player name is not set.",
+  incompatibleOptionsWillBeDiscardedDoYouReallyWantToReplaceTheEnginePath:
+    "Incompatible options will be discarded. Do you really want to replace the engine path?",
   totalNumber: (n: number) => `Total: ${n}`,
   number: (n: number) => "" + n,
   tryToReloginToCSAServerNSecondsLater: (n) => `Try to relogin to the CSA server in ${n} seconds.`,

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -335,6 +335,7 @@ export const ja: Texts = {
   earlyPonder: "早期Ponder",
   enginePath: "場所",
   openDirectory: "フォルダを開く",
+  replaceEnginePath: "エンジン再選択",
   displayName: "表示名",
   invoke: "実行",
   resetToEngineDefaultValues: "エンジンの既定値に戻す",
@@ -659,6 +660,8 @@ export const ja: Texts = {
   sourceDirectoryNotSet: "フォルダを選択してください。",
   minPlyMustBeLessThanMaxPly: "最小手数は最大手数より小さくしてください。",
   playerNameNotSet: "対局者名が設定されていません。",
+  incompatibleOptionsWillBeDiscardedDoYouReallyWantToReplaceTheEnginePath:
+    "互換性のないオプションがある場合それらは破棄されます。エンジンを置き換えますか？",
   totalNumber: (n: number) => `合計 ${n} 件`,
   number: (n: number) => `${n} 件`,
   tryToReloginToCSAServerNSecondsLater: (n) => `CSAサーバーへのログインを${n}秒後に再試行します。`,

--- a/src/common/i18n/locales/vi.ts
+++ b/src/common/i18n/locales/vi.ts
@@ -335,6 +335,7 @@ export const vi: Texts = {
   earlyPonder: "Tính nhanh",
   enginePath: "Đường dẫn phần mềm",
   openDirectory: "Mở đường dẫn",
+  replaceEnginePath: "エンジン再選択", // TODO: translate
   displayName: "Tên hiển thị",
   invoke: "Thực hiện",
   resetToEngineDefaultValues: "Đặt lại về giá trị ban đầu",
@@ -656,6 +657,8 @@ export const vi: Texts = {
   sourceDirectoryNotSet: "フォルダを選択してください。", // TODO: translate
   minPlyMustBeLessThanMaxPly: "最小手数は最大手数より小さくしてください。", // TODO: translate
   playerNameNotSet: "対局者名が設定されていません。", // TODO: translate
+  incompatibleOptionsWillBeDiscardedDoYouReallyWantToReplaceTheEnginePath:
+    "互換性のないオプションがある場合それらは破棄されます。エンジンを置き換えますか？", // TODO: translate
   totalNumber: (n: number) => `Tổng: ${n}`,
   number: (n: number) => "" + n,
   tryToReloginToCSAServerNSecondsLater: (n) => `Vui lòng đăng nhập lại sau ${n} giây.`,

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -332,6 +332,7 @@ export const zh_tw: Texts = {
   earlyPonder: "預先Ponder",
   enginePath: "場所",
   openDirectory: "開啟資料夾",
+  replaceEnginePath: "エンジン再選択", // TODO: translate
   displayName: "表示名稱",
   invoke: "執行",
   resetToEngineDefaultValues: "回復至引擎預設設定",
@@ -645,6 +646,8 @@ export const zh_tw: Texts = {
   sourceDirectoryNotSet: "フォルダを選択してください。", // TODO: translate
   minPlyMustBeLessThanMaxPly: "最小手数は最大手数より小さくしてください。", // TODO: translate
   playerNameNotSet: "対局者名が設定されていません。", // TODO: translate
+  incompatibleOptionsWillBeDiscardedDoYouReallyWantToReplaceTheEnginePath:
+    "互換性のないオプションがある場合それらは破棄されます。エンジンを置き換えますか？", // TODO: translate
   totalNumber: (n: number) => `總計 ${n} 筆`,
   number: (n: number) => `${n} 筆`,
   tryToReloginToCSAServerNSecondsLater: (n) => `請在${n}秒後再次嘗試登入 CSA 伺服器。`,

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -330,6 +330,7 @@ export type Texts = {
   earlyPonder: string;
   enginePath: string;
   openDirectory: string;
+  replaceEnginePath: string;
   displayName: string;
   invoke: string;
   resetToEngineDefaultValues: string;
@@ -631,6 +632,7 @@ export type Texts = {
   sourceDirectoryNotSet: string;
   minPlyMustBeLessThanMaxPly: string;
   playerNameNotSet: string;
+  incompatibleOptionsWillBeDiscardedDoYouReallyWantToReplaceTheEnginePath: string;
   totalNumber: (n: number) => string;
   number: (n: number) => string;
   tryToReloginToCSAServerNSecondsLater: (n: number) => string;


### PR DESCRIPTION
# 説明 / Description

#1005 

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [x] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added localization support for engine path management prompts in English, Japanese, Vietnamese, and Traditional Chinese.
  - Introduced a button in the USI Engine Options dialog for replacing the engine path, with user confirmation for incompatible options.

- **Bug Fixes**
  - Improved user interface clarity regarding engine path replacement and implications of incompatible options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->