### PR TITLE
局面図画像の端に余計な線が入ってしまう問題を修正

### DIFF
--- a/src/renderer/view/dialog/PositionImageExportDialog.vue
+++ b/src/renderer/view/dialog/PositionImageExportDialog.vue
@@ -198,8 +198,9 @@ import { readInputAsNumber } from "@/renderer/helpers/form";
 import { useErrorStore } from "@/renderer/store/error";
 
 const lazyUpdateDelay = 100;
-const marginHor = 150;
-const marginVer = 200;
+const windowMarginHor = 150;
+const windowMarginVer = 200;
+const frameMargin = 2; // 境界部分の丸めによる周囲の映り込みを防ぐ
 const aspectRatio = 16 / 9;
 
 const store = useStore();
@@ -255,10 +256,10 @@ const textShadow = computed(() => {
 });
 
 const maxSize = computed(() => {
-  const height = appSettings.positionImageSize / zoom.value;
-  const width = height * aspectRatio;
-  const maxWidth = windowSize.width - marginHor;
-  const maxHeight = windowSize.height - marginVer;
+  const height = appSettings.positionImageSize / zoom.value - frameMargin * 2;
+  const width = height * aspectRatio + frameMargin * 2;
+  const maxWidth = windowSize.width - windowMarginHor;
+  const maxHeight = windowSize.height - windowMarginVer;
   return new RectSize(Math.min(width, maxWidth), Math.min(height, maxHeight));
 });
 
@@ -359,7 +360,12 @@ const changeType = (value: string) => {
 const getRect = () => {
   const elem = board.value as HTMLElement;
   const domRect = elem.getBoundingClientRect();
-  return new Rect(domRect.x, domRect.y, domRect.width, domRect.height);
+  return new Rect(
+    domRect.x + frameMargin,
+    domRect.y + frameMargin,
+    domRect.width - frameMargin * 2,
+    domRect.height - frameMargin * 2,
+  );
 };
 
 const saveAsPNG = () => {


### PR DESCRIPTION
# 説明 / Description

座標の丸めの問題で、局面図画像の上辺または左辺の 1 pixel に外の領域が入ってしまう問題を修正する。

<img width="821" alt="スクリーンショット 2025-01-05 1 40 41" src="https://github.com/user-attachments/assets/87486402-9154-450c-b480-2f1465abbd90" />

上図のサンプルは左辺に線が出ているが、上辺に線が見えるケースも確認されている。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Enhanced margin handling in the Position Image Export Dialog
  - Refined image export calculations for improved accuracy
  - Updated variable names for better clarity
  - Introduced a new frame margin constant to manage export dimensions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->