### PR TITLE
ウィンドウが小さくなりすぎる問題を改善

### DIFF
--- a/src/background/settings.ts
+++ b/src/background/settings.ts
@@ -60,7 +60,11 @@ const windowSettingsPath = path.join(userDir, "window.json");
 
 export function saveWindowSettings(settings: WindowSettings): void {
   try {
-    fs.writeFileSync(windowSettingsPath, JSON.stringify(settings, undefined, 2), "utf8");
+    fs.writeFileSync(
+      windowSettingsPath,
+      JSON.stringify(normalizeWindowSettings(settings), undefined, 2),
+      "utf8",
+    );
   } catch (e) {
     getAppLogger().error("failed to write window settings: %s", e);
   }

--- a/src/common/settings/window.ts
+++ b/src/common/settings/window.ts
@@ -18,6 +18,8 @@ export function normalizeWindowSettings(settings: WindowSettings): WindowSetting
   return {
     ...defaultWindowSettings(),
     ...settings,
+    width: Math.max(200, settings.width),
+    height: Math.max(150, settings.height),
   };
 }
 

--- a/src/tests/common/settings/window.spec.ts
+++ b/src/tests/common/settings/window.spec.ts
@@ -70,5 +70,19 @@ describe("settings/window", () => {
     };
     const result = normalizeWindowSettings(settings);
     expect(result).toStrictEqual(settings);
+
+    expect(
+      normalizeWindowSettings({
+        width: 0,
+        height: 0,
+        maximized: false,
+        fullscreen: false,
+      }),
+    ).toEqual({
+      width: 200,
+      height: 150,
+      maximized: false,
+      fullscreen: false,
+    });
   });
 });


### PR DESCRIPTION
# 説明 / Description

主に macOS で、起動した時にウィンドウが極端に小さくなってしまうことがある。

十分に視認できる大きさより小さくなることがないような制御を加える。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced window settings validation to prevent extremely small window dimensions.

- **Bug Fixes**
	- Enforced minimum window width of 200 pixels and minimum height of 150 pixels.

- **Tests**
	- Added test case to verify window settings normalization for zero-dimension scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->