### PR TITLE
Remove book move ordering

### DIFF
--- a/src/background/book/types.ts
+++ b/src/background/book/types.ts
@@ -30,16 +30,6 @@ export const IDX_DEPTH = 3;
 export const IDX_COUNT = 4;
 export const IDX_COMMENTS = 5;
 
-export function compareMoves(a: BookMove, b: BookMove): number {
-  if (a[IDX_SCORE] !== undefined && b[IDX_SCORE] !== undefined && a[IDX_SCORE] !== b[IDX_SCORE]) {
-    return b[IDX_SCORE] - a[IDX_SCORE];
-  }
-  if (a[IDX_COUNT] !== undefined && b[IDX_COUNT] !== undefined && a[IDX_COUNT] !== b[IDX_COUNT]) {
-    return b[IDX_COUNT] - a[IDX_COUNT];
-  }
-  return 0;
-}
-
 export function arrayMoveToCommonBookMove(move: BookMove): CommonBookMove {
   return {
     usi: move[IDX_USI],

--- a/src/background/book/yaneuraou.ts
+++ b/src/background/book/yaneuraou.ts
@@ -6,7 +6,6 @@ import {
   Book,
   BookEntry,
   BookMove,
-  compareMoves,
   IDX_COMMENTS,
   IDX_COUNT,
   IDX_DEPTH,
@@ -160,10 +159,6 @@ export async function loadYaneuraOuBook(input: Readable): Promise<Book> {
   });
 
   await events.once(reader, "close");
-
-  for (const entry of Object.values(entries)) {
-    entry.moves.sort(compareMoves);
-  }
   return { entries, entryCount, duplicateCount };
 }
 
@@ -340,7 +335,5 @@ export async function searchBookMovesOnTheFly(
     }
     moves.push(parsed.move);
   }
-
-  moves.sort(compareMoves);
   return moves;
 }


### PR DESCRIPTION
# 説明 / Description

定跡読み込み時に実行されていた指し手の自動並べ替えを除去する。
定跡データの並び順に作成者の意図があるケースもあるので、書かれている順番を尊重する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed the `compareMoves` function, which affected the sorting of `BookMove` entries.
	- Sorting operations removed from the `loadYaneuraOuBook` and `searchBookMovesOnTheFly` functions, leading to potential changes in the order of displayed moves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->