### PR TITLE
履歴機能における棋譜バックアップの改善

### DIFF
--- a/src/common/file/history.ts
+++ b/src/common/file/history.ts
@@ -1,15 +1,28 @@
 export enum HistoryClass {
   USER = "user",
-  BACKUP = "backup",
+  BACKUP = "backup", // until v1.20.x
+  BACKUP_V2 = "backupV2", // since v1.21.0
 }
 
 export type RecordFileHistoryEntry = {
   id: string;
   /** ISO 8601 format */
   time: string;
-  class: HistoryClass;
-  userFilePath?: string;
-  backupFileName?: string;
+} & (UserFileEntry | BackupEntry | BackupEntryV2);
+
+export type UserFileEntry = {
+  class: HistoryClass.USER;
+  userFilePath: string;
+};
+
+export type BackupEntry = {
+  class: HistoryClass.BACKUP;
+  backupFileName: string;
+};
+
+export type BackupEntryV2 = {
+  class: HistoryClass.BACKUP_V2;
+  kif: string;
 };
 
 export type RecordFileHistory = {

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -1281,7 +1281,7 @@ class Store {
     }
   }
 
-  restoreFromBackup(name: string): void {
+  restoreFromBackupV1(name: string): void {
     if (this.appState !== AppState.RECORD_FILE_HISTORY_DIALOG || useBusyState().isBusy) {
       return;
     }
@@ -1304,6 +1304,21 @@ class Store {
       .finally(() => {
         useBusyState().release();
       });
+  }
+
+  restoreFromBackupV2(kif: string): void {
+    if (this.appState !== AppState.RECORD_FILE_HISTORY_DIALOG || useBusyState().isBusy) {
+      return;
+    }
+    const err = this.recordManager.importRecord(kif, {
+      type: RecordFormatType.KIF,
+      markAsSaved: true,
+    });
+    if (err) {
+      useErrorStore().add(err);
+      return;
+    }
+    this._appState = AppState.NORMAL;
   }
 
   get remoteRecordFileURL() {

--- a/src/renderer/view/dialog/RecordFileHistoryDialog.vue
+++ b/src/renderer/view/dialog/RecordFileHistoryDialog.vue
@@ -19,15 +19,21 @@
               <span class="datetime">{{ getDateTimeString(new Date(entry.time)) }}</span>
             </span>
             <span class="right">
-              <button v-if="entry.userFilePath" @click="open(entry.userFilePath)">
+              <button v-if="entry.class === HistoryClass.USER" @click="open(entry.userFilePath)">
                 {{ t.open }}
               </button>
-              <button v-if="entry.backupFileName" @click="restore(entry.backupFileName)">
+              <button
+                v-if="entry.class === HistoryClass.BACKUP"
+                @click="restoreV1(entry.backupFileName)"
+              >
+                {{ t.restore }}
+              </button>
+              <button v-if="entry.class === HistoryClass.BACKUP_V2" @click="restoreV2(entry.kif)">
                 {{ t.restore }}
               </button>
             </span>
           </div>
-          <div v-if="entry.userFilePath" class="file-path">
+          <div v-if="entry.class === HistoryClass.USER" class="file-path">
             {{ entry.userFilePath }}
           </div>
         </div>
@@ -85,8 +91,12 @@ const open = (path: string) => {
   store.openRecord(path);
 };
 
-const restore = (name: string) => {
-  store.restoreFromBackup(name);
+const restoreV1 = (name: string) => {
+  store.restoreFromBackupV1(name);
+};
+
+const restoreV2 = (kif: string) => {
+  store.restoreFromBackupV2(kif);
 };
 
 const clear = () => {

--- a/src/tests/background/book/yaneuraou.spec.ts
+++ b/src/tests/background/book/yaneuraou.spec.ts
@@ -43,7 +43,7 @@ describe("background/book/yaneuraou", () => {
       });
     });
 
-    it("invalid header", () => {
+    it("invalid header", async () => {
       const input = Readable.from([
         "#YANEURAOU-DB2016 2.00\n",
         "sfen +P1kg3nl/1ps2b3/+P3p3p/2pgsr1p1/s2p1pP2/2P1P1pR1/1SNG1P2P/1KG6/7NL w N2LPb2p 78\n",
@@ -55,7 +55,7 @@ describe("background/book/yaneuraou", () => {
         "sfen +B3g3l/5rgk1/pB+P1ppn1p/n4spp1/1G1SP3P/K2P5/1+pS3P2/P2+l+r4/LNP6 b SNL2Pg2p\n",
         "9f9e 8g7g 0 32 1\n",
       ]);
-      expect(loadYaneuraOuBook(input)).rejects.toThrow(
+      await expect(loadYaneuraOuBook(input)).rejects.toThrow(
         "Unsupported book header: #YANEURAOU-DB2016 2.00",
       );
     });

--- a/src/tests/background/file/history.spec.ts
+++ b/src/tests/background/file/history.spec.ts
@@ -1,3 +1,5 @@
+import path from "node:path";
+import fs from "node:fs";
 import {
   addHistory,
   clearHistory,
@@ -5,63 +7,113 @@ import {
   loadBackup,
   saveBackup,
 } from "@/background/file/history";
+import { getAppPath } from "@/background/proc/env";
+import {
+  BackupEntryV2,
+  HistoryClass,
+  RecordFileHistory,
+  UserFileEntry,
+} from "@/common/file/history";
 
-it("history", async () => {
-  let history = await getHistory();
-  expect(history.entries).toHaveLength(0);
+const userDir = getAppPath("userData");
+const historyPath = path.join(userDir, "record_file_history.json");
+const backupDir = path.join(userDir, "backup/kifu");
 
-  // 4 件を追加する。
-  saveBackup("test-kif-data1");
-  addHistory("/path/to/file1.kif");
-  saveBackup("test-kif-data2");
-  addHistory("/path/to/file2.kif");
+describe("history", () => {
+  it("v2", async () => {
+    let history = await getHistory();
+    expect(history.entries).toHaveLength(0);
 
-  history = await getHistory();
-  expect(history.entries).toHaveLength(4);
-  expect(history.entries[0].class).toBe("backup");
-  expect(history.entries[0].userFilePath).toBeUndefined();
-  const backupFileName1 = history.entries[0].backupFileName as string;
-  expect(history.entries[0].backupFileName).toMatch(/^[0-9]+-[0-9]+\.kifu$/);
-  expect(await loadBackup(backupFileName1)).toBe("test-kif-data1");
-  expect(history.entries[1].class).toBe("user");
-  expect(history.entries[1].userFilePath).toBe("/path/to/file1.kif");
-  expect(history.entries[2].class).toBe("backup");
-  const backupFileName2 = history.entries[2].backupFileName as string;
-  expect(await loadBackup(backupFileName2)).toBe("test-kif-data2");
-  expect(history.entries[3].class).toBe("user");
-  expect(history.entries[3].userFilePath).toBe("/path/to/file2.kif");
+    // 4 件を追加する。
+    await saveBackup("test-kif-data1");
+    addHistory("/path/to/file1.kif");
+    await saveBackup("test-kif-data2");
+    addHistory("/path/to/file2.kif");
 
-  // すでに存在するので履歴は増加しない。
-  addHistory("/path/to/file1.kif");
+    history = await getHistory();
+    expect(history.entries).toHaveLength(4);
+    expect(history.entries[0].class).toBe("backupV2");
+    expect(history.entries[1].class).toBe("user");
+    expect(history.entries[2].class).toBe("backupV2");
+    expect(history.entries[3].class).toBe("user");
+    const backup1 = (history.entries[0] as BackupEntryV2).kif;
+    const user1 = (history.entries[1] as UserFileEntry).userFilePath;
+    const backup2 = (history.entries[2] as BackupEntryV2).kif;
+    const user2 = (history.entries[3] as UserFileEntry).userFilePath;
+    expect(backup1).toBe("test-kif-data1");
+    expect(user1).toBe("/path/to/file1.kif");
+    expect(backup2).toBe("test-kif-data2");
+    expect(user2).toBe("/path/to/file2.kif");
 
-  history = await getHistory();
-  expect(history.entries).toHaveLength(4);
-  expect(history.entries[2].userFilePath).toBe("/path/to/file2.kif");
-  expect(history.entries[3].userFilePath).toBe("/path/to/file1.kif"); // 末尾に移動する。
+    // すでに存在するので履歴は増加しない。
+    addHistory("/path/to/file1.kif");
 
-  // 20 件ちょうどまで追加する。
-  for (let i = 3; i <= 18; i++) {
-    addHistory(`/path/to/file${i}.kif`);
-  }
+    history = await getHistory();
+    expect(history.entries).toHaveLength(4);
+    expect((history.entries[2] as UserFileEntry).userFilePath).toBe("/path/to/file2.kif");
+    expect((history.entries[3] as UserFileEntry).userFilePath).toBe("/path/to/file1.kif"); // 末尾に移動する。
 
-  history = await getHistory();
-  expect(history.entries).toHaveLength(20);
-  expect(history.entries[0].backupFileName).toMatch(backupFileName1);
-  expect(await loadBackup(backupFileName1)).toBe("test-kif-data1");
+    // 20 件ちょうどまで追加する。
+    for (let i = 3; i <= 18; i++) {
+      addHistory(`/path/to/file${i}.kif`);
+    }
 
-  // 20 件を超えたので最初の 1 件が削除される。
-  addHistory("/path/to/file19.kif");
+    history = await getHistory();
+    expect(history.entries).toHaveLength(20);
+    expect((history.entries[0] as BackupEntryV2).kif).toMatch(backup1);
 
-  history = await getHistory();
-  expect(history.entries).toHaveLength(20);
-  expect(history.entries[0].backupFileName).toMatch(backupFileName2);
-  await expect(() => loadBackup(backupFileName1)).rejects.toThrow();
+    // 20 件を超えたので最初の 1 件が削除される。
+    addHistory("/path/to/file19.kif");
 
-  expect(await loadBackup(backupFileName2)).toBe("test-kif-data2");
+    history = await getHistory();
+    expect(history.entries).toHaveLength(20);
+    expect((history.entries[0] as BackupEntryV2).kif).toMatch(backup2);
 
-  await clearHistory();
+    // 履歴をクリアする。
+    await clearHistory();
 
-  history = await getHistory();
-  expect(history.entries).toHaveLength(0);
-  await expect(() => loadBackup(backupFileName2)).rejects.toThrow();
+    history = await getHistory();
+    expect(history.entries).toHaveLength(0);
+  });
+
+  it("compatibility", async () => {
+    // 旧バージョンのバックアップファイルが存在する場合に
+    // 読み込みと削除が機能するかを確認する。
+    const original: RecordFileHistory = { entries: [] };
+    fs.mkdirSync(backupDir, { recursive: true });
+    for (let i = 1; i <= 10; i++) {
+      original.entries.push({
+        id: `user-${i}`,
+        time: "2024-01-01T00:00:00.000Z",
+        class: HistoryClass.USER,
+        userFilePath: `/path/to/file${i}.kif`,
+      });
+      original.entries.push({
+        id: "backup-" + i,
+        time: "2024-01-01T00:00:00.000Z",
+        class: HistoryClass.BACKUP,
+        backupFileName: `backup${i}.kifu`,
+      });
+      fs.writeFileSync(path.join(backupDir, `backup${i}.kifu`), `test-kif-data${i}`, "utf8");
+    }
+    fs.writeFileSync(historyPath, JSON.stringify(original), "utf8");
+
+    expect((await getHistory()).entries).toHaveLength(20);
+
+    // remove user-1
+    await saveBackup("test-kif-data11");
+    await expect(loadBackup("backup1.kifu")).resolves.toBe("test-kif-data1");
+
+    // remove backup-1
+    await saveBackup("test-kif-data12");
+    await expect(loadBackup("backup1.kifu")).rejects.toThrow();
+
+    // remove user-2
+    await saveBackup("test-kif-data13");
+    await expect(loadBackup("backup2.kifu")).resolves.toBe("test-kif-data2");
+
+    // remove backup-2
+    await saveBackup("test-kif-data14");
+    await expect(loadBackup("backup2.kifu")).rejects.toThrow();
+  });
 });


### PR DESCRIPTION
# 説明 / Description

#1057

- バックアップファイルを個別に作成するのをやめて record_file_history.json に埋め込む。
- 新しい実装で生成されたエントリーは `class=backupV2` とする。
- 古いバージョンのエントリーも扱えるようにする。
- ダウングレードしたときに旧バージョンで新しいデータを読むことはできない。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new backup versioning system with support for direct KIF string storage
	- Added ability to restore backups using both file names and KIF strings

- **Bug Fixes**
	- Improved history entry filtering and management
	- Enhanced backup restoration logic

- **Refactor**
	- Restructured backup and history entry type definitions
	- Updated restoration methods to support multiple backup formats

- **Tests**
	- Added comprehensive test cases for new history and backup functionality
	- Improved async test handling for book-related tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->