### PR TITLE
Use defineModel and v-model

### DIFF
--- a/src/renderer/view/dialog/AddBookMovesDialog.vue
+++ b/src/renderer/view/dialog/AddBookMovesDialog.vue
@@ -4,17 +4,12 @@
       <div class="title">定跡手追加</div>
       <div>
         <HorizontalSelector
-          :value="sourceType"
+          v-model:value="sourceType"
           :items="[
             { value: SourceType.MEMORY, label: '現在の棋譜から' },
             { value: SourceType.FILE, label: 'ファイルから' },
             { value: SourceType.DIRECTORY, label: 'フォルダから' },
           ]"
-          @change="
-            (value) => {
-              sourceType = value as SourceType;
-            }
-          "
         />
       </div>
       <div class="form-group scroll">
@@ -67,18 +62,13 @@
         </div>
         <div v-show="sourceType === 'directory' || sourceType === 'file'" class="form-item row">
           <HorizontalSelector
-            :value="playerCriteria"
+            v-model:value="playerCriteria"
             :items="[
               { value: PlayerCriteria.ALL, label: '全ての対局者' },
               { value: PlayerCriteria.BLACK, label: '先手のみ' },
               { value: PlayerCriteria.WHITE, label: '後手のみ' },
               { value: PlayerCriteria.FILTER_BY_NAME, label: '名前でフィルタ' },
             ]"
-            @change="
-              (value) => {
-                playerCriteria = value as PlayerCriteria;
-              }
-            "
           />
         </div>
         <div v-show="sourceType === 'directory' || sourceType === 'file'" class="form-item row">

--- a/src/renderer/view/dialog/AnalysisDialog.vue
+++ b/src/renderer/view/dialog/AnalysisDialog.vue
@@ -5,26 +5,18 @@
       <div class="form-group">
         <div>{{ t.searchEngine }}</div>
         <PlayerSelector
-          :player-uri="engineURI"
+          v-model:player-uri="engineURI"
           :engines="engines"
           :filter-label="USIEngineLabel.RESEARCH"
           :display-thread-state="true"
           :display-multi-pv-state="true"
           @update-engines="onUpdatePlayerSettings"
-          @select-player="onSelectPlayer"
         />
       </div>
       <div class="form-group">
         <div>{{ t.startEndCriteria }}</div>
         <div class="form-item">
-          <ToggleButton
-            :value="enableStartNumber"
-            @change="
-              (value: boolean) => {
-                enableStartNumber = value;
-              }
-            "
-          />
+          <ToggleButton v-model:value="enableStartNumber" />
           <div class="form-item-small-label">{{ t.fromPrefix }}{{ t.plyPrefix }}</div>
           <input
             ref="startNumber"
@@ -37,14 +29,7 @@
           <div class="form-item-small-label">{{ t.plySuffix }}{{ t.fromSuffix }}</div>
         </div>
         <div class="form-item">
-          <ToggleButton
-            :value="enableEndNumber"
-            @change="
-              (value: boolean) => {
-                enableEndNumber = value;
-              }
-            "
-          />
+          <ToggleButton v-model:value="enableEndNumber" />
           <div class="form-item-small-label">{{ t.toPrefix }}{{ t.plyPrefix }}</div>
           <input
             ref="endNumber"
@@ -70,6 +55,7 @@
         <div class="form-item">
           <div class="form-item-label-wide">{{ t.moveComments }}</div>
           <HorizontalSelector
+            v-model:value="commentBehavior"
             class="selector"
             :items="[
               { value: CommentBehavior.NONE, label: t.noOutputs },
@@ -77,12 +63,6 @@
               { value: CommentBehavior.APPEND, label: t.appendCommentToBottom },
               { value: CommentBehavior.OVERWRITE, label: t.overwrite },
             ]"
-            :value="commentBehavior"
-            @change="
-              (value: string) => {
-                commentBehavior = value as CommentBehavior;
-              }
-            "
           />
         </div>
       </div>
@@ -184,10 +164,6 @@ const onCancel = () => {
 
 const onUpdatePlayerSettings = async (val: USIEngines) => {
   engines.value = val;
-};
-
-const onSelectPlayer = (uri: string) => {
-  engineURI.value = uri;
 };
 </script>
 

--- a/src/renderer/view/dialog/AppSettingsDialog.vue
+++ b/src/renderer/view/dialog/AppSettingsDialog.vue
@@ -18,7 +18,7 @@
                 { label: '繁體中文', value: Language.ZH_TW },
                 { label: 'Tiếng Việt', value: Language.VI },
               ]"
-              @change="
+              @update:value="
                 (value: string) => {
                   update.language = value as Language;
                 }
@@ -55,7 +55,7 @@
                 { label: t.darkGreen, value: Thema.DARK_GREEN },
                 { label: t.dark, value: Thema.DARK },
               ]"
-              @change="
+              @update:value="
                 (value: string) => {
                   update.thema = value as Thema;
                 }
@@ -74,7 +74,7 @@
                 { label: t.bgContain, value: BackgroundImageType.CONTAIN },
                 { label: t.bgTile, value: BackgroundImageType.TILE },
               ]"
-              @change="
+              @update:value="
                 (value: string) => {
                   update.backgroundImageType = value as BackgroundImageType;
                 }
@@ -106,7 +106,7 @@
                 { label: t.compact, value: BoardLayoutType.COMPACT },
                 { label: t.portrait, value: BoardLayoutType.PORTRAIT },
               ]"
-              @change="
+              @update:value="
                 (value: string) => {
                   update.boardLayoutType = value as BoardLayoutType;
                 }
@@ -131,7 +131,7 @@
                   { label: t.customImage, value: PieceImageType.CUSTOM_IMAGE },
                 ].filter((item) => !isMobileWebApp() || item.value !== PieceImageType.CUSTOM_IMAGE)
               "
-              @change="
+              @update:value="
                 (value: string) => {
                   update.pieceImage = value as PieceImageType;
                 }
@@ -157,7 +157,7 @@
               <ToggleButton
                 :label="t.imageHasMarginsRemoveForLargerDisplay"
                 :value="original.deletePieceImageMargin"
-                @change="(checked: boolean) => (update.deletePieceImageMargin = checked)"
+                @update:value="(checked: boolean) => (update.deletePieceImageMargin = checked)"
               />
             </div>
           </div>
@@ -183,7 +183,7 @@
                   { label: t.customImage, value: BoardImageType.CUSTOM_IMAGE },
                 ].filter((item) => !isMobileWebApp() || item.value !== BoardImageType.CUSTOM_IMAGE)
               "
-              @change="
+              @update:value="
                 (value: string) => {
                   update.boardImage = value as BoardImageType;
                 }
@@ -221,7 +221,7 @@
                   (item) => !isMobileWebApp() || item.value !== PieceStandImageType.CUSTOM_IMAGE,
                 )
               "
-              @change="
+              @update:value="
                 (value: string) => {
                   update.pieceStandImage = value as PieceStandImageType;
                 }
@@ -247,7 +247,7 @@
             <div class="form-item-label-wide">{{ t.transparent }}</div>
             <ToggleButton
               :value="original.enableTransparent"
-              @change="(checked: boolean) => (update.enableTransparent = checked)"
+              @update:value="(checked: boolean) => (update.enableTransparent = checked)"
             />
           </div>
           <!-- 盤の不透明度 -->
@@ -309,7 +309,7 @@
             </div>
             <ToggleButton
               :value="original.boardLabelType != BoardLabelType.NONE"
-              @change="
+              @update:value="
                 (checked: boolean) =>
                   (update.boardLabelType = checked ? BoardLabelType.STANDARD : BoardLabelType.NONE)
               "
@@ -322,7 +322,7 @@
             </div>
             <ToggleButton
               :value="original.leftSideControlType != LeftSideControlType.NONE"
-              @change="
+              @update:value="
                 (checked: boolean) =>
                   (update.leftSideControlType = checked
                     ? LeftSideControlType.STANDARD
@@ -337,7 +337,7 @@
             </div>
             <ToggleButton
               :value="original.rightSideControlType != RightSideControlType.NONE"
-              @change="
+              @update:value="
                 (checked: boolean) =>
                   (update.rightSideControlType = checked
                     ? RightSideControlType.STANDARD
@@ -356,7 +356,7 @@
                 { label: t.twoColumns, value: TabPaneType.DOUBLE },
                 { label: `${t.twoColumns} v2`, value: TabPaneType.DOUBLE_V2 },
               ]"
-              @change="
+              @update:value="
                 (value: string) => {
                   update.tabPaneType = value as TabPaneType;
                 }
@@ -428,7 +428,7 @@
                 { label: t.anyTurn, value: ClockSoundTarget.ALL },
                 { label: t.onlyHumanTurn, value: ClockSoundTarget.ONLY_USER },
               ]"
-              @change="
+              @update:value="
                 (value: string) => {
                   update.clockSoundTarget = value as ClockSoundTarget;
                 }
@@ -456,7 +456,7 @@
                 { label: '.csa', value: RecordFileFormat.CSA },
                 { label: '.jkf', value: RecordFileFormat.JKF },
               ]"
-              @change="
+              @update:value="
                 (value: string) => {
                   update.defaultRecordFileFormat = value as RecordFileFormat;
                 }
@@ -475,7 +475,7 @@
                 { label: t.strict, value: TextDecodingRule.STRICT },
                 { label: t.autoDetect, value: TextDecodingRule.AUTO_DETECT },
               ]"
-              @change="
+              @update:value="
                 (value: string) => {
                   update.textDecodingRule = value as TextDecodingRule;
                 }
@@ -495,7 +495,7 @@
                 { label: 'LF (UNIX/Mac)', value: 'lf' },
                 { label: `CR (${t.old90sMac})`, value: 'cr' },
               ]"
-              @change="
+              @update:value="
                 (value: string) => {
                   update.returnCode = nameToReturnCode[value];
                 }
@@ -549,7 +549,7 @@
             <div class="form-item-label-wide">{{ t.csaV3Output }}</div>
             <ToggleButton
               :value="original.useCSAV3"
-              @change="(checked: boolean) => (update.useCSAV3 = checked)"
+              @update:value="(checked: boolean) => (update.useCSAV3 = checked)"
             />
           </div>
           <!-- USI の局面表記 -->
@@ -562,7 +562,7 @@
                 { label: t.onlySFEN, value: 'false' },
                 { label: 'startpos / SFEN', value: 'true' },
               ]"
-              @change="
+              @update:value="
                 (value: string) => {
                   update.enableUSIFileStartpos = value === 'true';
                 }
@@ -579,7 +579,7 @@
                 { label: t.onlySFEN, value: 'false' },
                 { label: 'SFEN / resign', value: 'true' },
               ]"
-              @change="
+              @update:value="
                 (value: string) => {
                   update.enableUSIFileResign = value === 'true';
                 }
@@ -621,7 +621,7 @@
             </div>
             <ToggleButton
               :value="original.translateEngineOptionName"
-              @change="(checked: boolean) => (update.translateEngineOptionName = checked)"
+              @update:value="(checked: boolean) => (update.translateEngineOptionName = checked)"
             />
             <div class="form-item-small-label">({{ t.functionalOnJapaneseOnly }})</div>
           </div>
@@ -663,7 +663,7 @@
                   value: EvaluationViewFrom.BLACK,
                 },
               ]"
-              @change="
+              @update:value="
                 (value: string) => {
                   update.evaluationViewFrom = value as EvaluationViewFrom;
                 }
@@ -811,7 +811,7 @@
                 { label: 'CSA V3', value: SearchCommentFormat.CSA3 },
                 { label: 'ShogiGUI', value: SearchCommentFormat.SHOGIGUI },
               ]"
-              @change="
+              @update:value="
                 (value: string) => {
                   update.searchCommentFormat = value as SearchCommentFormat;
                 }
@@ -870,7 +870,7 @@
             <div class="form-item-label-wide">{{ t.enableAppLog }}</div>
             <ToggleButton
               :value="original.enableAppLog"
-              @change="(checked: boolean) => (update.enableAppLog = checked)"
+              @update:value="(checked: boolean) => (update.enableAppLog = checked)"
             />
           </div>
           <!-- USI通信ログを出力 -->
@@ -878,7 +878,7 @@
             <div class="form-item-label-wide">{{ t.enableUSILog }}</div>
             <ToggleButton
               :value="original.enableUSILog"
-              @change="(checked: boolean) => (update.enableUSILog = checked)"
+              @update:value="(checked: boolean) => (update.enableUSILog = checked)"
             />
           </div>
           <!-- CSA通信ログを出力 -->
@@ -886,7 +886,7 @@
             <div class="form-item-label-wide">{{ t.enableCSALog }}</div>
             <ToggleButton
               :value="original.enableCSALog"
-              @change="(checked: boolean) => (update.enableCSALog = checked)"
+              @update:value="(checked: boolean) => (update.enableCSALog = checked)"
             />
           </div>
           <!-- ログレベル -->
@@ -901,7 +901,7 @@
                 { label: 'WARN', value: LogLevel.WARN },
                 { label: 'ERROR', value: LogLevel.ERROR },
               ]"
-              @change="
+              @update:value="
                 (value: string) => {
                   update.logLevel = value as LogLevel;
                 }

--- a/src/renderer/view/dialog/BatchConversionDialog.vue
+++ b/src/renderer/view/dialog/BatchConversionDialog.vue
@@ -16,94 +16,27 @@
         <div class="form-item">
           <div class="form-item-label-wide">{{ t.formats }}</div>
           <div class="formats">
-            <ToggleButton
-              class="toggle"
-              label=".kif"
-              :value="sourceFormats.kif"
-              @change="
-                (val: boolean) => {
-                  sourceFormats.kif = val;
-                }
-              "
-            />
-            <ToggleButton
-              class="toggle"
-              label=".kifu"
-              :value="sourceFormats.kifu"
-              @change="
-                (val: boolean) => {
-                  sourceFormats.kifu = val;
-                }
-              "
-            />
-            <ToggleButton
-              class="toggle"
-              label=".ki2"
-              :value="sourceFormats.ki2"
-              @change="
-                (val: boolean) => {
-                  sourceFormats.ki2 = val;
-                }
-              "
-            />
-            <ToggleButton
-              class="toggle"
-              label=".ki2u"
-              :value="sourceFormats.ki2u"
-              @change="
-                (val: boolean) => {
-                  sourceFormats.ki2u = val;
-                }
-              "
-            />
-            <ToggleButton
-              class="toggle"
-              label=".csa"
-              :value="sourceFormats.csa"
-              @change="
-                (val: boolean) => {
-                  sourceFormats.csa = val;
-                }
-              "
-            />
-            <ToggleButton
-              class="toggle"
-              label=".jkf"
-              :value="sourceFormats.jkf"
-              @change="
-                (val: boolean) => {
-                  sourceFormats.jkf = val;
-                }
-              "
-            />
+            <ToggleButton v-model:value="sourceFormats.kif" class="toggle" label=".kif" />
+            <ToggleButton v-model:value="sourceFormats.kifu" class="toggle" label=".kifu" />
+            <ToggleButton v-model:value="sourceFormats.ki2" class="toggle" label=".ki2" />
+            <ToggleButton v-model:value="sourceFormats.ki2u" class="toggle" label=".ki2u" />
+            <ToggleButton v-model:value="sourceFormats.csa" class="toggle" label=".csa" />
+            <ToggleButton v-model:value="sourceFormats.jkf" class="toggle" label=".jkf" />
           </div>
         </div>
         <div class="form-item row">
           <div class="form-item-label-wide">{{ t.subdirectories }}</div>
-          <ToggleButton
-            class="toggle"
-            :value="subdirectories"
-            @change="
-              (val: boolean) => {
-                subdirectories = val;
-              }
-            "
-          />
+          <ToggleButton v-model:value="subdirectories" class="toggle" />
         </div>
         <hr />
         <div>{{ t.outputs }}</div>
         <div class="form-item center">
           <HorizontalSelector
+            v-model:value="destinationType"
             :items="[
               { label: t.separate, value: DestinationType.DIRECTORY },
               { label: t.merge, value: DestinationType.SINGLE_FILE },
             ]"
-            :value="destinationType"
-            @change="
-              (val: string) => {
-                destinationType = val as DestinationType;
-              }
-            "
           />
         </div>
         <div v-show="destinationType !== DestinationType.SINGLE_FILE" class="form-item row">
@@ -119,6 +52,7 @@
           <div class="form-item-label-wide">{{ t.format }}</div>
           <div class="formats">
             <HorizontalSelector
+              v-model:value="destinationFormat"
               :items="[
                 { label: '.kif', value: RecordFileFormat.KIF },
                 { label: '.kifu', value: RecordFileFormat.KIFU },
@@ -127,30 +61,17 @@
                 { label: '.csa', value: RecordFileFormat.CSA },
                 { label: '.jkf', value: RecordFileFormat.JKF },
               ]"
-              :value="destinationFormat"
-              @change="
-                (val: string) => {
-                  destinationFormat = val as RecordFileFormat;
-                }
-              "
             />
           </div>
         </div>
         <div v-show="destinationType !== DestinationType.SINGLE_FILE" class="form-item row">
           <div class="form-item-label-wide">{{ t.createSubdirectories }}</div>
-          <ToggleButton
-            class="toggle"
-            :value="createSubdirectories"
-            @change="
-              (val: boolean) => {
-                createSubdirectories = val;
-              }
-            "
-          />
+          <ToggleButton v-model:value="createSubdirectories" class="toggle" />
         </div>
         <div v-show="destinationType !== DestinationType.SINGLE_FILE" class="form-item row">
           <div class="form-item-label-wide">{{ t.nameConflictAction }}</div>
           <HorizontalSelector
+            v-model:value="fileNameConflictAction"
             :items="[
               { label: t.overwrite, value: FileNameConflictAction.OVERWRITE },
               {
@@ -159,12 +80,6 @@
               },
               { label: t.skip, value: FileNameConflictAction.SKIP },
             ]"
-            :value="fileNameConflictAction"
-            @change="
-              (val: string) => {
-                fileNameConflictAction = val as FileNameConflictAction;
-              }
-            "
           />
         </div>
         <div v-show="destinationType === DestinationType.SINGLE_FILE" class="form-item row">

--- a/src/renderer/view/dialog/BookMoveDialog.vue
+++ b/src/renderer/view/dialog/BookMoveDialog.vue
@@ -17,14 +17,7 @@
             :value="score || 0"
             :readonly="!enableScore"
           />
-          <ToggleButton
-            :value="enableScore"
-            @change="
-              (value: boolean) => {
-                enableScore = value;
-              }
-            "
-          />
+          <ToggleButton v-model:value="enableScore" />
         </div>
         <div class="form-item">
           <div class="form-item-label">{{ t.depth }}</div>
@@ -36,14 +29,7 @@
             :value="depth || 0"
             :readonly="!enableDepth"
           />
-          <ToggleButton
-            :value="enableDepth"
-            @change="
-              (value: boolean) => {
-                enableDepth = value;
-              }
-            "
-          />
+          <ToggleButton v-model:value="enableDepth" />
         </div>
         <div class="form-item">
           <div class="form-item-label">{{ t.frequency }}</div>
@@ -55,14 +41,7 @@
             :value="count || 0"
             :readonly="!enableCount"
           />
-          <ToggleButton
-            :value="enableCount"
-            @change="
-              (value: boolean) => {
-                enableCount = value;
-              }
-            "
-          />
+          <ToggleButton v-model:value="enableCount" />
         </div>
         <div class="form-item">
           <div class="form-item-label">{{ t.comments }}</div>

--- a/src/renderer/view/dialog/CSAGameDialog.vue
+++ b/src/renderer/view/dialog/CSAGameDialog.vue
@@ -13,7 +13,7 @@
         <div class="form-group">
           <div>{{ t.player }}</div>
           <PlayerSelector
-            :player-uri="playerURI"
+            v-model:player-uri="playerURI"
             :contains-human="true"
             :contains-basic-engines="true"
             :engines="engines"
@@ -22,19 +22,11 @@
             :display-thread-state="true"
             :display-multi-pv-state="true"
             @update-engines="onUpdatePlayerSettings"
-            @select-player="onSelectPlayer"
           />
           <hr v-if="uri.isUSIEngine(playerURI)" />
           <div v-if="uri.isUSIEngine(playerURI)" class="form-item">
             <div class="form-item-label-wide">{{ t.restartItEveryGame }}</div>
-            <ToggleButton
-              :value="restartPlayerEveryGame"
-              @change="
-                (value: boolean) => {
-                  restartPlayerEveryGame = value;
-                }
-              "
-            />
+            <ToggleButton v-model:value="restartPlayerEveryGame" />
           </div>
         </div>
         <div class="form-group">
@@ -55,12 +47,7 @@
           <hr />
           <div class="form-item">
             <div class="form-item-label-wide">{{ t.version }}</div>
-            <select
-              ref="protocolVersion"
-              class="long-text"
-              value="CSA_v121"
-              @change="onChangeProtocolVersion"
-            >
+            <select v-model="protocolVersion" class="long-text">
               <option :value="CSAProtocolVersion.V121">
                 {{ t.csaProtocolV121 }}
               </option>
@@ -69,10 +56,7 @@
               </option>
             </select>
           </div>
-          <div
-            v-if="selectedProtocolVersion === CSAProtocolVersion.V121"
-            class="form-group warning"
-          >
+          <div v-if="protocolVersion === CSAProtocolVersion.V121" class="form-group warning">
             <div class="note">
               {{ t.notSendPVOnStandardCSAProtocol }}
             </div>
@@ -100,15 +84,11 @@
           </div>
           <div class="form-item">
             <div class="form-item-label-wide">{{ t.password }}</div>
-            <input ref="password" class="long-text" type="password" />
+            <input ref="password" class="long-text" :type="revealPassword ? 'text' : 'password'" />
           </div>
           <div class="form-item">
             <div class="form-item-label-wide"></div>
-            <ToggleButton
-              :label="t.revealPassword"
-              :value="false"
-              @change="onTogglePasswordVisibility"
-            />
+            <ToggleButton v-model:value="revealPassword" :label="t.revealPassword" />
           </div>
           <div class="form-group warning">
             <div v-if="isEncryptionAvailable" class="note">
@@ -136,14 +116,7 @@
           </div>
           <div class="form-item">
             <div class="form-item-label-wide">{{ t.blankLinePing }}</div>
-            <ToggleButton
-              :value="blankLinePing"
-              @change="
-                (value: boolean) => {
-                  blankLinePing = value;
-                }
-              "
-            />
+            <ToggleButton v-model:value="blankLinePing" />
           </div>
           <div v-show="blankLinePing" class="form-item">
             <div class="form-item-label-wide">{{ t.blankLinePingInitialDelay }}</div>
@@ -175,14 +148,7 @@
           </div>
           <div class="form-item">
             <div class="form-item-label-wide">{{ t.saveHistory }}</div>
-            <ToggleButton
-              :value="saveHistory"
-              @change="
-                (value: boolean) => {
-                  saveHistory = value;
-                }
-              "
-            />
+            <ToggleButton v-model:value="saveHistory" />
           </div>
           <hr />
           <div class="form-item">
@@ -193,53 +159,25 @@
           </div>
           <div class="form-item">
             <div class="form-item-label-wide">{{ t.autoRelogin }}</div>
-            <ToggleButton
-              :value="autoRelogin"
-              @change="
-                (value: boolean) => {
-                  autoRelogin = value;
-                }
-              "
-            />
+            <ToggleButton v-model:value="autoRelogin" />
           </div>
         </div>
         <div class="form-group">
           <div class="form-item">
             <div class="form-item-label-wide">{{ t.outputComments }}</div>
-            <ToggleButton
-              :value="enableComment"
-              @change="
-                (value: boolean) => {
-                  enableComment = value;
-                }
-              "
-            />
+            <ToggleButton v-model:value="enableComment" />
           </div>
           <div class="form-item">
             <div class="form-item-label-wide">
               {{ t.saveRecordAutomatically }}
             </div>
-            <ToggleButton
-              :value="enableAutoSave"
-              @change="
-                (value: boolean) => {
-                  enableAutoSave = value;
-                }
-              "
-            />
+            <ToggleButton v-model:value="enableAutoSave" />
           </div>
           <div class="form-item">
             <div class="form-item-label-wide">
               {{ t.adjustBoardAutomatically }}
             </div>
-            <ToggleButton
-              :value="autoFlip"
-              @change="
-                (value: boolean) => {
-                  autoFlip = value;
-                }
-              "
-            />
+            <ToggleButton v-model:value="autoFlip" />
           </div>
         </div>
       </div>
@@ -297,12 +235,12 @@ const busyState = useBusyState();
 const messageStore = useMessageStore();
 const appSettings = useAppSettings();
 const dialog = ref();
-const protocolVersion = ref();
-const selectedProtocolVersion = ref(CSAProtocolVersion.V121);
+const protocolVersion = ref(CSAProtocolVersion.V121);
 const host = ref();
 const port = ref();
 const id = ref();
 const password = ref();
+const revealPassword = ref(false);
 const keepaliveInitialDelay = ref();
 const blankLinePing = ref(false);
 const blankLineInitialDelay = ref();
@@ -348,8 +286,7 @@ onUpdated(() => {
     return;
   }
   const defaultSettings = buildCSAGameSettingsByHistory(history.value, 0);
-  protocolVersion.value.value = selectedProtocolVersion.value =
-    defaultSettings.server.protocolVersion;
+  protocolVersion.value = defaultSettings.server.protocolVersion;
   host.value.value = defaultSettings.server.host;
   port.value.value = defaultSettings.server.port;
   id.value.value = defaultSettings.server.id;
@@ -387,7 +324,7 @@ const buildConfig = (): CSAGameSettings => {
   return {
     player: buildPlayerSettings(playerURI.value),
     server: {
-      protocolVersion: protocolVersion.value.value,
+      protocolVersion: protocolVersion.value,
       host: String(host.value.value || "").trim(),
       port: Number(port.value.value),
       id: String(id.value.value || "").trim(),
@@ -469,19 +406,11 @@ const onUpdatePlayerSettings = async (val: USIEngines) => {
   engines.value = val;
 };
 
-const onSelectPlayer = (uri: string) => {
-  playerURI.value = uri;
-};
-
-const onTogglePasswordVisibility = (value: boolean) => {
-  password.value.type = value ? "text" : "password";
-};
-
 const onChangeHistory = (event: Event) => {
   const select = event.target as HTMLSelectElement;
   const server = history.value.serverHistory[Number(select.value)];
   if (server) {
-    protocolVersion.value.value = selectedProtocolVersion.value = server.protocolVersion;
+    protocolVersion.value = server.protocolVersion;
     host.value.value = server.host;
     port.value.value = server.port;
     id.value.value = server.id;
@@ -493,10 +422,6 @@ const onChangeHistory = (event: Event) => {
       blankLineInterval.value.value = server.blankLinePing.interval;
     }
   }
-};
-
-const onChangeProtocolVersion = () => {
-  selectedProtocolVersion.value = protocolVersion.value.value;
 };
 
 const logEnabled = computed(() => {

--- a/src/renderer/view/dialog/ConnectToCSAServerDialog.vue
+++ b/src/renderer/view/dialog/ConnectToCSAServerDialog.vue
@@ -32,15 +32,11 @@
         </div>
         <div class="form-item">
           <div class="form-item-label-wide">{{ t.password }}</div>
-          <input ref="password" class="long-text" type="password" />
+          <input ref="password" class="long-text" :type="revealPassword ? 'text' : 'password'" />
         </div>
         <div class="form-item">
           <div class="form-item-label-wide"></div>
-          <ToggleButton
-            :label="t.revealPassword"
-            :value="false"
-            @change="onTogglePasswordVisibility"
-          />
+          <ToggleButton v-model:value="revealPassword" :label="t.revealPassword" />
         </div>
       </div>
       <div class="form-group warning">
@@ -83,6 +79,7 @@ const host = ref();
 const port = ref();
 const id = ref();
 const password = ref();
+const revealPassword = ref(false);
 
 onMounted(() => {
   showModalDialog(dialog.value, onCancel);
@@ -92,10 +89,6 @@ onMounted(() => {
 onBeforeUnmount(() => {
   uninstallHotKeyForDialog(dialog.value);
 });
-
-const onTogglePasswordVisibility = (value: boolean) => {
-  password.value.type = value ? "text" : "password";
-};
 
 const onStart = () => {
   const settings = {

--- a/src/renderer/view/dialog/GameDialog.vue
+++ b/src/renderer/view/dialog/GameDialog.vue
@@ -7,7 +7,7 @@
           <div class="half-column">
             <div class="top-label">{{ t.senteOrShitate }}</div>
             <PlayerSelector
-              :player-uri="blackPlayerURI"
+              v-model:player-uri="blackPlayerURI"
               :contains-human="true"
               :contains-basic-engines="true"
               :engines="engines"
@@ -16,14 +16,13 @@
               :display-thread-state="true"
               :display-multi-pv-state="true"
               @update-engines="onUpdatePlayerSettings"
-              @select-player="onSelectBlackPlayer"
             />
           </div>
           <div class="half-column">
             <div class="top-label">{{ t.goteOrUwate }}</div>
             <PlayerSelector
               v-if="whitePlayerURI"
-              :player-uri="whitePlayerURI"
+              v-model:player-uri="whitePlayerURI"
               :contains-human="true"
               :contains-basic-engines="true"
               :engines="engines"
@@ -32,7 +31,6 @@
               :display-thread-state="true"
               :display-multi-pv-state="true"
               @update-engines="onUpdatePlayerSettings"
-              @select-player="onSelectWhitePlayer"
             />
           </div>
         </div>
@@ -56,46 +54,61 @@
               <div class="form-item-small-label">{{ t.secondsSuffix }}</div>
             </div>
             <div class="form-item">
-              <ToggleButton
-                :label="t.enableEngineTimeout"
-                :value="enableEngineTimeout"
-                @change="
-                  (value: boolean) => {
-                    enableEngineTimeout = value;
-                  }
-                "
-              />
+              <ToggleButton v-model:value="enableEngineTimeout" :label="t.enableEngineTimeout" />
             </div>
           </div>
           <div class="half-column">
             <div class="form-item">
               <div class="form-item-label">{{ t.allottedTime }}</div>
-              <input ref="whiteHours" class="time" type="number" min="0" max="99" step="1" />
+              <input
+                ref="whiteHours"
+                class="time"
+                type="number"
+                min="0"
+                max="99"
+                step="1"
+                :disabled="!setDifferentTime"
+              />
               <div class="form-item-small-label">{{ t.hoursSuffix }}</div>
-              <input ref="whiteMinutes" class="time" type="number" min="0" max="59" step="1" />
+              <input
+                ref="whiteMinutes"
+                class="time"
+                type="number"
+                min="0"
+                max="59"
+                step="1"
+                :disabled="!setDifferentTime"
+              />
               <div class="form-item-small-label">{{ t.minutesSuffix }}</div>
             </div>
             <div class="form-item">
               <div class="form-item-label">{{ t.byoyomi }}</div>
-              <input ref="whiteByoyomi" class="time" type="number" min="0" max="60" step="1" />
+              <input
+                ref="whiteByoyomi"
+                class="time"
+                type="number"
+                min="0"
+                max="60"
+                step="1"
+                :disabled="!setDifferentTime"
+              />
               <div class="form-item-small-label">{{ t.secondsSuffix }}</div>
             </div>
             <div class="form-item">
               <div class="form-item-label">{{ t.increments }}</div>
-              <input ref="whiteIncrement" class="time" type="number" min="0" max="99" step="1" />
+              <input
+                ref="whiteIncrement"
+                class="time"
+                type="number"
+                min="0"
+                max="99"
+                step="1"
+                :disabled="!setDifferentTime"
+              />
               <div class="form-item-small-label">{{ t.secondsSuffix }}</div>
             </div>
             <div class="form-item">
-              <ToggleButton
-                :label="t.setDifferentTimeForGote"
-                :value="setDifferentTime"
-                @change="
-                  (value: boolean) => {
-                    setDifferentTime = value;
-                    onUpdateSetDifferentTime();
-                  }
-                "
-              />
+              <ToggleButton v-model:value="setDifferentTime" :label="t.setDifferentTimeForGote" />
             </div>
           </div>
         </div>
@@ -111,14 +124,7 @@
           <div class="half-column">
             <div class="form-item">
               <div class="form-item-label">{{ t.startPosition }}</div>
-              <select
-                :value="startPosition"
-                @change="
-                  (event) =>
-                    (startPosition = (event.target as HTMLSelectElement)
-                      .value as GameStartPositionType)
-                "
-              >
+              <select v-model="startPosition">
                 <option value="current">{{ t.currentPosition }}</option>
                 <option value="list">{{ t.positionList }}</option>
                 <option :value="InitialPositionType.STANDARD">
@@ -161,15 +167,7 @@
               <button class="thin" @click="onSelectStartPositionListFile">{{ t.select }}</button>
             </div>
             <div v-show="startPosition === 'list'" class="form-item">
-              <ToggleButton
-                :label="t.shuffle"
-                :value="startPositionListShuffle"
-                @change="
-                  (value: boolean) => {
-                    startPositionListShuffle = value;
-                  }
-                "
-              />
+              <ToggleButton v-model:value="startPositionListShuffle" :label="t.shuffle" />
             </div>
             <div class="form-item">
               <div class="form-item-label">{{ t.maxMoves }}</div>
@@ -191,48 +189,16 @@
           </div>
           <div class="half-column">
             <div class="form-item">
-              <ToggleButton
-                :label="t.swapTurnWhenGameRepetition"
-                :value="swapPlayers"
-                @change="
-                  (value: boolean) => {
-                    swapPlayers = value;
-                  }
-                "
-              />
+              <ToggleButton v-model:value="swapPlayers" :label="t.swapTurnWhenGameRepetition" />
             </div>
             <div class="form-item">
-              <ToggleButton
-                :label="t.outputComments"
-                :value="enableComment"
-                @change="
-                  (value: boolean) => {
-                    enableComment = value;
-                  }
-                "
-              />
+              <ToggleButton v-model:value="enableComment" :label="t.outputComments" />
             </div>
             <div class="form-item">
-              <ToggleButton
-                :label="t.saveRecordAutomatically"
-                :value="enableAutoSave"
-                @change="
-                  (value: boolean) => {
-                    enableAutoSave = value;
-                  }
-                "
-              />
+              <ToggleButton v-model:value="enableAutoSave" :label="t.saveRecordAutomatically" />
             </div>
             <div class="form-item">
-              <ToggleButton
-                :label="t.adjustBoardToHumanPlayer"
-                :value="humanIsFront"
-                @change="
-                  (value: boolean) => {
-                    humanIsFront = value;
-                  }
-                "
-              />
+              <ToggleButton v-model:value="humanIsFront" :label="t.adjustBoardToHumanPlayer" />
             </div>
           </div>
         </div>
@@ -329,13 +295,6 @@ onBeforeUnmount(() => {
   uninstallHotKeyForDialog(dialog.value);
 });
 
-const onUpdateSetDifferentTime = () => {
-  whiteHours.value.disabled = !setDifferentTime.value;
-  whiteMinutes.value.disabled = !setDifferentTime.value;
-  whiteByoyomi.value.disabled = !setDifferentTime.value;
-  whiteIncrement.value.disabled = !setDifferentTime.value;
-};
-
 onUpdated(() => {
   if (!defaultValueLoaded || defaultValueApplied) {
     return;
@@ -362,7 +321,6 @@ onUpdated(() => {
   enableAutoSave.value = gameSettings.value.enableAutoSave;
   humanIsFront.value = gameSettings.value.humanIsFront;
   defaultValueApplied = true;
-  onUpdateSetDifferentTime();
 });
 
 const buildPlayerSettings = (playerURI: string): PlayerSettings => {
@@ -425,13 +383,6 @@ const onCancel = () => {
 
 const onUpdatePlayerSettings = (val: USIEngines) => {
   engines.value = val;
-};
-
-const onSelectBlackPlayer = (uri: string) => {
-  blackPlayerURI.value = uri;
-};
-const onSelectWhitePlayer = (uri: string) => {
-  whitePlayerURI.value = uri;
 };
 
 const onSwapColor = () => {

--- a/src/renderer/view/dialog/LaunchUSIEngineDialog.vue
+++ b/src/renderer/view/dialog/LaunchUSIEngineDialog.vue
@@ -5,12 +5,11 @@
       <div class="form-group">
         <div>{{ t.searchEngine }}</div>
         <PlayerSelector
-          :player-uri="engineURI"
+          v-model:player-uri="engineURI"
           :engines="engines"
           :display-thread-state="true"
           :display-multi-pv-state="true"
           @update-engines="onUpdatePlayerSettings"
-          @select-player="onSelectPlayer"
         />
       </div>
       <div class="form-group warning">
@@ -92,10 +91,6 @@ const onCancel = () => {
 
 const onUpdatePlayerSettings = async (val: USIEngines) => {
   engines.value = val;
-};
-
-const onSelectPlayer = (uri: string) => {
-  engineURI.value = uri;
 };
 </script>
 

--- a/src/renderer/view/dialog/MateSearchDialog.vue
+++ b/src/renderer/view/dialog/MateSearchDialog.vue
@@ -4,7 +4,7 @@
       <div class="title">{{ t.mateSearch }}</div>
       <div class="form-group scroll">
         <PlayerSelector
-          :player-uri="engineURI"
+          v-model:player-uri="engineURI"
           :engines="engines"
           :filter-label="USIEngineLabel.MATE"
           :display-thread-state="true"
@@ -12,11 +12,6 @@
           @update-engines="
             (val: USIEngines) => {
               engines = val;
-            }
-          "
-          @select-player="
-            (uri: string) => {
-              engineURI = uri;
             }
           "
         />

--- a/src/renderer/view/dialog/PlayerSelector.vue
+++ b/src/renderer/view/dialog/PlayerSelector.vue
@@ -1,13 +1,7 @@
 <template>
   <div>
     <div class="root">
-      <select
-        ref="playerSelect"
-        class="player-select"
-        size="1"
-        :value="playerUri"
-        @change="onPlayerChange"
-      >
+      <select ref="playerSelect" v-model="selectedPlayerURI" class="player-select" size="1">
         <option v-if="containsHuman" :value="uri.ES_HUMAN">{{ t.human }}</option>
         <option v-for="engine in filteredEngines.engineList" :key="engine.uri" :value="engine.uri">
           {{ engine.name }}
@@ -73,11 +67,9 @@ import api from "@/renderer/ipc/api";
 import { useErrorStore } from "@/renderer/store/error";
 import { useBusyState } from "@/renderer/store/busy";
 
+const selectedPlayerURI = defineModel<string>("playerUri", { required: true });
+
 const props = defineProps({
-  playerUri: {
-    type: String,
-    required: true,
-  },
   containsHuman: {
     type: Boolean,
     default: false,
@@ -118,7 +110,6 @@ const emit = defineEmits<{
 }>();
 
 const busyState = useBusyState();
-const playerSelect = ref();
 const engineOptionsDialog = ref(null as USIEngine | null);
 
 const filteredEngines = computed(() => {
@@ -126,20 +117,20 @@ const filteredEngines = computed(() => {
 });
 
 const ponderState = computed(() => {
-  if (!uri.isUSIEngine(props.playerUri)) {
+  if (!uri.isUSIEngine(selectedPlayerURI.value)) {
     return null;
   }
-  const engine = filteredEngines.value.getEngine(props.playerUri);
+  const engine = filteredEngines.value.getEngine(selectedPlayerURI.value);
   return engine && getUSIEngineOptionCurrentValue(engine.options[USIPonder]) === "true"
     ? "ON"
     : "OFF";
 });
 
 const threadState = computed(() => {
-  if (!uri.isUSIEngine(props.playerUri)) {
+  if (!uri.isUSIEngine(selectedPlayerURI.value)) {
     return null;
   }
-  const engine = filteredEngines.value.getEngine(props.playerUri);
+  const engine = filteredEngines.value.getEngine(selectedPlayerURI.value);
   if (!engine) {
     return null;
   }
@@ -148,10 +139,10 @@ const threadState = computed(() => {
 });
 
 const multiPVState = computed(() => {
-  if (!uri.isUSIEngine(props.playerUri)) {
+  if (!uri.isUSIEngine(selectedPlayerURI.value)) {
     return null;
   }
-  const engine = filteredEngines.value.getEngine(props.playerUri);
+  const engine = filteredEngines.value.getEngine(selectedPlayerURI.value);
   if (!engine) {
     return null;
   }
@@ -160,12 +151,12 @@ const multiPVState = computed(() => {
 });
 
 const isPlayerSettingsEnabled = computed(() => {
-  return uri.isUSIEngine(props.playerUri);
+  return uri.isUSIEngine(selectedPlayerURI.value);
 });
 
 const openPlayerSettings = () => {
-  if (uri.isUSIEngine(props.playerUri)) {
-    const engine = filteredEngines.value.getEngine(props.playerUri);
+  if (uri.isUSIEngine(selectedPlayerURI.value)) {
+    const engine = filteredEngines.value.getEngine(selectedPlayerURI.value);
     if (!engine) {
       useErrorStore().add("利用可能なエンジンが選択されていません。");
       return;
@@ -191,10 +182,6 @@ const savePlayerSettings = async (settings: USIEngine) => {
 
 const closePlayerSettings = () => {
   engineOptionsDialog.value = null;
-};
-
-const onPlayerChange = () => {
-  emit("selectPlayer", playerSelect.value.value);
 };
 </script>
 

--- a/src/renderer/view/dialog/PositionImageExportDialog.vue
+++ b/src/renderer/view/dialog/PositionImageExportDialog.vue
@@ -54,7 +54,7 @@
                   { value: PositionImageTypeface.GOTHIC, label: t.gothic },
                   { value: PositionImageTypeface.MINCHO, label: t.mincho },
                 ]"
-                @change="changeTypeface"
+                @update:value="changeTypeface"
               />
             </div>
             <div>
@@ -89,7 +89,7 @@
                   { value: PositionImageFontWeight.W400X, label: t.bold },
                   { value: PositionImageFontWeight.W700X, label: t.extraBold },
                 ]"
-                @change="(v) => changeFontWeight(v as PositionImageFontWeight)"
+                @update:value="(v) => changeFontWeight(v as PositionImageFontWeight)"
               />
             </div>
           </div>
@@ -104,7 +104,7 @@
                 { value: PositionImageHandLabelType.TSUME_SHOGI, label: t.tsumeShogi },
                 { value: PositionImageHandLabelType.NONE, label: t.none },
               ]"
-              @change="changeHandLabel"
+              @update:value="changeHandLabel"
             />
           </div>
           <div class="form-item">
@@ -118,7 +118,7 @@
             <ToggleButton
               :value="appSettings.useBookmarkAsPositionImageHeader"
               :label="t.useBookmarkAsHeader"
-              @change="changeWhetherToUseBookmark"
+              @update:value="changeWhetherToUseBookmark"
             />
           </div>
         </div>
@@ -131,7 +131,7 @@
               { value: PositionImageStyle.BOOK, label: t.bookStyle },
               { value: PositionImageStyle.GAME, label: t.gameStyle },
             ]"
-            @change="changeType"
+            @update:value="changeType"
           />
           <input
             class="number"

--- a/src/renderer/view/dialog/ResearchDialog.vue
+++ b/src/renderer/view/dialog/ResearchDialog.vue
@@ -4,32 +4,22 @@
       <div class="title">{{ t.research }}</div>
       <div class="form-group">
         <PlayerSelector
-          :player-uri="engineURI"
+          v-model:player-uri="engineURI"
           :engines="engines"
           :filter-label="USIEngineLabel.RESEARCH"
           :display-thread-state="true"
           :display-multi-pv-state="true"
           @update-engines="onUpdatePlayerSettings"
-          @select-player="
-            (uri: string) => {
-              engineURI = uri;
-            }
-          "
         />
       </div>
-      <div v-for="(uri, index) in secondaryEngineURIs" :key="index" class="form-group">
+      <div v-for="(_, index) in secondaryEngineURIs" :key="index" class="form-group">
         <PlayerSelector
-          :player-uri="uri"
+          v-model:player-uri="secondaryEngineURIs[index]"
           :engines="engines"
           :filter-label="USIEngineLabel.RESEARCH"
           :display-thread-state="true"
           :display-multi-pv-state="true"
           @update-engines="onUpdatePlayerSettings"
-          @select-player="
-            (uri: string) => {
-              secondaryEngineURIs[index] = uri;
-            }
-          "
         />
         <button class="remove-button" @click="secondaryEngineURIs.splice(index, 1)">
           {{ t.remove }}
@@ -41,14 +31,7 @@
       </button>
       <div class="form-group">
         <div class="form-item">
-          <ToggleButton
-            :value="enableMaxSeconds"
-            @change="
-              (value: boolean) => {
-                enableMaxSeconds = value;
-              }
-            "
-          />
+          <ToggleButton v-model:value="enableMaxSeconds" />
           <div class="form-item-small-label">{{ t.toPrefix }}</div>
           <input
             ref="maxSeconds"

--- a/src/renderer/view/dialog/USIEngineManagementDialog.vue
+++ b/src/renderer/view/dialog/USIEngineManagementDialog.vue
@@ -31,19 +31,19 @@
                   :value="!!engine.labels[USIEngineLabel.GAME]"
                   :label="t.game"
                   :height="18"
-                  @change="(value) => changeLabel(engine.uri, USIEngineLabel.GAME, value)"
+                  @update:value="(value) => changeLabel(engine.uri, USIEngineLabel.GAME, value)"
                 />
                 <CheckBox
                   :value="!!engine.labels[USIEngineLabel.RESEARCH]"
                   :label="t.research"
                   :height="18"
-                  @change="(value) => changeLabel(engine.uri, USIEngineLabel.RESEARCH, value)"
+                  @update:value="(value) => changeLabel(engine.uri, USIEngineLabel.RESEARCH, value)"
                 />
                 <CheckBox
                   :value="!!engine.labels[USIEngineLabel.MATE]"
                   :label="t.mateSearch"
                   :height="18"
-                  @change="(value) => changeLabel(engine.uri, USIEngineLabel.MATE, value)"
+                  @update:value="(value) => changeLabel(engine.uri, USIEngineLabel.MATE, value)"
                 />
               </div>
             </div>

--- a/src/renderer/view/dialog/USIEngineMergeDialog.vue
+++ b/src/renderer/view/dialog/USIEngineMergeDialog.vue
@@ -6,18 +6,16 @@
         <div class="select-area row">
           <div class="engine-column">
             <PlayerSelector
-              player-uri=""
+              v-model:player-uri="leftEngineURI"
               :engines="usiEngines"
               :enable-edit-button="false"
-              @select-player="selectLeft"
             />
           </div>
           <div class="engine-column">
             <PlayerSelector
-              player-uri=""
+              v-model:player-uri="rightEngineURI"
               :engines="usiEngines"
               :enable-edit-button="false"
-              @select-player="selectRight"
             />
           </div>
         </div>
@@ -122,14 +120,6 @@ onMounted(async () => {
 onBeforeUnmount(() => {
   uninstallHotKeyForDialog(dialog.value);
 });
-
-const selectLeft = (uri: string) => {
-  leftEngineURI.value = uri;
-};
-
-const selectRight = (uri: string) => {
-  rightEngineURI.value = uri;
-};
 
 const merge = (name: string, srcURI: string, dstURI: string) => {
   const src = usiEngines.getEngine(srcURI);

--- a/src/renderer/view/layout/LayoutManager.vue
+++ b/src/renderer/view/layout/LayoutManager.vue
@@ -41,7 +41,7 @@
             class="color-toggle"
             :value="!!customProfile.backgroundColor"
             :label="t.backgroundColor"
-            @change="
+            @update:value="
               (value) => updateCustomProfileProp('backgroundColor', value ? '#000000' : undefined)
             "
           />
@@ -56,7 +56,7 @@
             class="backdrop-toggle"
             :value="!!customProfile.dialogBackdrop"
             :label="t.dialogBackdrop"
-            @change="(value) => updateCustomProfileProp('dialogBackdrop', value)"
+            @update:value="(value) => updateCustomProfileProp('dialogBackdrop', value)"
           />
         </div>
         <div class="row">
@@ -128,14 +128,18 @@
               <ToggleButton
                 :value="!!component.rightControlBox"
                 :label="t.rightControlBox"
-                @change="(value) => updateCustomProfileComponent(index, 'rightControlBox', value)"
+                @update:value="
+                  (value) => updateCustomProfileComponent(index, 'rightControlBox', value)
+                "
               />
             </span>
             <span class="property">
               <ToggleButton
                 :value="!!component.leftControlBox"
                 :label="t.leftControlBox"
-                @change="(value) => updateCustomProfileComponent(index, 'leftControlBox', value)"
+                @update:value="
+                  (value) => updateCustomProfileComponent(index, 'leftControlBox', value)
+                "
               />
             </span>
             <span>
@@ -146,7 +150,7 @@
                   { label: t.compact, value: BoardLayoutType.COMPACT },
                   { label: t.portrait, value: BoardLayoutType.PORTRAIT },
                 ]"
-                @change="(value) => updateCustomProfileComponent(index, 'layoutType', value)"
+                @update:value="(value) => updateCustomProfileComponent(index, 'layoutType', value)"
               />
             </span>
           </div>
@@ -155,14 +159,16 @@
               <ToggleButton
                 :value="!!component.showCommentColumn"
                 :label="t.comments"
-                @change="(value) => updateCustomProfileComponent(index, 'showCommentColumn', value)"
+                @update:value="
+                  (value) => updateCustomProfileComponent(index, 'showCommentColumn', value)
+                "
               />
             </span>
             <span class="property">
               <ToggleButton
                 :value="!!component.showElapsedTimeColumn"
                 :label="t.elapsedTime"
-                @change="
+                @update:value="
                   (value) => updateCustomProfileComponent(index, 'showElapsedTimeColumn', value)
                 "
               />
@@ -171,14 +177,16 @@
               <ToggleButton
                 :value="!!component.topControlBox"
                 :label="t.topControlBox"
-                @change="(value) => updateCustomProfileComponent(index, 'topControlBox', value)"
+                @update:value="
+                  (value) => updateCustomProfileComponent(index, 'topControlBox', value)
+                "
               />
             </span>
             <span class="property">
               <ToggleButton
                 :value="!!component.branches"
                 :label="t.branches"
-                @change="(value) => updateCustomProfileComponent(index, 'branches', value)"
+                @update:value="(value) => updateCustomProfileComponent(index, 'branches', value)"
               />
             </span>
           </div>
@@ -190,14 +198,14 @@
                   { label: t.rawScore, value: EvaluationChartType.RAW },
                   { label: t.estimatedWinRate, value: EvaluationChartType.WIN_RATE },
                 ]"
-                @change="(value) => updateCustomProfileComponent(index, 'chartType', value)"
+                @update:value="(value) => updateCustomProfileComponent(index, 'chartType', value)"
               />
             </span>
             <span class="property">
               <ToggleButton
                 :value="!!component.showLegend"
                 :label="t.legends"
-                @change="(value) => updateCustomProfileComponent(index, 'showLegend', value)"
+                @update:value="(value) => updateCustomProfileComponent(index, 'showLegend', value)"
               />
             </span>
           </div>
@@ -206,63 +214,75 @@
               <ToggleButton
                 :value="!!component.historyMode"
                 :label="t.historyMode"
-                @change="(value) => updateCustomProfileComponent(index, 'historyMode', value)"
+                @update:value="(value) => updateCustomProfileComponent(index, 'historyMode', value)"
               />
             </span>
             <span class="property">
               <ToggleButton
                 :value="!!component.showHeader"
                 :label="t.headers"
-                @change="(value) => updateCustomProfileComponent(index, 'showHeader', value)"
+                @update:value="(value) => updateCustomProfileComponent(index, 'showHeader', value)"
               />
             </span>
             <span class="property">
               <ToggleButton
                 :value="!!component.showTimeColumn"
                 :label="t.elapsedTime"
-                @change="(value) => updateCustomProfileComponent(index, 'showTimeColumn', value)"
+                @update:value="
+                  (value) => updateCustomProfileComponent(index, 'showTimeColumn', value)
+                "
               />
             </span>
             <span class="property">
               <ToggleButton
                 :value="!!component.showMultiPvColumn"
                 :label="t.rank"
-                @change="(value) => updateCustomProfileComponent(index, 'showMultiPvColumn', value)"
+                @update:value="
+                  (value) => updateCustomProfileComponent(index, 'showMultiPvColumn', value)
+                "
               />
             </span>
             <span class="property">
               <ToggleButton
                 :value="!!component.showDepthColumn"
                 :label="t.depth"
-                @change="(value) => updateCustomProfileComponent(index, 'showDepthColumn', value)"
+                @update:value="
+                  (value) => updateCustomProfileComponent(index, 'showDepthColumn', value)
+                "
               />
             </span>
             <span class="property">
               <ToggleButton
                 :value="!!component.showNodesColumn"
                 :label="t.nodes"
-                @change="(value) => updateCustomProfileComponent(index, 'showNodesColumn', value)"
+                @update:value="
+                  (value) => updateCustomProfileComponent(index, 'showNodesColumn', value)
+                "
               />
             </span>
             <span class="property">
               <ToggleButton
                 :value="!!component.showScoreColumn"
                 :label="t.score"
-                @change="(value) => updateCustomProfileComponent(index, 'showScoreColumn', value)"
+                @update:value="
+                  (value) => updateCustomProfileComponent(index, 'showScoreColumn', value)
+                "
               />
             </span>
             <span class="property">
               <ToggleButton
                 :value="!!component.showPlayButton"
                 :label="t.playButton"
-                @change="(value) => updateCustomProfileComponent(index, 'showPlayButton', value)"
+                @update:value="
+                  (value) => updateCustomProfileComponent(index, 'showPlayButton', value)
+                "
               />
             </span>
             <span class="property">
               <ToggleButton
                 :value="!!component.showSuggestionsCount"
                 :label="t.suggestionsCount"
-                @change="
+                @update:value="
                   (value) => updateCustomProfileComponent(index, 'showSuggestionsCount', value)
                 "
               />
@@ -273,7 +293,9 @@
               <ToggleButton
                 :value="!!component.showBookmark"
                 :label="t.bookmark"
-                @change="(value) => updateCustomProfileComponent(index, 'showBookmark', value)"
+                @update:value="
+                  (value) => updateCustomProfileComponent(index, 'showBookmark', value)
+                "
               />
             </span>
           </div>

--- a/src/renderer/view/main/MobileLayout.vue
+++ b/src/renderer/view/main/MobileLayout.vue
@@ -33,14 +33,9 @@
         />
         <ToggleButton
           v-if="showRecordViewOnBottom"
+          v-model:value="commentEditorMode"
           label="コメント編集モード"
           :height="toggleHeight"
-          :value="commentEditorMode"
-          @change="
-            (value) => {
-              commentEditorMode = value;
-            }
-          "
         />
       </div>
       <div

--- a/src/renderer/view/primitive/CheckBox.vue
+++ b/src/renderer/view/primitive/CheckBox.vue
@@ -2,8 +2,8 @@
   <div style="display: inline-block">
     <div class="container">
       <div class="toggle" :style="toggleStyle">
-        <input :id="id" type="checkbox" :checked="value" @change="onChange" />
-        <div class="box" :style="boxStyle"><span v-if="value">✔</span></div>
+        <input :id="id" v-model="model" type="checkbox" />
+        <div class="box" :style="boxStyle"><span v-if="model">✔</span></div>
       </div>
       <div>
         <label :for="id" :style="labelStyle">{{ label }}</label>
@@ -16,11 +16,9 @@
 import { computed } from "vue";
 import { issueDOMID } from "@/renderer/helpers/unique";
 
+const model = defineModel<boolean>("value", { required: true });
+
 const props = defineProps({
-  value: {
-    type: Boolean,
-    required: true,
-  },
   label: {
     type: String,
     default: "",
@@ -30,10 +28,6 @@ const props = defineProps({
     default: 20,
   },
 });
-
-const emit = defineEmits<{
-  change: [value: boolean];
-}>();
 
 const id = issueDOMID();
 const toggleStyle = computed(() => ({
@@ -47,10 +41,6 @@ const labelStyle = computed(() => ({
   fontSize: `${props.height * 0.7}px`,
   lineHeight: `${props.height}px`,
 }));
-const onChange = (event: Event) => {
-  const input = event.target as HTMLInputElement;
-  emit("change", input.checked);
-};
 </script>
 
 <style scoped>

--- a/src/renderer/view/primitive/HorizontalSelector.vue
+++ b/src/renderer/view/primitive/HorizontalSelector.vue
@@ -7,7 +7,7 @@
           :name="name"
           :checked="item.value === value"
           :value="item.value"
-          @change="emit('change', item.value)"
+          @change="emit('update:value', item.value)"
         />
         <div class="button" :style="buttonStyle">
           <div class="label">{{ item.label }}</div>
@@ -41,7 +41,7 @@ const props = defineProps({
   },
 });
 const emit = defineEmits<{
-  change: [value: string];
+  "update:value": [value: string];
 }>();
 
 const container = ref() as Ref<HTMLDivElement>;
@@ -61,7 +61,7 @@ const setValue = (value: string) => {
   for (const input of container.value.querySelectorAll("input")) {
     if (input.value === value) {
       input.checked = true;
-      emit("change", value);
+      emit("update:value", value);
       break;
     }
   }

--- a/src/renderer/view/primitive/RecordView.vue
+++ b/src/renderer/view/primitive/RecordView.vue
@@ -69,28 +69,20 @@
     </div>
     <div v-if="showBottomControl" class="row wrap options">
       <div v-if="subAreaToggleLabel" class="option">
-        <ToggleButton
-          :label="subAreaToggleLabel"
-          :value="showSubArea"
-          @change="
-            (enabled: boolean) => {
-              showSubArea = enabled;
-            }
-          "
-        />
+        <ToggleButton v-model:value="showSubArea" :label="subAreaToggleLabel" />
       </div>
       <div v-if="elapsedTimeToggleLabel" class="option">
         <ToggleButton
           :label="elapsedTimeToggleLabel"
           :value="showElapsedTime"
-          @change="(enabled: boolean) => emit('toggleShowElapsedTime', enabled)"
+          @update:value="(enabled: boolean) => emit('toggleShowElapsedTime', enabled)"
         />
       </div>
       <div v-if="commentToggleLabel" class="option">
         <ToggleButton
           :label="commentToggleLabel"
           :value="showComment"
-          @change="(enabled: boolean) => emit('toggleShowComment', enabled)"
+          @update:value="(enabled: boolean) => emit('toggleShowComment', enabled)"
         />
       </div>
     </div>

--- a/src/renderer/view/primitive/ToggleButton.vue
+++ b/src/renderer/view/primitive/ToggleButton.vue
@@ -2,7 +2,7 @@
   <div style="display: inline-block">
     <div class="container">
       <div class="toggle" :style="toggleStyle">
-        <input :id="id" type="checkbox" :checked="value" @change="onChange" />
+        <input :id="id" v-model="model" type="checkbox" />
         <div class="slider" :style="sliderStyle"></div>
         <div class="knob" :style="knobStyle"></div>
       </div>
@@ -17,11 +17,9 @@
 import { computed } from "vue";
 import { issueDOMID } from "@/renderer/helpers/unique";
 
+const model = defineModel<boolean>("value", { required: true });
+
 const props = defineProps({
-  value: {
-    type: Boolean,
-    required: true,
-  },
   label: {
     type: String,
     default: "",
@@ -31,10 +29,6 @@ const props = defineProps({
     default: 20,
   },
 });
-
-const emit = defineEmits<{
-  change: [value: boolean];
-}>();
 
 const id = issueDOMID();
 const toggleStyle = computed(() => ({
@@ -52,10 +46,6 @@ const labelStyle = computed(() => ({
   fontSize: `${props.height * 0.7}px`,
   lineHeight: `${props.height}px`,
 }));
-const onChange = (event: Event) => {
-  const input = event.target as HTMLInputElement;
-  emit("change", input.checked);
-};
 </script>
 
 <style scoped>

--- a/src/renderer/view/prompt/CommandHistory.vue
+++ b/src/renderer/view/prompt/CommandHistory.vue
@@ -2,24 +2,8 @@
   <div>
     <div class="root column">
       <div class="tools row">
-        <ToggleButton
-          :value="autoScroll"
-          :label="t.autoScroll"
-          @change="
-            (value) => {
-              autoScroll = value;
-            }
-          "
-        />
-        <ToggleButton
-          :value="showTimestamp"
-          :label="t.showTimestamp"
-          @change="
-            (value) => {
-              showTimestamp = value;
-            }
-          "
-        />
+        <ToggleButton v-model:value="autoScroll" :label="t.autoScroll" />
+        <ToggleButton v-model:value="showTimestamp" :label="t.showTimestamp" />
         <input
           class="search-text"
           type="text"

--- a/src/renderer/view/prompt/CommandInput.vue
+++ b/src/renderer/view/prompt/CommandInput.vue
@@ -3,8 +3,8 @@
     <div class="column">
       <div class="row">
         <HorizontalSelector
+          v-model:value="mode"
           :height="24"
-          :value="mode"
           :items="[
             {
               value: CommandType.SEND,
@@ -15,11 +15,6 @@
             },
             { value: CommandType.RECEIVE, label: `\u25C0 ${t.shogiHome}` },
           ]"
-          @change="
-            (value) => {
-              mode = value as CommandType;
-            }
-          "
         />
         <input
           class="grow"
@@ -42,33 +37,9 @@
         </datalist>
       </div>
       <div class="row settings">
-        <ToggleButton
-          :value="allowBlankLine"
-          :label="t.allowBlankLine"
-          @change="
-            (value) => {
-              allowBlankLine = value;
-            }
-          "
-        />
-        <ToggleButton
-          :value="trim"
-          :label="t.removeSpaceFromBothEnds"
-          @change="
-            (value) => {
-              trim = value;
-            }
-          "
-        />
-        <ToggleButton
-          :value="collapse"
-          :label="t.collapseSequentialSpaces"
-          @change="
-            (value) => {
-              collapse = value;
-            }
-          "
-        />
+        <ToggleButton v-model:value="allowBlankLine" :label="t.allowBlankLine" />
+        <ToggleButton v-model:value="trim" :label="t.removeSpaceFromBothEnds" />
+        <ToggleButton v-model:value="collapse" :label="t.collapseSequentialSpaces" />
       </div>
     </div>
   </div>

--- a/src/renderer/view/tab/RecordInfo.vue
+++ b/src/renderer/view/tab/RecordInfo.vue
@@ -33,7 +33,7 @@
         <ToggleButton
           :value="appSettings.emptyRecordInfoVisibility"
           :label="t.displayEmptyElements"
-          @change="changeEmptyInfoVisibility"
+          @update:value="changeEmptyInfoVisibility"
         />
       </div>
     </div>


### PR DESCRIPTION
# 説明 / Description

`@change` で値を書き戻していた箇所を defineModel と v-model を使った書き方に変更する。
加えて、エンジンオプションの「規定値」のハイライトが編集中もリアルタイムに切り替わるようにする。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Streamlined data binding across dialogs and controls to enhance responsiveness and consistency.
	- Input elements such as toggles, selectors, and password fields now update instantly and intuitively.
	- Improved player and engine selection experiences with simplified interactions.
	- Enhanced event handling by transitioning to `v-model` for more intuitive state management.
	- Overall interface responsiveness and maintainability have been enhanced, ensuring smoother user operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->