### PR TITLE
Fix getElectron function

### DIFF
--- a/src/background/csa/index.ts
+++ b/src/background/csa/index.ts
@@ -41,7 +41,9 @@ function registerClient(client: Client): void {
   clients.set(client.sessionID, client);
   if (powerSaveBlockID === undefined) {
     powerSaveBlockID = preventAppSuspension();
-    getAppLogger().info("prevent app suspension: blocker=%d", powerSaveBlockID);
+    if (powerSaveBlockID !== undefined) {
+      getAppLogger().info("prevent app suspension: blocker=%d", powerSaveBlockID);
+    }
   }
 }
 

--- a/src/background/helpers/portability.ts
+++ b/src/background/helpers/portability.ts
@@ -3,7 +3,12 @@
  * Electron が存在しない場合は例外が投げられます。
  */
 export function requireElectron() {
-  return require("electron");
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const electron = require("electron");
+  if (typeof electron !== "object") {
+    throw new Error("Electron is not available");
+  }
+  return electron;
 }
 
 /**


### PR DESCRIPTION
# 説明 / Description

コマンドラインツールを利用した場合に `require("electron")` が文字列を返す振る舞いが想定外だった。
`typeof` の結果が `object` かどうかをチェックするように修正する。

参考: https://stackoverflow.com/questions/45274548/node-js-require-returns-a-string-instead-of-module-object

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for Electron module loading
  - Enhanced logging mechanism to prevent unnecessary log entries

- **Refactor**
  - Refined power save block logging logic
  - Added robust type checking for Electron module import

<!-- end of auto-generated comment: release notes by coderabbit.ai -->