### PR TITLE
Update UI texts

### DIFF
--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -294,7 +294,7 @@ export const en: Texts = {
   searchEngine: "Search Engine",
   ponder: "Ponder",
   numberOfThreads: "Threads",
-  multiPV: "Multi PV",
+  suggestionsCount: "Suggestions Count",
   startPosition: "Position",
   beginFromThisPosition: "Begin from this position",
   maxMoves: "Max Moves",

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -294,7 +294,7 @@ export const ja: Texts = {
   searchEngine: "エンジン",
   ponder: "先読み(Ponder)",
   numberOfThreads: "スレッド数",
-  multiPV: "マルチPV",
+  suggestionsCount: "候補手の数",
   startPosition: "開始局面",
   beginFromThisPosition: "この局面から開始",
   maxMoves: "最大手数",

--- a/src/common/i18n/locales/vi.ts
+++ b/src/common/i18n/locales/vi.ts
@@ -294,7 +294,7 @@ export const vi: Texts = {
   searchEngine: "Phần mềm",
   ponder: "Đọc trước",
   numberOfThreads: "Luồng",
-  multiPV: "Nhiều biến",
+  suggestionsCount: "Nhiều biến", // TODO: 日本語が「マルチPV」から「候補手の数」へ変更されたのでそれを反映したい。
   startPosition: "Thế cờ ban đầu",
   beginFromThisPosition: "この局面から開始", // TODO: translate
   maxMoves: "Số nước tối đa",

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -291,7 +291,7 @@ export const zh_tw: Texts = {
   searchEngine: "引擎",
   ponder: "對方手番時運算 (Ponder)",
   numberOfThreads: "執行緒數",
-  multiPV: "多重PV",
+  suggestionsCount: "多重PV", // TODO: 日本語が「マルチPV」から「候補手の数」へ変更されたのでそれを反映したい。
   startPosition: "開始局面",
   beginFromThisPosition: "この局面から開始", // TODO: translate
   maxMoves: "最大手數",

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -289,7 +289,7 @@ export type Texts = {
   searchEngine: string;
   ponder: string;
   numberOfThreads: string;
-  multiPV: string;
+  suggestionsCount: string;
   startPosition: string;
   beginFromThisPosition: string;
   maxMoves: string;

--- a/src/common/i18n/usi.ts
+++ b/src/common/i18n/usi.ts
@@ -12,7 +12,7 @@ const ja: USIOptionNameMap = {
   NumberOfThreads: "スレッド数",
   thread_num_per_gpu: "GPUあたりのスレッド数",
   ThreadIdOffset: "スレッドIDオフセット",
-  MultiPV: "マルチPV",
+  MultiPV: "マルチPV(候補手の表示件数)",
   BookFile: "定跡ファイル",
   Book_File: "定跡ファイル",
   Book_Enable: "定跡あり",

--- a/src/renderer/view/dialog/PlayerSelector.vue
+++ b/src/renderer/view/dialog/PlayerSelector.vue
@@ -29,7 +29,7 @@
         <span class="player-info-value">{{ threadState || "---" }}</span>
       </div>
       <div v-if="displayMultiPvState" class="row player-info">
-        <span class="player-info-key">{{ t.multiPV }}:</span>
+        <span class="player-info-key">{{ t.suggestionsCount }}:</span>
         <span class="player-info-value">{{ multiPVState || "---" }}</span>
       </div>
       <button

--- a/src/renderer/view/layout/LayoutManager.vue
+++ b/src/renderer/view/layout/LayoutManager.vue
@@ -226,7 +226,7 @@
             <span class="property">
               <ToggleButton
                 :value="!!component.showMultiPvColumn"
-                :label="t.multiPV"
+                :label="t.rank"
                 @change="(value) => updateCustomProfileComponent(index, 'showMultiPvColumn', value)"
               />
             </span>


### PR DESCRIPTION
# 説明 / Description

「マルチPV」という表示文言がわかりにくいので「候補手の数」に変更する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [x] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Localization Updates**
	- Replaced "Multi PV" terminology with "Suggestions Count" across multiple language files (English, Japanese, Vietnamese, Traditional Chinese)
	- Updated user interface labels to reflect new terminology in player selection and layout management views

<!-- end of auto-generated comment: release notes by coderabbit.ai -->