### PR TITLE
反転した局面を定跡から検索する機能

### DIFF
--- a/src/common/helpers/sfen.ts
+++ b/src/common/helpers/sfen.ts
@@ -1,0 +1,64 @@
+// SFEN の先後を反転させる。
+// 正規化された SFEN にしか使用できない。
+export function flippedSFEN(sfen: string): string {
+  const sections = sfen.split(" ");
+
+  // 盤
+  const board = [] as string[];
+  for (let i = sections[0].length - 1; i >= 0; i--) {
+    let c = sections[0][i];
+    c = c === c.toLowerCase() ? c.toUpperCase() : c.toLowerCase();
+    if (i > 0 && sections[0][i - 1] === "+") {
+      board.push("+");
+      i--;
+    }
+    board.push(c);
+  }
+  sections[0] = board.join("");
+
+  // 手番
+  sections[1] = sections[1] === "b" ? "w" : "b";
+
+  // 持ち駒
+  let blackHandLength = sections[2].length;
+  for (; blackHandLength >= 1; blackHandLength--) {
+    const char = sections[2][blackHandLength - 1];
+    if (char !== char.toLowerCase()) {
+      break;
+    }
+  }
+  sections[2] =
+    sections[2].slice(blackHandLength).toUpperCase() +
+    sections[2].slice(0, blackHandLength).toLowerCase();
+
+  return sections.join(" ");
+}
+
+const usiFlipMap: { [char: string]: string } = {
+  "1": "9",
+  "2": "8",
+  "3": "7",
+  "4": "6",
+  "5": "5",
+  "6": "4",
+  "7": "3",
+  "8": "2",
+  "9": "1",
+  a: "i",
+  b: "h",
+  c: "g",
+  d: "f",
+  e: "e",
+  f: "d",
+  g: "c",
+  h: "b",
+  i: "a",
+};
+
+export function flippedUSIMove(usi: string): string {
+  let flipped = "";
+  for (let i = 0; i < usi.length; i++) {
+    flipped += usiFlipMap[usi[i]] || usi[i];
+  }
+  return flipped;
+}

--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -485,6 +485,7 @@ export const en: Texts = {
   play: "Play",
   edit: "Edit",
   addMoves: "Add Moves",
+  flippedBook: "Flipped Book",
   freq: "Freq.",
   frequency: "Frequency",
   new: "New",

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -485,6 +485,7 @@ export const ja: Texts = {
   play: "着手",
   edit: "編集",
   addMoves: "指し手追加",
+  flippedBook: "反転も検索",
   freq: "出現頻度",
   frequency: "出現頻度",
   new: "新規",

--- a/src/common/i18n/locales/vi.ts
+++ b/src/common/i18n/locales/vi.ts
@@ -485,6 +485,7 @@ export const vi: Texts = {
   play: "Chơi",
   edit: "Sửa",
   addMoves: "Thêm nước đi",
+  flippedBook: "反転も検索", // TODO: Translate
   freq: "Tần suất",
   frequency: "Tần suất xuất hiện",
   new: "Mới",

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -482,6 +482,7 @@ export const zh_tw: Texts = {
   play: "著手",
   edit: "編輯",
   addMoves: "新增該手",
+  flippedBook: "反転も検索", // TODO: Translate
   freq: "出現次數",
   frequency: "出現次數",
   new: "新增",

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -480,6 +480,7 @@ export type Texts = {
   play: string;
   edit: string;
   addMoves: string;
+  flippedBook: string;
   freq: string;
   frequency: string;
   new: string;

--- a/src/common/settings/app.ts
+++ b/src/common/settings/app.ts
@@ -189,6 +189,7 @@ export type AppSettings = {
 
   // Opening Book
   bookOnTheFlyThresholdMB: number;
+  flippedBook: boolean;
 
   // Engine
   translateEngineOptionName: boolean;
@@ -332,6 +333,7 @@ export function defaultAppSettings(opt?: {
     enableUSIFileResign: false,
     showPasteDialog: true,
     bookOnTheFlyThresholdMB: 256,
+    flippedBook: true,
     translateEngineOptionName: true,
     engineTimeoutSeconds: 10,
     evaluationViewFrom: EvaluationViewFrom.EACH,

--- a/src/renderer/store/settings.ts
+++ b/src/renderer/store/settings.ts
@@ -171,6 +171,9 @@ class AppSettingsStore {
   get bookOnTheFlyThresholdMB(): number {
     return this.merged.bookOnTheFlyThresholdMB;
   }
+  get flippedBook(): boolean {
+    return this.merged.flippedBook;
+  }
   get translateEngineOptionName(): boolean {
     return this.merged.translateEngineOptionName;
   }

--- a/src/renderer/view/main/BookPanel.vue
+++ b/src/renderer/view/main/BookPanel.vue
@@ -17,6 +17,11 @@
         <button @click="onOpenBook">{{ t.open }}</button>
         <button :disabled="!isBookOperational" @click="onSaveBook">{{ t.saveAs }}</button>
         <button :disabled="!isBookOperational" @click="onAddBookMoves">{{ t.addMoves }}</button>
+        <ToggleButton
+          :value="appSettings.flippedBook"
+          :label="t.flippedBook"
+          @update:value="onUpdateFlippedBook"
+        />
       </div>
       <BookMoveDialog
         v-if="editingData"
@@ -45,9 +50,12 @@ import { t } from "@/common/i18n";
 import { useConfirmationStore } from "@/renderer/store/confirm";
 import BookView from "@/renderer/view/primitive/BookView.vue";
 import { useErrorStore } from "@/renderer/store/error";
+import ToggleButton from "@/renderer/view/primitive/ToggleButton.vue";
+import { useAppSettings } from "@/renderer/store/settings";
 
 const store = useStore();
 const bookStore = useBookStore();
+const appSettings = useAppSettings();
 
 const isBookOperational = computed(
   () => store.appState === AppState.NORMAL && bookStore.mode === "in-memory",
@@ -74,6 +82,12 @@ const onSaveBook = () => {
 
 const onAddBookMoves = () => {
   store.showAddBookMovesDialog();
+};
+
+const onUpdateFlippedBook = (value: boolean) => {
+  appSettings.updateAppSettings({ flippedBook: value }).then(() => {
+    bookStore.reloadBookMoves();
+  });
 };
 
 const playBookMove = (move: Move) => {
@@ -141,6 +155,9 @@ const onCancelEditBookMove = () => {
 }
 .control > button:not(:first-child) {
   margin-left: 2px;
+}
+.control > :not(:first-child) {
+  margin-left: 8px;
 }
 .book-list {
   height: calc(100% - 27px);

--- a/src/tests/common/helpers/sfen.spec.ts
+++ b/src/tests/common/helpers/sfen.spec.ts
@@ -1,0 +1,36 @@
+import { flippedSFEN, flippedUSIMove } from "@/common/helpers/sfen";
+
+describe("helpers/sfen", () => {
+  it("flippedSFEN", () => {
+    const testCases = [
+      {
+        sfen1: "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1",
+        sfen2: "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL w - 1",
+      },
+      {
+        sfen1: "l8/2+P3s1R/b3g1kp1/p2p2psp/2nPSp3/PPP2LP1P/K3P4/2GSG4/LN4+b1L w G2Pr2n2p 114",
+        sfen2: "l1+B4nl/4gsg2/4p3k/p1pl2ppp/3PspN2/PSP2P2P/1PK1G3B/r1S3+p2/8L b R2N2Pg2p 114",
+      },
+      {
+        sfen1: "6+Pn1/6gk1/6gp1/9/9/6b1P/9/9/9 b 2R2Gb4s3n4l15p 1",
+        sfen2: "9/9/9/p1B6/9/9/1PG6/1KG6/1N+p6 w B4S3N4L15P2r2g 1",
+      },
+    ];
+    for (const { sfen1, sfen2 } of testCases) {
+      expect(flippedSFEN(sfen1)).toBe(sfen2);
+      expect(flippedSFEN(sfen2)).toBe(sfen1);
+    }
+  });
+
+  it("flippedUSIMove", () => {
+    const testCases = [
+      { usi1: "7g7f", usi2: "3c3d" },
+      { usi1: "8h2b+", usi2: "2b8h+" },
+      { usi1: "L*3i", usi2: "L*7a" },
+    ];
+    for (const { usi1, usi2 } of testCases) {
+      expect(flippedUSIMove(usi1)).toBe(usi2);
+      expect(flippedUSIMove(usi2)).toBe(usi1);
+    }
+  });
+});

--- a/src/tests/renderer/store/book.spec.ts
+++ b/src/tests/renderer/store/book.spec.ts
@@ -1,0 +1,75 @@
+import api, { API } from "@/renderer/ipc/api";
+import { defaultAppSettings } from "@/common/settings/app";
+import { BookStore } from "@/renderer/store/book";
+import { useAppSettings } from "@/renderer/store/settings";
+import { Record } from "tsshogi";
+import { Mocked } from "vitest";
+
+vi.mock("@/renderer/ipc/api");
+
+const mockAPI = api as Mocked<API>;
+
+describe("store/book", () => {
+  afterEach(async () => {
+    vi.clearAllMocks();
+    await useAppSettings().updateAppSettings(defaultAppSettings());
+  });
+
+  describe("searchMoves", () => {
+    const sfen = "lr5nl/3g1kg2/2n1p1sp1/p1ppspp1p/1p3P1P1/P1PPS1P1P/1PS1P1N2/2GK1G3/LN5RL w Bb 1";
+    const sfen_r = "lr5nl/3g1kg2/2n1p1sp1/p1p1spp1p/1p1p3P1/P1PPSPP1P/1PS1P1N2/2GK1G3/LN5RL b Bb 1";
+
+    it("match", async () => {
+      await useAppSettings().updateAppSettings({
+        flippedBook: true,
+      });
+      mockAPI.searchBookMoves.mockResolvedValue([
+        { usi: "8a4a", comment: "foo" },
+        { usi: "4d4e", comment: "bar" },
+      ]);
+      const record = new Record();
+      const store = new BookStore(record);
+      const moves = store.searchMoves(sfen);
+      await expect(moves).resolves.toEqual([
+        { usi: "8a4a", comment: "foo" },
+        { usi: "4d4e", comment: "bar" },
+      ]);
+      expect(mockAPI.searchBookMoves).toHaveBeenCalledTimes(1);
+      expect(mockAPI.searchBookMoves).toHaveBeenNthCalledWith(1, sfen);
+    });
+
+    it("match/flipped", async () => {
+      await useAppSettings().updateAppSettings({
+        flippedBook: true,
+      });
+      mockAPI.searchBookMoves.mockResolvedValueOnce([]);
+      mockAPI.searchBookMoves.mockResolvedValueOnce([
+        { usi: "8a4a", comment: "foo" },
+        { usi: "4d4e", comment: "bar" },
+      ]);
+      const record = new Record();
+      const store = new BookStore(record);
+      const moves = store.searchMoves(sfen_r);
+      await expect(moves).resolves.toEqual([
+        { usi: "2i6i", comment: "foo" },
+        { usi: "6f6e", comment: "bar" },
+      ]);
+      expect(mockAPI.searchBookMoves).toHaveBeenCalledTimes(2);
+      expect(mockAPI.searchBookMoves).toHaveBeenNthCalledWith(1, sfen_r);
+      expect(mockAPI.searchBookMoves).toHaveBeenNthCalledWith(2, sfen);
+    });
+
+    it("no match", async () => {
+      await useAppSettings().updateAppSettings({
+        flippedBook: false,
+      });
+      mockAPI.searchBookMoves.mockResolvedValue([]);
+      const record = new Record();
+      const store = new BookStore(record);
+      const moves = store.searchMoves(sfen);
+      await expect(moves).resolves.toEqual([]);
+      expect(mockAPI.searchBookMoves).toHaveBeenCalledTimes(1);
+      expect(mockAPI.searchBookMoves).toHaveBeenNthCalledWith(1, sfen);
+    });
+  });
+});

--- a/src/tests/renderer/store/index.spec.ts
+++ b/src/tests/renderer/store/index.spec.ts
@@ -127,14 +127,14 @@ describe("store/index", () => {
     mockMateSearchManager.prototype.on.mockReturnThis();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     vi.useRealTimers();
     vi.clearAllMocks();
     while (useMessageStore().hasMessage) {
       useMessageStore().dequeue();
     }
     useErrorStore().clear();
-    useAppSettings().updateAppSettings(defaultAppSettings());
+    await useAppSettings().updateAppSettings(defaultAppSettings());
   });
 
   it("updateUSIInfo", () => {


### PR DESCRIPTION
# 説明 / Description

#1132 

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated
  - [x] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new board and move transformation that inverts piece configuration and notation.
	- Added a configuration option to control automatic flipping for opening moves.
	- Implemented an intuitive toggle in the user interface for enabling or disabling the flip setting.
	- Expanded localization options for the flipped book feature in English, Japanese, Vietnamese, and Traditional Chinese.
- **Tests**
	- Added automated tests to ensure the transformation functions perform as expected.
	- Enhanced test coverage for the book moves retrieval functionality, including scenarios for flipped settings and no available moves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->