### PR TITLE
エンジンオプションでComboBoxの自由入力を使用すると対局開始できない問題を修正

### DIFF
--- a/src/common/settings/usi.ts
+++ b/src/common/settings/usi.ts
@@ -189,9 +189,6 @@ function isValidOptionValue(option: USIEngineOption): boolean {
       if (typeof option.value !== "string") {
         return false;
       }
-      if (!option.vars.includes(option.value)) {
-        return false;
-      }
       break;
   }
   return true;

--- a/src/tests/common/settings/usi.spec.ts
+++ b/src/tests/common/settings/usi.spec.ts
@@ -220,17 +220,25 @@ describe("settings/usi", () => {
       value: "b",
       vars: ["a", "b", "c"],
     };
+    const validComboOption2: USIEngineOption = {
+      name: "MyCombo2",
+      type: "combo",
+      order: 5,
+      default: "a",
+      value: "x",
+      vars: ["a", "b", "c"],
+    };
     const validFilenameOption: USIEngineOption = {
       name: "MyFilename",
       type: "filename",
-      order: 5,
+      order: 6,
       default: "<empty>",
       value: "/path/to/file",
     };
     const validButtonOption: USIEngineOption = {
       name: "MyButton",
       type: "button",
-      order: 6,
+      order: 7,
     };
 
     it("ok", () => {
@@ -246,6 +254,7 @@ describe("settings/usi", () => {
             USI_Hash: validUSIHashOption,
             MyString: validStringOption,
             MyCombo: validComboOption,
+            MyCombo2: validComboOption2,
             MyFilename: validFilenameOption,
             MyButton: validButtonOption,
           },
@@ -267,6 +276,7 @@ describe("settings/usi", () => {
             USI_Hash: validUSIHashOption,
             MyString: validStringOption,
             MyCombo: validComboOption,
+            MyCombo2: validComboOption2,
             MyFilename: validFilenameOption,
             MyButton: validButtonOption,
           },
@@ -294,6 +304,7 @@ describe("settings/usi", () => {
             USI_Hash: validUSIHashOption,
             MyString: validStringOption,
             MyCombo: validComboOption,
+            MyCombo2: validComboOption2,
             MyFilename: validFilenameOption,
             MyButton: validButtonOption,
           },
@@ -322,6 +333,7 @@ describe("settings/usi", () => {
             },
             MyString: validStringOption,
             MyCombo: validComboOption,
+            MyCombo2: validComboOption2,
             MyFilename: validFilenameOption,
             MyButton: validButtonOption,
           },
@@ -349,6 +361,7 @@ describe("settings/usi", () => {
               value: 123,
             },
             MyCombo: validComboOption,
+            MyCombo2: validComboOption2,
             MyFilename: validFilenameOption,
             MyButton: validButtonOption,
           },


### PR DESCRIPTION
# 説明 / Description

#1037 

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated test cases for engine option validation
	- Added a new combo option to test scenarios
	- Adjusted order of existing test options

- **Bug Fixes**
	- Modified validation logic for combo options to allow more flexible value assignment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->