### PR TITLE
Add click and drag for pieces on the Board UI

### DIFF
--- a/src/renderer/view/primitive/BoardView.vue
+++ b/src/renderer/view/primitive/BoardView.vue
@@ -101,7 +101,9 @@
           :key="pointer.id"
           :style="pointer.style"
           @mousedown.stop.prevent="dragHand(Color.BLACK, pointer.type, $event)"
+          @touchstart.stop.prevent="dragHand(Color.BLACK, pointer.type, $event)"
           @mouseup.stop.prevent="dropHand(Color.BLACK, pointer.type, $event)"
+          @touchend.stop.prevent="dropHand(Color.BLACK, pointer.type, $event)"
         ></div>
       </div>
       <div class="hand" :style="main.whiteHandStyle">
@@ -110,7 +112,9 @@
           :key="pointer.id"
           :style="pointer.style"
           @mousedown.stop.prevent="dragHand(Color.WHITE, pointer.type, $event)"
+          @touchstart.stop.prevent="dragHand(Color.WHITE, pointer.type, $event)"
           @mouseup.stop.prevent="dropHand(Color.WHITE, pointer.type, $event)"
+          @touchend.stop.prevent="dropHand(Color.WHITE, pointer.type, $event)"
         ></div>
       </div>
 

--- a/src/renderer/view/primitive/BoardView.vue
+++ b/src/renderer/view/primitive/BoardView.vue
@@ -522,7 +522,7 @@ const startDragging = (event: MouseEvent | TouchEvent) => {
   // ドラッグ操作を開始する
   state.isDragging = true;
   moveDraggedPiece(event);
-  if(event instanceof MouseEvent) {
+  if (event instanceof MouseEvent) {
     window.addEventListener("mousemove", moveDraggedPiece);
     window.addEventListener("mouseup", stopDragging);
   } else {

--- a/src/renderer/view/primitive/BoardView.vue
+++ b/src/renderer/view/primitive/BoardView.vue
@@ -5,7 +5,7 @@
       class="frame"
       :style="main.frame.style"
       @mousedown.stop.prevent="clickFrame()"
-      @touchdown.stop.prevent="clickFrame()"
+      @touchstart.stop.prevent="clickFrame()"
     >
       <!-- 盤面 -->
       <div class="board" :style="main.boardStyle">
@@ -393,9 +393,7 @@ const dragSquare = (file: number, rank: number, event: MouseEvent | TouchEvent) 
       state.piecePath = config.value.pieceImages[piece.color][piece.type];
     }
     moveDraggedPiece(event);
-    state.isDragging = true;
-    window.addEventListener("mousemove", moveDraggedPiece);
-    window.addEventListener("mouseup", stopDragging);
+    startDragging();
     state.pointer = newPointer;
   }
 };
@@ -482,9 +480,7 @@ const dragHand = (color: Color, type: PieceType, event: MouseEvent | TouchEvent)
       state.piecePath = config.value.pieceImages[piece.color][piece.type];
     }
     moveDraggedPiece(event);
-    state.isDragging = true;
-    window.addEventListener("mousemove", moveDraggedPiece);
-    window.addEventListener("mouseup", stopDragging);
+    startDragging();
     state.pointer = newPointer;
   }
 };
@@ -524,6 +520,15 @@ const dropHand = (color: Color, type: PieceType, event: MouseEvent | TouchEvent)
   }
 };
 
+const startDragging = () => {
+  // ドラッグ操作を開始する
+  state.isDragging = true;
+  window.removeEventListener("mousemove", moveDraggedPiece);
+  window.removeEventListener("mouseup", stopDragging);
+  window.removeEventListener("touchmove", moveDraggedPiece);
+  window.removeEventListener("touchend", stopDragging);
+};
+
 const moveDraggedPiece = (event: MouseEvent | TouchEvent) => {
   // 駒をドラッグ中に位置を更新する
   const clientX = event instanceof MouseEvent ? event.clientX : event.touches[0].clientX;
@@ -544,6 +549,8 @@ const stopDragging = () => {
   state.isDragging = false;
   window.removeEventListener("mousemove", moveDraggedPiece);
   window.removeEventListener("mouseup", stopDragging);
+  window.removeEventListener("touchmove", moveDraggedPiece);
+  window.removeEventListener("touchend", stopDragging);
 };
 
 const clickSquareR = (file: number, rank: number) => {

--- a/src/renderer/view/primitive/BoardView.vue
+++ b/src/renderer/view/primitive/BoardView.vue
@@ -1,9 +1,9 @@
 <template>
   <div>
-    <div 
-      ref="frame" 
-      class="frame" 
-      :style="main.frame.style" 
+    <div
+      ref="frame"
+      class="frame"
+      :style="main.frame.style"
       @mousedown.stop.prevent="clickFrame()"
       @touchdown.stop.prevent="clickFrame()"
     >
@@ -178,7 +178,7 @@ import {
   secondsToHHMMSS,
 } from "tsshogi";
 import { computed, reactive, ref, watch, PropType } from "vue";
-import type { CSSProperties } from 'vue';
+import type { CSSProperties } from "vue";
 import {
   BoardImageType,
   BoardLabelType,
@@ -371,72 +371,8 @@ const dragStyle = reactive<CSSProperties>({
   height: "0px",
 });
 
-const updatePointer = (newPointer: Square | Piece, empty: boolean, color: Color | undefined) => {
-  const prevPointer = state.pointer;
-  resetState();
-  if (
-    newPointer instanceof Square &&
-    prevPointer instanceof Square &&
-    newPointer.equals(prevPointer)
-  ) {
-    return;
-  }
-  if (
-    newPointer instanceof Piece &&
-    prevPointer instanceof Piece &&
-    newPointer.equals(prevPointer)
-  ) {
-    return;
-  }
-  if (prevPointer) {
-    const editFrom = prevPointer;
-    const editTo = newPointer instanceof Square ? newPointer : (newPointer as Piece).color;
-    if (props.allowEdit && props.position.isValidEditing(editFrom, editTo)) {
-      emit("edit", {
-        move: {
-          from: prevPointer,
-          to: editTo,
-        },
-      });
-      return;
-    }
-    if (props.allowMove && newPointer instanceof Square) {
-      const moveFrom = prevPointer instanceof Square ? prevPointer : prevPointer.type;
-      const moveTo = newPointer;
-      const move = props.position.createMove(moveFrom, moveTo);
-      if (!move) {
-        return;
-      }
-      const noProm = props.position.isValidMove(move);
-      const prom = props.position.isValidMove(move.withPromote());
-      if (noProm && prom) {
-        state.reservedMove = move;
-        return;
-      }
-      if (noProm) {
-        emit("move", move);
-        return;
-      }
-      if (prom) {
-        emit("move", move.withPromote());
-        return;
-      }
-    }
-  }
-  if ((!props.allowMove && !props.allowEdit) || empty) {
-    return;
-  }
-  if (!props.allowEdit && color !== props.position.color) {
-    return;
-  }
-  state.pointer = newPointer;
-};
-
 const dragSquare = (file: number, rank: number, event: MouseEvent | TouchEvent) => {
-  if ((
-    event instanceof MouseEvent && event.button === 0) || 
-    event instanceof TouchEvent
-  ) {
+  if ((event instanceof MouseEvent && event.button === 0) || event instanceof TouchEvent) {
     const square = new Square(file, rank);
     const piece = props.position.board.at(square);
     const empty = !piece;
@@ -454,17 +390,14 @@ const dragSquare = (file: number, rank: number, event: MouseEvent | TouchEvent) 
     }
     moveDraggedPiece(event);
     state.isDragging = true;
-    window.addEventListener('mousemove', moveDraggedPiece);
-    window.addEventListener('mouseup', stopDragging);
+    window.addEventListener("mousemove", moveDraggedPiece);
+    window.addEventListener("mouseup", stopDragging);
     state.pointer = newPointer;
   }
 };
 
 const dropSquare = (file: number, rank: number, event: MouseEvent | TouchEvent) => {
-  if ((
-    event instanceof MouseEvent && event.button === 0) || 
-    event instanceof TouchEvent
-  ) {
+  if ((event instanceof MouseEvent && event.button === 0) || event instanceof TouchEvent) {
     const square = new Square(file, rank);
     const piece = props.position.board.at(square);
     const empty = !piece;
@@ -474,7 +407,11 @@ const dropSquare = (file: number, rank: number, event: MouseEvent | TouchEvent) 
     if (!prevPointer) {
       return;
     }
-    if (prevPointer instanceof Square && newPointer instanceof Square && newPointer.equals(prevPointer)) {
+    if (
+      prevPointer instanceof Square &&
+      newPointer instanceof Square &&
+      newPointer.equals(prevPointer)
+    ) {
       state.pieceSelected = !state.pieceSelected;
       if (!state.pieceSelected) {
         resetState();
@@ -525,10 +462,7 @@ const dropSquare = (file: number, rank: number, event: MouseEvent | TouchEvent) 
 };
 
 const dragHand = (color: Color, type: PieceType, event: MouseEvent | TouchEvent) => {
-  if ((
-    event instanceof MouseEvent && event.button === 0) || 
-    event instanceof TouchEvent
-  ) {
+  if ((event instanceof MouseEvent && event.button === 0) || event instanceof TouchEvent) {
     const piece = new Piece(color, type);
     const empty = props.position.hand(color).count(type) === 0;
     const prevPointer = state.pointer;
@@ -545,17 +479,14 @@ const dragHand = (color: Color, type: PieceType, event: MouseEvent | TouchEvent)
     }
     moveDraggedPiece(event);
     state.isDragging = true;
-    window.addEventListener('mousemove', moveDraggedPiece);
-    window.addEventListener('mouseup', stopDragging); 
+    window.addEventListener("mousemove", moveDraggedPiece);
+    window.addEventListener("mouseup", stopDragging);
     state.pointer = newPointer;
   }
 };
 
 const dropHand = (color: Color, type: PieceType, event: MouseEvent | TouchEvent) => {
-  if ((
-    event instanceof MouseEvent && event.button === 0) || 
-    event instanceof TouchEvent
-  ) {
+  if ((event instanceof MouseEvent && event.button === 0) || event instanceof TouchEvent) {
     const piece = new Piece(color, type);
     const prevPointer = state.pointer;
     const newPointer = piece;
@@ -563,7 +494,11 @@ const dropHand = (color: Color, type: PieceType, event: MouseEvent | TouchEvent)
     if (!prevPointer) {
       return;
     }
-    if (prevPointer instanceof Piece && newPointer instanceof Piece && newPointer.equals(prevPointer)) {
+    if (
+      prevPointer instanceof Piece &&
+      newPointer instanceof Piece &&
+      newPointer.equals(prevPointer)
+    ) {
       state.pieceSelected = !state.pieceSelected;
       if (!state.pieceSelected) {
         resetState();
@@ -593,8 +528,8 @@ const moveDraggedPiece = (event: MouseEvent | TouchEvent) => {
   const width = commonParams.piece.width * main.value.ratio;
   const height = commonParams.piece.height * main.value.ratio;
   if (frameRect) {
-    dragStyle.left = (clientX - frameRect.left) - width / 2 + "px";
-    dragStyle.top = (clientY - frameRect.top) - height / 2 + "px";
+    dragStyle.left = clientX - frameRect.left - width / 2 + "px";
+    dragStyle.top = clientY - frameRect.top - height / 2 + "px";
   }
   dragStyle.width = width + "px";
   dragStyle.height = height + "px";
@@ -603,8 +538,8 @@ const moveDraggedPiece = (event: MouseEvent | TouchEvent) => {
 const stopDragging = () => {
   // ドラッグ操作を終了する
   state.isDragging = false;
-  window.removeEventListener('mousemove', moveDraggedPiece);
-  window.removeEventListener('mouseup', stopDragging);
+  window.removeEventListener("mousemove", moveDraggedPiece);
+  window.removeEventListener("mouseup", stopDragging);
 };
 
 const clickSquareR = (file: number, rank: number) => {

--- a/src/renderer/view/primitive/BoardView.vue
+++ b/src/renderer/view/primitive/BoardView.vue
@@ -392,8 +392,7 @@ const dragSquare = (file: number, rank: number, event: MouseEvent | TouchEvent) 
       resetState();
       state.piecePath = config.value.pieceImages[piece.color][piece.type];
     }
-    moveDraggedPiece(event);
-    startDragging();
+    startDragging(event);
     state.pointer = newPointer;
   }
 };
@@ -405,7 +404,7 @@ const dropSquare = (file: number, rank: number, event: MouseEvent | TouchEvent) 
     const empty = !piece;
     const prevPointer = state.pointer;
     const newPointer = square;
-    stopDragging();
+    stopDragging(event);
     if (!prevPointer) {
       return;
     }
@@ -479,8 +478,7 @@ const dragHand = (color: Color, type: PieceType, event: MouseEvent | TouchEvent)
       resetState();
       state.piecePath = config.value.pieceImages[piece.color][piece.type];
     }
-    moveDraggedPiece(event);
-    startDragging();
+    startDragging(event);
     state.pointer = newPointer;
   }
 };
@@ -490,7 +488,7 @@ const dropHand = (color: Color, type: PieceType, event: MouseEvent | TouchEvent)
     const piece = new Piece(color, type);
     const prevPointer = state.pointer;
     const newPointer = piece;
-    stopDragging();
+    stopDragging(event);
     if (!prevPointer) {
       return;
     }
@@ -520,13 +518,17 @@ const dropHand = (color: Color, type: PieceType, event: MouseEvent | TouchEvent)
   }
 };
 
-const startDragging = () => {
+const startDragging = (event: MouseEvent | TouchEvent) => {
   // ドラッグ操作を開始する
   state.isDragging = true;
-  window.removeEventListener("mousemove", moveDraggedPiece);
-  window.removeEventListener("mouseup", stopDragging);
-  window.removeEventListener("touchmove", moveDraggedPiece);
-  window.removeEventListener("touchend", stopDragging);
+  moveDraggedPiece(event);
+  if(event instanceof MouseEvent) {
+    window.addEventListener("mousemove", moveDraggedPiece);
+    window.addEventListener("mouseup", stopDragging);
+  } else {
+    window.addEventListener("touchmove", moveDraggedPiece);
+    window.addEventListener("touchend", stopDragging);
+  }
 };
 
 const moveDraggedPiece = (event: MouseEvent | TouchEvent) => {
@@ -544,13 +546,16 @@ const moveDraggedPiece = (event: MouseEvent | TouchEvent) => {
   dragStyle.height = height + "px";
 };
 
-const stopDragging = () => {
+const stopDragging = (event: MouseEvent | TouchEvent) => {
   // ドラッグ操作を終了する
   state.isDragging = false;
-  window.removeEventListener("mousemove", moveDraggedPiece);
-  window.removeEventListener("mouseup", stopDragging);
-  window.removeEventListener("touchmove", moveDraggedPiece);
-  window.removeEventListener("touchend", stopDragging);
+  if (event instanceof MouseEvent) {
+    window.removeEventListener("mousemove", moveDraggedPiece);
+    window.removeEventListener("mouseup", stopDragging);
+  } else {
+    window.removeEventListener("touchmove", moveDraggedPiece);
+    window.removeEventListener("touchend", stopDragging);
+  }
 };
 
 const clickSquareR = (file: number, rank: number) => {


### PR DESCRIPTION
# 説明 / Description

駒をクリックとドラッグできるようにしました。駒をクリックとドラッグすると、駒の画像がカーソルについて行きます。駒をクリックすると状態が選択中になって、もう一度クリックすると駒を移動します。

- Clicking on a piece selects it; clicking on it again deselects it.
- Clicking on a destination square will attempt to move the selected piece
- Dragging makes the dragged piece visible, which follows the cursor
- Releasing a dragged piece will attempt to move it to the dropped location
- Works for board pieces on board and in hand area
- Also works for edit mode

https://github.com/user-attachments/assets/478fcaa2-eb57-430d-9756-60f3c0e5bce5


# チェックリスト / Checklist

- MUST
  - [X] `npm test` passed
  - [X] `npm run lint` was applied without warnings
  - [X] changes of `/docs/webapp` not included (except release branch)
  - [X] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [X] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced drag-and-drop functionality for chess pieces.
	- Added support for mouse and touch-based piece movement.
	- Enhanced board interaction with improved piece selection and dragging mechanics.

- **Improvements**
	- Implemented visual feedback during piece dragging.
	- Updated event handling to support more intuitive piece movement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->