### PR TITLE
Change AnalysisDialog buttons to use i18n

### DIFF
--- a/src/renderer/view/dialog/AnalysisDialog.vue
+++ b/src/renderer/view/dialog/AnalysisDialog.vue
@@ -87,8 +87,12 @@
         </div>
       </div>
       <div class="main-buttons">
-        <button data-hotkey="Enter" autofocus @click="onStart()">解析実行</button>
-        <button data-hotkey="Escape" @click="onCancel()">キャンセル</button>
+        <button data-hotkey="Enter" autofocus @click="onStart()">
+          {{ t.analyze }}
+        </button>
+        <button data-hotkey="Escape" @click="onCancel()">
+          {{ t.cancel }}
+        </button>
       </div>
     </dialog>
   </div>


### PR DESCRIPTION
# 説明 / Description

Change Analysis Dialog button to use i18n instead of hardcoded Japanese. Note that for Japanese by using i18n files the original "解析実行" is now "解析開始".

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [x] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [x] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Localization**
	- Updated button labels in the Analysis Dialog to use dynamic translations
	- Improved internationalization support for button text

<!-- end of auto-generated comment: release notes by coderabbit.ai -->