### PR TITLE
読み込み可能な棋譜フォーマットの制限緩和

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "proper-lockfile": "^4.1.2",
         "semver": "^7.7.1",
         "splitpanes": "^3.1.5",
-        "tsshogi": "^1.6.0",
+        "tsshogi": "^1.8.0",
         "vue": "^3.4.34",
         "yaml": "^2.5.0"
       },
@@ -14121,9 +14121,9 @@
       "license": "0BSD"
     },
     "node_modules/tsshogi": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/tsshogi/-/tsshogi-1.6.1.tgz",
-      "integrity": "sha512-xcFEBcwIlUxckWKox+B3DmxWbJ2XJY1Za6A3xboRUMFuYaTNbBAAM54Xif2c1kC4aDkd5gF5VZpAUP+PqeunqQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/tsshogi/-/tsshogi-1.8.0.tgz",
+      "integrity": "sha512-ObIC7NwN9DmHBHYnAqERYYwfHr/E86MDtwg1NZk4LVse4LOSAJphoEmxjr11oZjNqrTq/nCUdFe0eJM1TH58Hw==",
       "license": "MIT"
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "proper-lockfile": "^4.1.2",
     "semver": "^7.7.1",
     "splitpanes": "^3.1.5",
-    "tsshogi": "^1.6.0",
+    "tsshogi": "^1.8.0",
     "vue": "^3.4.34",
     "yaml": "^2.5.0"
   },

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -1153,7 +1153,7 @@ class Store {
     if (this.appState !== AppState.NORMAL) {
       return;
     }
-    const error = this.recordManager.importRecord(data);
+    const error = this.recordManager.importRecord(data.trim());
     if (error) {
       useErrorStore().add(error);
       return;


### PR DESCRIPTION
# 説明 / Description

#1115 

- クリップボードからの読み込み時に先頭と末尾の空白・改行を無視
- 手数の無い SFEN を許容
- USI の末尾の resign を投了として棋譜に反映

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n
