### PR TITLE
Write temp file to the same location as real file

### DIFF
--- a/src/background/file/atomic.ts
+++ b/src/background/file/atomic.ts
@@ -1,11 +1,9 @@
-import path from "node:path";
-import os from "node:os";
 import fs from "node:fs";
 
-function newTempFilePath(): string {
+function newTempFilePath(filePath: string): string {
   const time = Date.now().toString(16);
   const random = Math.floor(Math.random() * 0x100000).toString(16);
-  return path.join(os.tmpdir(), `${time}-${random}.tmp`);
+  return `${filePath}-${time}-${random}.tmp`;
 }
 
 export async function writeFileAtomic(
@@ -13,13 +11,13 @@ export async function writeFileAtomic(
   data: string,
   encoding?: BufferEncoding,
 ): Promise<void> {
-  const tempFilePath = newTempFilePath();
+  const tempFilePath = newTempFilePath(filePath);
   await fs.promises.writeFile(tempFilePath, data, encoding);
   await fs.promises.rename(tempFilePath, filePath);
 }
 
 export function writeFileAtomicSync(filePath: string, data: string, encoding?: BufferEncoding) {
-  const tempFilePath = newTempFilePath();
+  const tempFilePath = newTempFilePath(filePath);
   fs.writeFileSync(tempFilePath, data, encoding);
   fs.renameSync(tempFilePath, filePath);
 }


### PR DESCRIPTION
# Description

Like described in https://github.com/sunfish-shogi/shogihome/issues/1102, writing temporary files to `/tmp` and then renaming them to a path on a different device seems to cause issues.

This pull request tries to fix this issue by putting the temporary file in the same location as the real file, so that both are stored on the same device. I'm not sure if this is the best way to fix this, but it resolves the issue for me.

Closes https://github.com/sunfish-shogi/shogihome/issues/1102.

# Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [x] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the behind-the-scenes file saving process for enhanced consistency and stability.
- **Chore**
	- Streamlined the internal file handling by removing unnecessary dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->