### PR TITLE
評価値グラフとコメントを同時に表示するレイアウト

### DIFF
--- a/src/common/settings/app.ts
+++ b/src/common/settings/app.ts
@@ -78,6 +78,7 @@ export enum RightSideControlType {
 export enum TabPaneType {
   SINGLE = "single",
   DOUBLE = "double",
+  DOUBLE_V2 = "doubleV2",
 }
 
 export enum Tab {
@@ -331,6 +332,7 @@ export function buildUpdatedAppSettings(org: AppSettings, update: AppSettingsUpd
   // カラム構成に合わせて選択可能なタブを制限する。
   switch (updated.tabPaneType) {
     case TabPaneType.DOUBLE:
+    case TabPaneType.DOUBLE_V2:
       switch (updated.tab) {
         case Tab.COMMENT:
           updated.tab = Tab.RECORD_INFO;
@@ -338,6 +340,15 @@ export function buildUpdatedAppSettings(org: AppSettings, update: AppSettingsUpd
         case Tab.CHART:
         case Tab.PERCENTAGE_CHART:
           updated.tab = Tab.PV;
+          break;
+      }
+      break;
+  }
+  switch (updated.tabPaneType) {
+    case TabPaneType.DOUBLE_V2:
+      switch (updated.tab2) {
+        case Tab.COMMENT:
+          updated.tab2 = Tab.CHART;
           break;
       }
       break;
@@ -377,9 +388,9 @@ export function defaultAppSettings(opt?: {
     clockPitch: 500,
     clockSoundTarget: ClockSoundTarget.ONLY_USER,
     boardFlipping: false,
-    tabPaneType: TabPaneType.DOUBLE,
+    tabPaneType: TabPaneType.DOUBLE_V2,
     tab: Tab.RECORD_INFO,
-    tab2: Tab.COMMENT,
+    tab2: Tab.CHART,
     topPaneHeightPercentage: 60,
     topPanePreviousHeightPercentage: 60,
     bottomLeftPaneWidthPercentage: 60,

--- a/src/renderer/view/dialog/AppSettingsDialog.vue
+++ b/src/renderer/view/dialog/AppSettingsDialog.vue
@@ -361,6 +361,7 @@
               :items="[
                 { label: t.oneColumn, value: TabPaneType.SINGLE },
                 { label: t.twoColumns, value: TabPaneType.DOUBLE },
+                { label: `${t.twoColumns} v2`, value: TabPaneType.DOUBLE_V2 },
               ]"
               @change="
                 (value: string) => {

--- a/src/renderer/view/main/StandardLayout.vue
+++ b/src/renderer/view/main/StandardLayout.vue
@@ -77,6 +77,7 @@
           </Pane>
           <Pane>
             <TabPane
+              v-if="appSettings.tabPaneType === TabPaneType.DOUBLE"
               class="full"
               :size="tabPaneSize2"
               :visible-tabs="[Tab.COMMENT, Tab.CHART, Tab.PERCENTAGE_CHART]"
@@ -85,6 +86,17 @@
               @on-change-tab="onChangeTab2"
               @on-minimize="onMinimizeTab"
             />
+            <div v-else class="full column">
+              <TabPane
+                :size="tabPaneSize2a"
+                :visible-tabs="[Tab.CHART, Tab.PERCENTAGE_CHART]"
+                :active-tab="appSettings.tab2"
+                :display-minimize-toggle="true"
+                @on-change-tab="onChangeTab2"
+                @on-minimize="onMinimizeTab"
+              />
+              <RecordComment class="full" />
+            </div>
           </Pane>
         </Splitpanes>
       </Pane>
@@ -98,6 +110,7 @@ import { reactive, onMounted, onUnmounted, computed, ref } from "vue";
 import BoardPane from "./BoardPane.vue";
 import RecordPane, { minWidth as minRecordWidth } from "./RecordPane.vue";
 import TabPane, { headerHeight as tabHeaderHeight } from "./TabPane.vue";
+import RecordComment from "@/renderer/view/tab/RecordComment.vue";
 import ControlPane, { ControlGroup } from "./ControlPane.vue";
 import { RectSize } from "@/common/assets/geometry";
 import { AppSettingsUpdate, Tab, TabPaneType } from "@/common/settings/app";
@@ -257,6 +270,17 @@ const tabPaneSize2 = computed(() => {
     (windowSize.height - splitterWidth) * (bottomPaneHeightPercentage.value / 100),
   );
 });
+
+const tabPaneSize2a = computed(
+  () =>
+    new RectSize(
+      tabPaneSize2.value.width,
+      Math.min(
+        Math.max(tabPaneSize2.value.width * 0.5, 150),
+        tabPaneSize2.value.height * 0.2 + 100,
+      ),
+    ),
+);
 </script>
 
 <style>

--- a/src/renderer/view/tab/EvaluationChart.vue
+++ b/src/renderer/view/tab/EvaluationChart.vue
@@ -268,6 +268,7 @@ const buildDatasets = (record: ImmutableRecord, config: ChartConfig) => {
 };
 
 const buildScalesOption = (record: ImmutableRecord, config: ChartConfig) => {
+  const stepSize = config.type === EvaluationChartType.RAW ? MAX_SCORE / 2 : 25;
   return {
     x: {
       min: 0,
@@ -278,7 +279,7 @@ const buildScalesOption = (record: ImmutableRecord, config: ChartConfig) => {
     y: {
       min: getMinScore(config.type),
       max: getMaxScore(config.type),
-      ticks: { color: config.palette.ticks },
+      ticks: { color: config.palette.ticks, stepSize },
       grid: { color: config.palette.grid },
     },
   };


### PR DESCRIPTION
# 説明 / Description

#1072

タブビューの形式に「2列 v2」を追加しする。
これを選ぶとコメントが常に表示され、評価値グラフとコメントを同時に見ることができる。

<img width="453" alt="スクリーンショット 2025-01-25 21 36 27" src="https://github.com/user-attachments/assets/e3f73a57-261a-484a-9f3f-46f2e879e1cf" />
<img width="1214" alt="スクリーンショット 2025-01-25 21 38 19" src="https://github.com/user-attachments/assets/59f9bd48-0117-4c9c-911f-4e3fc569176c" />

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new two-column view style (v2) in application settings
  - Enhanced chart configuration with more precise y-axis tick management

- **Improvements**
  - Updated tab pane rendering logic to support more flexible layout options
  - Refined default application settings for improved user experience

- **UI Changes**
  - Added new layout option in application settings dialog
  - Adjusted standard layout to accommodate new tab pane configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->