### PR TITLE
Disable the auto-save feature by default on the web app

### DIFF
--- a/src/renderer/ipc/web.ts
+++ b/src/renderer/ipc/web.ts
@@ -105,7 +105,10 @@ export const webAPI: Bridge = {
   async loadGameSettings(): Promise<string> {
     const json = localStorage.getItem(STORAGE_KEY.GAME_SETTINGS);
     if (!json) {
-      return JSON.stringify(defaultGameSettings());
+      return JSON.stringify({
+        ...defaultGameSettings(),
+        enableAutoSave: false,
+      });
     }
     return JSON.stringify({
       ...defaultGameSettings(),


### PR DESCRIPTION
# 説明 / Description

#1140 

ブラウザ版では、棋譜の自動保存のでデフォルト値を false に設定する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the default game configuration so that auto-save is now disabled by default when no saved settings are found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->