### PR TITLE
Hide showPasteDialog option for web app

### DIFF
--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -1,4 +1,4 @@
-import api from "@/renderer/ipc/api";
+import api, { isNative } from "@/renderer/ipc/api";
 import {
   Color,
   exportCSA,
@@ -328,7 +328,7 @@ class Store {
       return;
     }
     const appSettings = useAppSettings();
-    if (appSettings.showPasteDialog) {
+    if (appSettings.showPasteDialog || !isNative()) {
       this._appState = AppState.PASTE_DIALOG;
     } else {
       navigator.clipboard.readText().then((text) => {

--- a/src/renderer/view/dialog/AppSettingsDialog.vue
+++ b/src/renderer/view/dialog/AppSettingsDialog.vue
@@ -465,7 +465,7 @@
             />
           </div>
           <!-- 貼り付けダイアログを表示 -->
-          <div class="form-item">
+          <div v-if="isNative()" class="form-item">
             <div class="form-item-label-wide">{{ t.pasteDialog }}</div>
             <ToggleButton v-model:value="update.showPasteDialog" />
           </div>

--- a/src/renderer/view/dialog/PasteDialog.vue
+++ b/src/renderer/view/dialog/PasteDialog.vue
@@ -11,7 +11,7 @@
           {{ t.desktopVersionPastesAutomatically }}
         </div>
         <textarea ref="textarea"></textarea>
-        <ToggleButton v-model:value="doNotShowAgain" :label="t.doNotShowAgain" />
+        <ToggleButton v-if="isNative()" v-model:value="doNotShowAgain" :label="t.doNotShowAgain" />
       </div>
       <div class="main-buttons">
         <button data-hotkey="Enter" autofocus @click="onOk">


### PR DESCRIPTION
# 説明 / Description

#1123 

ウェブアプリで貼り付けダイアログは必須なので無効化できないようにする。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Refined paste functionality: the paste dialog now adapts based on your platform. It appears automatically for non-native environments, while native platforms offer a toggle option.
  - Improved settings visibility: display options for the paste dialog adjust seamlessly to match the operating environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->