### PR TITLE
ダイアログ表示中の暗転を無効にしてもわずかに暗くなる問題の修正

### DIFF
--- a/src/renderer/css/dialog.css
+++ b/src/renderer/css/dialog.css
@@ -13,6 +13,10 @@ dialog {
   background: rgba(0, 0, 0, 0.3);
 }
 
+.dialog-no-backdrop dialog::backdrop {
+  background: rgba(0, 0, 0, 0);
+}
+
 dialog button {
   margin: 0px 5px 0px 5px;
   padding: 5px 15px 5px 15px;


### PR DESCRIPTION
# 説明 / Description

#1111 

dialog backdrop に対する Chromium のデフォルトの色は `rgba(0, 0, 0, 0.1)` なのでわずかに暗くなっていた。
レイアウトマネージャーで無効化した場合には明示的に `rgba(0, 0, 0, 0)` を指定する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an option to display dialogs without a visible backdrop, offering a cleaner, unobstructed dialog presentation while maintaining existing visual styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->