### PR TITLE
定跡手追加時に対局者名でフィルターすると記名無しの指し手が入る問題を修正

### DIFF
--- a/src/background/book/index.ts
+++ b/src/background/book/index.ts
@@ -377,10 +377,16 @@ export async function importBookMoves(
         if (!settings.playerName) {
           throw new Error("player name is not set");
         }
-        if (blackPlayerName?.indexOf(settings.playerName.toLowerCase()) === -1) {
+        if (
+          !blackPlayerName ||
+          blackPlayerName?.indexOf(settings.playerName.toLowerCase()) === -1
+        ) {
           targetColorSet[Color.BLACK] = false;
         }
-        if (whitePlayerName?.indexOf(settings.playerName.toLowerCase()) === -1) {
+        if (
+          !whitePlayerName ||
+          whitePlayerName?.indexOf(settings.playerName.toLowerCase()) === -1
+        ) {
           targetColorSet[Color.WHITE] = false;
         }
         break;

--- a/src/tests/background/book/index.spec.ts
+++ b/src/tests/background/book/index.spec.ts
@@ -340,13 +340,16 @@ sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1
           sourceDirectory: "src/tests/testdata/book/source",
         },
         summary: {
-          successFileCount: 3,
+          successFileCount: 4,
           errorFileCount: 0,
-          entryCount: 28,
+          entryCount: 34,
           duplicateCount: 2,
         },
-        includedSFEN: "ln1gk1snl/1rs3gb1/p1ppppppp/9/1p5P1/P8/1PPPPPP1P/1BG3SR1/LNS1KG1NL w - 1",
-        missedSFEN: "ln1gk1snl/1rs3gb1/2ppppppp/p8/1p5P1/P8/1PPPPPP1P/1BG3SR1/LNS1KG1NL b - 1",
+        includedSFEN: [
+          "ln1gk1snl/1rs3gb1/p1ppppppp/9/1p5P1/P8/1PPPPPP1P/1BG3SR1/LNS1KG1NL w - 1",
+          "lnsgkgsnl/1r5b1/p1pppp1pp/1p4p2/9/2P1P4/PP1P1PPPP/1B2R4/LNSGKGSNL w - 1",
+        ],
+        missedSFEN: ["ln1gk1snl/1rs3gb1/2ppppppp/p8/1p5P1/P8/1PPPPPP1P/1BG3SR1/LNS1KG1NL b - 1"],
       },
       {
         title: "directory with ply",
@@ -357,13 +360,16 @@ sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1
           maxPly: 5,
         },
         summary: {
-          successFileCount: 3,
+          successFileCount: 4,
           errorFileCount: 0,
-          entryCount: 11,
+          entryCount: 15,
           duplicateCount: 1,
         },
-        includedSFEN: "lnsgkgsnl/1r5b1/p1ppppppp/9/1p5P1/9/PPPPPPP1P/1B5R1/LNSGKGSNL b - 1",
-        missedSFEN: "lnsgkgsnl/1r5b1/p1ppppppp/9/1p5P1/9/PPPPPPP1P/1BG4R1/LNS1KGSNL w - 1",
+        includedSFEN: ["lnsgkgsnl/1r5b1/p1ppppppp/9/1p5P1/9/PPPPPPP1P/1B5R1/LNSGKGSNL b - 1"],
+        missedSFEN: [
+          "lnsgkgsnl/1r5b1/p1ppppppp/9/1p5P1/9/PPPPPPP1P/1BG4R1/LNS1KGSNL w - 1",
+          "lnsgkgsnl/1r5b1/p1pppp1pp/1p4p2/9/2P1P4/PP1P1PPPP/1B2R4/LNSGKGSNL w - 1",
+        ],
       },
       {
         title: "directory with player name",
@@ -374,13 +380,16 @@ sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1
           playerName: "藤井",
         },
         summary: {
-          successFileCount: 3,
+          successFileCount: 4,
           errorFileCount: 0,
           entryCount: 10,
           duplicateCount: 0,
         },
-        includedSFEN: "lnsgkgsnl/1r5b1/p1ppppppp/9/1p5P1/9/PPPPPPP1P/1BG4R1/LNS1KGSNL w - 1",
-        missedSFEN: "lnsgkgsnl/1r5b1/p1ppppppp/9/1p5P1/9/PPPPPPP1P/1B5R1/LNSGKGSNL b - 1",
+        includedSFEN: ["lnsgkgsnl/1r5b1/p1ppppppp/9/1p5P1/9/PPPPPPP1P/1BG4R1/LNS1KGSNL w - 1"],
+        missedSFEN: [
+          "lnsgkgsnl/1r5b1/p1ppppppp/9/1p5P1/9/PPPPPPP1P/1B5R1/LNSGKGSNL b - 1",
+          "lnsgkgsnl/1r5b1/p1pppp1pp/1p4p2/9/2P1P4/PP1P1PPPP/1B2R4/LNSGKGSNL w - 1",
+        ],
       },
       {
         title: "single file",
@@ -394,8 +403,8 @@ sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1
           entryCount: 10,
           duplicateCount: 0,
         },
-        includedSFEN: "lnsgkgsnl/1r5b1/p1pppp1pp/6p2/1p7/2P4P1/PPBPPPP1P/7R1/LNSGKGSNL b - 1",
-        missedSFEN: "lnsgk1snl/1r4gb1/p1ppppppp/9/1p5P1/9/PPPPPPP1P/1BG4R1/LNS1KGSNL b - 1",
+        includedSFEN: ["lnsgkgsnl/1r5b1/p1pppp1pp/6p2/1p7/2P4P1/PPBPPPP1P/7R1/LNSGKGSNL b - 1"],
+        missedSFEN: ["lnsgk1snl/1r4gb1/p1ppppppp/9/1p5P1/9/PPPPPPP1P/1BG4R1/LNS1KGSNL b - 1"],
       },
       {
         title: "single file black",
@@ -410,8 +419,8 @@ sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1
           entryCount: 5,
           duplicateCount: 0,
         },
-        includedSFEN: "lnsgkgsnl/1r5b1/p1pppp1pp/6p2/1p7/2P4P1/PPBPPPP1P/7R1/LNSGKGSNL b - 1",
-        missedSFEN: "lnsgkgsnl/1r5b1/p1pppp1pp/6p2/1p7/2P4P1/PPBPPPP1P/1S5R1/LN1GKGSNL w - 1",
+        includedSFEN: ["lnsgkgsnl/1r5b1/p1pppp1pp/6p2/1p7/2P4P1/PPBPPPP1P/7R1/LNSGKGSNL b - 1"],
+        missedSFEN: ["lnsgkgsnl/1r5b1/p1pppp1pp/6p2/1p7/2P4P1/PPBPPPP1P/1S5R1/LN1GKGSNL w - 1"],
       },
       {
         title: "single file white",
@@ -426,19 +435,23 @@ sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1
           entryCount: 5,
           duplicateCount: 0,
         },
-        includedSFEN: "lnsgkgsnl/1r5b1/p1pppp1pp/6p2/1p7/2P4P1/PPBPPPP1P/1S5R1/LN1GKGSNL w - 1",
-        missedSFEN: "lnsgkgsnl/1r5b1/p1pppp1pp/6p2/1p7/2P4P1/PPBPPPP1P/7R1/LNSGKGSNL b - 1",
+        includedSFEN: ["lnsgkgsnl/1r5b1/p1pppp1pp/6p2/1p7/2P4P1/PPBPPPP1P/1S5R1/LN1GKGSNL w - 1"],
+        missedSFEN: ["lnsgkgsnl/1r5b1/p1pppp1pp/6p2/1p7/2P4P1/PPBPPPP1P/7R1/LNSGKGSNL b - 1"],
       },
     ];
     for (const pattern of patterns) {
-      it("directory", async () => {
+      it(pattern.title, async () => {
         const summary = await importBookMoves({
           ...defaultBookImportSettings(),
           ...pattern.settings,
         });
         expect(summary).toEqual(pattern.summary);
-        expect((await searchBookMoves(pattern.includedSFEN)).length).not.toBe(0);
-        expect((await searchBookMoves(pattern.missedSFEN)).length).toBe(0);
+        for (const sfen of pattern.includedSFEN) {
+          expect((await searchBookMoves(sfen)).length).not.toBe(0);
+        }
+        for (const sfen of pattern.missedSFEN) {
+          expect((await searchBookMoves(sfen)).length).toBe(0);
+        }
       });
     }
   });

--- a/src/tests/testdata/book/source/src04.csa
+++ b/src/tests/testdata/book/source/src04.csa
@@ -1,0 +1,10 @@
+V2.2
+'no player names
+PI
++
++5756FU
+-3334FU
++2858HI
+-8384FU
++7776FU
+-7162GI


### PR DESCRIPTION
# 説明 / Description

棋譜ファイルから指し手を抽出して定跡を追加する場合に、対局者名の部分一致でフィルターできる。
しかし、棋譜に対局者名が書かれていない場合にフィルターをパスしてしまっていた。
対局者名を指定した場合には、対局者名が無いものを含めないように修正する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of missing player information for more reliable game move processing.

- **Tests**
  - Enhanced test scenarios and added new test data to ensure robust validation of game move processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->