### PR TITLE
Update book UI

### DIFF
--- a/src/renderer/view/primitive/BookView.vue
+++ b/src/renderer/view/primitive/BookView.vue
@@ -7,7 +7,7 @@
         <thead>
           <tr>
             <td class="number">No.</td>
-            <td class="text">{{ t.bookMove }}</td>
+            <td class="move">{{ t.bookMove }}</td>
             <td v-show="playable" class="menu">{{ t.play }}</td>
             <td v-show="editable" class="menu">{{ t.edit }}</td>
             <td v-show="editable" class="menu">{{ t.remove }}</td>
@@ -33,7 +33,7 @@
                 </option>
               </select>
             </td>
-            <td class="text">
+            <td class="move">
               <span>{{ formatMove(position, entry.move) }}</span>
             </td>
             <td v-show="playable" class="menu">
@@ -193,6 +193,10 @@ table.list > tbody > tr > td > * {
 }
 td.menu {
   text-align: center;
+}
+td.move {
+  text-align: left;
+  width: 8em;
 }
 td.text {
   text-align: left;


### PR DESCRIPTION
# 説明 / Description

定跡の着手ボタンのX座標が変わらないように、指し手のカラムの幅を固定する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated class names for book move text in table cells
	- Added CSS styling for the new `move` class, setting left text alignment and 8em width

<!-- end of auto-generated comment: release notes by coderabbit.ai -->