### PR TITLE
Mac版において子ウィンドウをデスクトップ間で移動可能にする改善

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -93,17 +93,15 @@ app.on("will-quit", (event) => {
   shutdownLoggers();
 });
 
-// Quit when all windows are closed.
-app.on("window-all-closed", () => {
-  getAppLogger().info("on window-all-closed");
+function onMainWindowClosed() {
   app.quit();
-});
+}
 
 app.on("activate", () => {
   // On macOS it's common to re-create a window in the app when the
   // dock icon is clicked and there are no other windows open.
   if (BrowserWindow.getAllWindows().length === 0) {
-    createWindow();
+    createWindow(onMainWindowClosed);
   }
 });
 
@@ -160,7 +158,7 @@ app.on("ready", () => {
     validateHTTPRequest(details.method, details.url);
     callback({});
   });
-  createWindow();
+  createWindow(onMainWindowClosed);
 });
 
 // Exit cleanly on request from parent process in development mode.

--- a/src/background/window/auxiliary.ts
+++ b/src/background/window/auxiliary.ts
@@ -3,11 +3,11 @@ import { BrowserWindow } from "electron";
 import { getPreloadPath, isDevelopment, isPreview, isTest } from "@/background/proc/env";
 import { getAppLogger } from "@/background/log";
 
-export function createChildWindow(
+export function createAuxiliaryWindow(
   name: string,
   query: Record<string, string>,
   parent: BrowserWindow,
-  onClose: (webContentsID: number) => void,
+  onClosed: (webContentsID: number) => void,
 ): BrowserWindow {
   const win = new BrowserWindow({
     webPreferences: {
@@ -17,16 +17,15 @@ export function createChildWindow(
       // NOTE: 現状、子ウィンドウではタイマーの実行が抑制されても困るケースが無いので、スロットリングは有効(デフォルト)にしておく。
       //backgroundThrottling: false,
     },
+    backgroundColor: "#888",
   });
-  win.setBackgroundColor("#888");
-  win.setParentWindow(parent);
   win.menuBarVisible = false;
   win.once("ready-to-show", () => {
     win.webContents.setZoomLevel(parent.webContents.getZoomLevel());
   });
 
   win.on("close", () => {
-    onClose(win.webContents.id);
+    onClosed(win.webContents.id);
   });
 
   if (isDevelopment() || isTest()) {

--- a/src/background/window/layout.ts
+++ b/src/background/window/layout.ts
@@ -1,5 +1,5 @@
 import { BrowserWindow } from "electron";
-import { createChildWindow } from "./child";
+import { createAuxiliaryWindow } from "./auxiliary";
 
 let win: BrowserWindow | null = null;
 
@@ -8,7 +8,7 @@ export function createLayoutManagerWindow(parent: BrowserWindow) {
     win.focus();
     return;
   }
-  win = createChildWindow("layout-manager", {}, parent, () => {
+  win = createAuxiliaryWindow("layout-manager", {}, parent, () => {
     win = null;
   });
 }

--- a/src/background/window/main.ts
+++ b/src/background/window/main.ts
@@ -18,7 +18,7 @@ import { setupMenu } from "@/background/window/menu";
 import { t } from "@/common/i18n";
 import { ghioDomain } from "@/common/links/github";
 
-export function createWindow() {
+export function createWindow(onClosed: () => void) {
   let settings = loadWindowSettings();
 
   getAppLogger().info("create BrowserWindow");
@@ -35,8 +35,8 @@ export function createWindow() {
       // 対局や棋譜解析の用途では処理の遅延が致命的なのでスロットリングを無効にする。
       backgroundThrottling: false,
     },
+    backgroundColor: "#888",
   });
-  win.setBackgroundColor("#888");
   if (settings.maximized) {
     win.maximize();
   }
@@ -56,6 +56,7 @@ export function createWindow() {
     }
     settings = buildWindowSettings(settings, win);
     saveWindowSettings(settings);
+    onClosed();
   });
 
   setupIPC(win);

--- a/src/background/window/menu.ts
+++ b/src/background/window/menu.ts
@@ -337,8 +337,7 @@ function createMenuTemplate(window: BrowserWindow) {
         {
           label: t.defaultFontSize,
           click: () => {
-            window.webContents.setZoomLevel(0);
-            window.getChildWindows().forEach((child) => {
+            BrowserWindow.getAllWindows().forEach((child) => {
               child.webContents.setZoomLevel(0);
             });
           },
@@ -348,8 +347,7 @@ function createMenuTemplate(window: BrowserWindow) {
           label: t.increaseFontSize,
           click: () => {
             const level = window.webContents.getZoomLevel() + 1;
-            window.webContents.setZoomLevel(level);
-            window.getChildWindows().forEach((child) => {
+            BrowserWindow.getAllWindows().forEach((child) => {
               child.webContents.setZoomLevel(level);
             });
           },
@@ -359,8 +357,7 @@ function createMenuTemplate(window: BrowserWindow) {
           label: t.decreaseFontSize,
           click: () => {
             const level = window.webContents.getZoomLevel() - 1;
-            window.webContents.setZoomLevel(level);
-            window.getChildWindows().forEach((child) => {
+            BrowserWindow.getAllWindows().forEach((child) => {
               child.webContents.setZoomLevel(level);
             });
           },

--- a/src/background/window/monitor.ts
+++ b/src/background/window/monitor.ts
@@ -1,5 +1,5 @@
 import { BrowserWindow } from "electron";
-import { createChildWindow } from "./child";
+import { createAuxiliaryWindow } from "./auxiliary";
 
 let win: BrowserWindow | null = null;
 
@@ -8,7 +8,7 @@ export function createMonitorWindow(parent: BrowserWindow) {
     win.focus();
     return;
   }
-  win = createChildWindow("monitor", {}, parent, () => {
+  win = createAuxiliaryWindow("monitor", {}, parent, () => {
     win = null;
   });
 }

--- a/src/background/window/prompt.ts
+++ b/src/background/window/prompt.ts
@@ -1,18 +1,18 @@
 import { BrowserWindow } from "electron";
 import { PromptTarget } from "@/common/advanced/prompt";
-import { createChildWindow } from "./child";
+import { createAuxiliaryWindow } from "./auxiliary";
 
 export function createCommandWindow(
   parent: BrowserWindow,
   target: PromptTarget,
   sessionID: number,
   name: string,
-  onClose: (webContentsID: number) => void,
+  onClosed: (webContentsID: number) => void,
 ) {
   const query = {
     target,
     session: String(sessionID),
     name,
   };
-  createChildWindow("prompt", query, parent, onClose);
+  createAuxiliaryWindow("prompt", query, parent, onClosed);
 }


### PR DESCRIPTION
# 説明 / Description

#1093 

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced window management with improved callback functionality upon window closure.

- **Bug Fixes**
  - None

- **Refactor**
  - Updated window creation method across multiple window management modules.
  - Streamlined background color configuration for application windows.
  - Modified zoom level adjustment to apply across all application windows.
  - Centralized application quitting logic for improved clarity and maintainability.

- **Chores**
  - Renamed `createChildWindow` to `createAuxiliaryWindow`.
  - Updated parameter naming for consistency across window management functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->