### PR TITLE
Refactoring

### DIFF
--- a/src/renderer/view/dialog/AppSettingsDialog.vue
+++ b/src/renderer/view/dialog/AppSettingsDialog.vue
@@ -216,7 +216,7 @@
           <div v-if="!isMobileWebApp()" class="form-item">
             <div class="form-item-label-wide">{{ t.boardOpacity }}</div>
             <input
-              v-model="update.boardOpacity"
+              v-model.number="update.boardOpacity"
               :readonly="!update.enableTransparent"
               type="number"
               max="100"
@@ -228,7 +228,7 @@
           <div v-if="!isMobileWebApp()" class="form-item">
             <div class="form-item-label-wide">{{ t.pieceStandOpacity }}</div>
             <input
-              v-model="update.pieceStandOpacity"
+              v-model.number="update.pieceStandOpacity"
               :readonly="!update.enableTransparent"
               type="number"
               max="100"
@@ -240,7 +240,7 @@
           <div v-if="!isMobileWebApp()" class="form-item">
             <div class="form-item-label-wide">{{ t.recordOpacity }}</div>
             <input
-              v-model="update.recordOpacity"
+              v-model.number="update.recordOpacity"
               :readonly="!update.enableTransparent"
               type="number"
               max="100"
@@ -401,12 +401,7 @@
             <div class="form-item-label-wide">
               {{ t.autoSavingDirectory }}
             </div>
-            <input
-              ref="autoSaveDirectory"
-              v-model="update.autoSaveDirectory"
-              class="file-path"
-              type="text"
-            />
+            <input v-model="update.autoSaveDirectory" class="file-path" type="text" />
             <button class="thin" @click="selectAutoSaveDirectory">
               {{ t.select }}
             </button>
@@ -795,7 +790,6 @@ const update = ref({
   logLevel: org.logLevel,
   enableHardwareAcceleration: org.enableHardwareAcceleration,
 });
-const autoSaveDirectory = ref();
 const dialog = ref();
 const versionStatus = ref({} as VersionStatus);
 
@@ -852,9 +846,9 @@ const saveAndClose = async () => {
 const selectAutoSaveDirectory = async () => {
   busyState.retain();
   try {
-    const path = await api.showSelectDirectoryDialog(autoSaveDirectory.value.value);
+    const path = await api.showSelectDirectoryDialog(update.value.autoSaveDirectory);
     if (path) {
-      autoSaveDirectory.value.value = update.value.autoSaveDirectory = path;
+      update.value.autoSaveDirectory = path;
     }
   } catch (e) {
     useErrorStore().add(e);
@@ -864,7 +858,7 @@ const selectAutoSaveDirectory = async () => {
 };
 
 const onOpenAutoSaveDirectory = () => {
-  api.openExplorer(autoSaveDirectory.value.value);
+  api.openExplorer(update.value.autoSaveDirectory);
 };
 
 const howToWriteFileNameTemplate = () => {

--- a/src/renderer/view/dialog/BookMoveDialog.vue
+++ b/src/renderer/view/dialog/BookMoveDialog.vue
@@ -10,11 +10,10 @@
         <div class="form-item">
           <div class="form-item-label">{{ t.evaluation }}</div>
           <input
-            ref="scoreInput"
+            v-model.number="scoreValue"
             :min="-32767"
             :max="32767"
             type="number"
-            :value="score || 0"
             :readonly="!enableScore"
           />
           <ToggleButton v-model:value="enableScore" />
@@ -22,11 +21,10 @@
         <div class="form-item">
           <div class="form-item-label">{{ t.depth }}</div>
           <input
-            ref="depthInput"
+            v-model.number="depthValue"
             :min="0"
             :max="127"
             type="number"
-            :value="depth || 0"
             :readonly="!enableDepth"
           />
           <ToggleButton v-model:value="enableDepth" />
@@ -34,18 +32,17 @@
         <div class="form-item">
           <div class="form-item-label">{{ t.frequency }}</div>
           <input
-            ref="countInput"
+            v-model.number="countValue"
             :min="0"
             :max="2147483647"
             type="number"
-            :value="count || 0"
             :readonly="!enableCount"
           />
           <ToggleButton v-model:value="enableCount" />
         </div>
         <div class="form-item">
           <div class="form-item-label">{{ t.comments }}</div>
-          <textarea ref="commentInput" :value="comment" />
+          <textarea v-model="commentValue" />
         </div>
       </div>
       <div class="main-buttons">
@@ -73,7 +70,6 @@ export type Result = {
 import { t } from "@/common/i18n";
 import { installHotKeyForDialog, uninstallHotKeyForDialog } from "@/renderer/devices/hotkey";
 import { showModalDialog } from "@/renderer/helpers/dialog";
-import { readInputAsNumber } from "@/renderer/helpers/form";
 import { onBeforeUnmount, onMounted, ref } from "vue";
 import ToggleButton from "@/renderer/view/primitive/ToggleButton.vue";
 
@@ -91,10 +87,10 @@ const emits = defineEmits<{
 }>();
 
 const dialog = ref();
-const scoreInput = ref();
-const depthInput = ref();
-const countInput = ref();
-const commentInput = ref();
+const scoreValue = ref(props.score || 0);
+const depthValue = ref(props.depth || 0);
+const countValue = ref(props.count || 0);
+const commentValue = ref(props.comment || "");
 const enableScore = ref(props.score !== undefined);
 const enableDepth = ref(props.depth !== undefined);
 const enableCount = ref(props.count !== undefined);
@@ -110,10 +106,10 @@ onBeforeUnmount(() => {
 
 const onOk = () => {
   emits("ok", {
-    score: enableScore.value ? readInputAsNumber(scoreInput.value) : undefined,
-    depth: enableDepth.value ? readInputAsNumber(depthInput.value) : undefined,
-    count: enableCount.value ? readInputAsNumber(countInput.value) : undefined,
-    comment: commentInput.value.value,
+    score: enableScore.value ? scoreValue.value : undefined,
+    depth: enableDepth.value ? depthValue.value : undefined,
+    count: enableCount.value ? countValue.value : undefined,
+    comment: commentValue.value,
   });
 };
 

--- a/src/renderer/view/dialog/GameDialog.vue
+++ b/src/renderer/view/dialog/GameDialog.vue
@@ -38,30 +38,54 @@
           <div class="half-column">
             <div class="form-item">
               <div class="form-item-label">{{ t.allottedTime }}</div>
-              <input ref="hours" class="time" type="number" min="0" max="99" step="1" />
+              <input v-model.number="hours" class="time" type="number" min="0" max="99" step="1" />
               <div class="form-item-small-label">{{ t.hoursSuffix }}</div>
-              <input ref="minutes" class="time" type="number" min="0" max="59" step="1" />
+              <input
+                v-model.number="minutes"
+                class="time"
+                type="number"
+                min="0"
+                max="59"
+                step="1"
+              />
               <div class="form-item-small-label">{{ t.minutesSuffix }}</div>
             </div>
             <div class="form-item">
               <div class="form-item-label">{{ t.byoyomi }}</div>
-              <input ref="byoyomi" class="time" type="number" min="0" max="60" step="1" />
+              <input
+                v-model.number="byoyomi"
+                class="time"
+                type="number"
+                min="0"
+                max="60"
+                step="1"
+              />
               <div class="form-item-small-label">{{ t.secondsSuffix }}</div>
             </div>
             <div class="form-item">
               <div class="form-item-label">{{ t.increments }}</div>
-              <input ref="increment" class="time" type="number" min="0" max="99" step="1" />
+              <input
+                v-model.number="increment"
+                class="time"
+                type="number"
+                min="0"
+                max="99"
+                step="1"
+              />
               <div class="form-item-small-label">{{ t.secondsSuffix }}</div>
             </div>
             <div class="form-item">
-              <ToggleButton v-model:value="enableEngineTimeout" :label="t.enableEngineTimeout" />
+              <ToggleButton
+                v-model:value="gameSettings.enableEngineTimeout"
+                :label="t.enableEngineTimeout"
+              />
             </div>
           </div>
           <div class="half-column">
             <div class="form-item">
               <div class="form-item-label">{{ t.allottedTime }}</div>
               <input
-                ref="whiteHours"
+                v-model.number="whiteHours"
                 class="time"
                 type="number"
                 min="0"
@@ -71,7 +95,7 @@
               />
               <div class="form-item-small-label">{{ t.hoursSuffix }}</div>
               <input
-                ref="whiteMinutes"
+                v-model.number="whiteMinutes"
                 class="time"
                 type="number"
                 min="0"
@@ -84,7 +108,7 @@
             <div class="form-item">
               <div class="form-item-label">{{ t.byoyomi }}</div>
               <input
-                ref="whiteByoyomi"
+                v-model.number="whiteByoyomi"
                 class="time"
                 type="number"
                 min="0"
@@ -97,7 +121,7 @@
             <div class="form-item">
               <div class="form-item-label">{{ t.increments }}</div>
               <input
-                ref="whiteIncrement"
+                v-model.number="whiteIncrement"
                 class="time"
                 type="number"
                 min="0"
@@ -124,7 +148,7 @@
           <div class="half-column">
             <div class="form-item">
               <div class="form-item-label">{{ t.startPosition }}</div>
-              <select v-model="startPosition">
+              <select v-model="gameSettings.startPosition">
                 <option value="current">{{ t.currentPosition }}</option>
                 <option value="list">{{ t.positionList }}</option>
                 <option :value="InitialPositionType.STANDARD">
@@ -162,24 +186,28 @@
                 </option>
               </select>
             </div>
-            <div v-show="startPosition === 'list'" class="form-item">
-              <input ref="startPositionListFile" type="text" placeholder="*.sfen" />
+            <div v-show="gameSettings.startPosition === 'list'" class="form-item">
+              <input
+                v-model="gameSettings.startPositionListFile"
+                type="text"
+                placeholder="*.sfen"
+              />
               <button class="thin" @click="onSelectStartPositionListFile">{{ t.select }}</button>
             </div>
-            <div v-show="startPosition === 'list'" class="form-item">
+            <div v-show="gameSettings.startPosition === 'list'" class="form-item">
               <ToggleButton v-model:value="startPositionListShuffle" :label="t.shuffle" />
             </div>
             <div class="form-item">
               <div class="form-item-label">{{ t.maxMoves }}</div>
-              <input ref="maxMoves" class="number" type="number" min="1" />
+              <input v-model.number="gameSettings.maxMoves" class="number" type="number" min="1" />
             </div>
             <div class="form-item">
               <div class="form-item-label">{{ t.gameRepetition }}</div>
-              <input ref="repeat" class="number" type="number" min="1" />
+              <input v-model.number="gameSettings.repeat" class="number" type="number" min="1" />
             </div>
             <div class="form-item">
               <div class="form-item-label">{{ t.jishogi }}</div>
-              <select ref="jishogiRule">
+              <select v-model="gameSettings.jishogiRule">
                 <option :value="JishogiRule.NONE">{{ t.none }}</option>
                 <option :value="JishogiRule.GENERAL24">{{ t.rule24 }}</option>
                 <option :value="JishogiRule.GENERAL27">{{ t.rule27 }}</option>
@@ -189,16 +217,25 @@
           </div>
           <div class="half-column">
             <div class="form-item">
-              <ToggleButton v-model:value="swapPlayers" :label="t.swapTurnWhenGameRepetition" />
+              <ToggleButton
+                v-model:value="gameSettings.swapPlayers"
+                :label="t.swapTurnWhenGameRepetition"
+              />
             </div>
             <div class="form-item">
-              <ToggleButton v-model:value="enableComment" :label="t.outputComments" />
+              <ToggleButton v-model:value="gameSettings.enableComment" :label="t.outputComments" />
             </div>
             <div class="form-item">
-              <ToggleButton v-model:value="enableAutoSave" :label="t.saveRecordAutomatically" />
+              <ToggleButton
+                v-model:value="gameSettings.enableAutoSave"
+                :label="t.saveRecordAutomatically"
+              />
             </div>
             <div class="form-item">
-              <ToggleButton v-model:value="humanIsFront" :label="t.adjustBoardToHumanPlayer" />
+              <ToggleButton
+                v-model:value="gameSettings.humanIsFront"
+                :label="t.adjustBoardToHumanPlayer"
+              />
             </div>
           </div>
         </div>
@@ -218,20 +255,18 @@
 <script setup lang="ts">
 import { t } from "@/common/i18n";
 import { USIEngineLabel, USIEngine, USIEngines } from "@/common/settings/usi";
-import { ref, onMounted, onUpdated, onBeforeUnmount } from "vue";
+import { ref, onMounted, onBeforeUnmount } from "vue";
 import api, { isNative } from "@/renderer/ipc/api";
 import { useStore } from "@/renderer/store";
 import {
   defaultGameSettings,
   GameSettings,
-  GameStartPositionType,
   JishogiRule,
   validateGameSettings,
   validateGameSettingsForWeb,
 } from "@/common/settings/game";
 import { showModalDialog } from "@/renderer/helpers/dialog.js";
 import * as uri from "@/common/uri.js";
-import { readInputAsNumber } from "@/renderer/helpers/form.js";
 import { IconType } from "@/renderer/assets/icons";
 import Icon from "@/renderer/view/primitive/Icon.vue";
 import PlayerSelector from "@/renderer/view/dialog/PlayerSelector.vue";
@@ -245,33 +280,21 @@ import { useBusyState } from "@/renderer/store/busy";
 const store = useStore();
 const busyState = useBusyState();
 const dialog = ref();
-const hours = ref();
-const minutes = ref();
-const byoyomi = ref();
-const increment = ref();
-const enableEngineTimeout = ref(false);
-const whiteHours = ref();
-const whiteMinutes = ref();
-const whiteByoyomi = ref();
-const whiteIncrement = ref();
+const hours = ref(0);
+const minutes = ref(0);
+const byoyomi = ref(0);
+const increment = ref(0);
+const whiteHours = ref(0);
+const whiteMinutes = ref(0);
+const whiteByoyomi = ref(0);
+const whiteIncrement = ref(0);
 const setDifferentTime = ref(false);
-const startPosition = ref<GameStartPositionType>(InitialPositionType.STANDARD);
-const startPositionListFile = ref();
 const startPositionListShuffle = ref(false);
-const maxMoves = ref();
-const repeat = ref();
-const jishogiRule = ref();
-const swapPlayers = ref(false);
-const enableComment = ref(false);
-const enableAutoSave = ref(false);
-const humanIsFront = ref(false);
 const gameSettings = ref(defaultGameSettings());
 const engines = ref(new USIEngines());
 const blackPlayerURI = ref("");
 const whitePlayerURI = ref("");
 
-let defaultValueLoaded = false;
-let defaultValueApplied = false;
 busyState.retain();
 
 onMounted(async () => {
@@ -280,9 +303,19 @@ onMounted(async () => {
     engines.value = await api.loadUSIEngines();
     blackPlayerURI.value = gameSettings.value.black.uri;
     whitePlayerURI.value = gameSettings.value.white.uri;
+    hours.value = Math.floor(gameSettings.value.timeLimit.timeSeconds / 3600);
+    minutes.value = Math.floor(gameSettings.value.timeLimit.timeSeconds / 60) % 60;
+    byoyomi.value = gameSettings.value.timeLimit.byoyomi;
+    increment.value = gameSettings.value.timeLimit.increment;
+    const whiteTimeLimit = gameSettings.value.whiteTimeLimit || gameSettings.value.timeLimit;
+    whiteHours.value = Math.floor(whiteTimeLimit.timeSeconds / 3600);
+    whiteMinutes.value = Math.floor(whiteTimeLimit.timeSeconds / 60) % 60;
+    whiteByoyomi.value = whiteTimeLimit.byoyomi;
+    whiteIncrement.value = whiteTimeLimit.increment;
+    setDifferentTime.value = !!gameSettings.value.whiteTimeLimit;
+    startPositionListShuffle.value = gameSettings.value.startPositionListOrder === "shuffle";
     showModalDialog(dialog.value, onCancel);
     installHotKeyForDialog(dialog.value);
-    defaultValueLoaded = true;
   } catch (e) {
     useErrorStore().add(e);
     store.destroyModalDialog();
@@ -293,34 +326,6 @@ onMounted(async () => {
 
 onBeforeUnmount(() => {
   uninstallHotKeyForDialog(dialog.value);
-});
-
-onUpdated(() => {
-  if (!defaultValueLoaded || defaultValueApplied) {
-    return;
-  }
-  hours.value.value = Math.floor(gameSettings.value.timeLimit.timeSeconds / 3600);
-  minutes.value.value = Math.floor(gameSettings.value.timeLimit.timeSeconds / 60) % 60;
-  byoyomi.value.value = gameSettings.value.timeLimit.byoyomi;
-  increment.value.value = gameSettings.value.timeLimit.increment;
-  enableEngineTimeout.value = gameSettings.value.enableEngineTimeout;
-  const whiteTimeLimit = gameSettings.value.whiteTimeLimit || gameSettings.value.timeLimit;
-  whiteHours.value.value = Math.floor(whiteTimeLimit.timeSeconds / 3600);
-  whiteMinutes.value.value = Math.floor(whiteTimeLimit.timeSeconds / 60) % 60;
-  whiteByoyomi.value.value = whiteTimeLimit.byoyomi;
-  whiteIncrement.value.value = whiteTimeLimit.increment;
-  setDifferentTime.value = !!gameSettings.value.whiteTimeLimit;
-  startPosition.value = gameSettings.value.startPosition;
-  startPositionListFile.value.value = gameSettings.value.startPositionListFile;
-  startPositionListShuffle.value = gameSettings.value.startPositionListOrder === "shuffle";
-  maxMoves.value.value = gameSettings.value.maxMoves;
-  repeat.value.value = gameSettings.value.repeat;
-  jishogiRule.value.value = gameSettings.value.jishogiRule;
-  swapPlayers.value = gameSettings.value.swapPlayers;
-  enableComment.value = gameSettings.value.enableComment;
-  enableAutoSave.value = gameSettings.value.enableAutoSave;
-  humanIsFront.value = gameSettings.value.humanIsFront;
-  defaultValueApplied = true;
 });
 
 const buildPlayerSettings = (playerURI: string): PlayerSettings => {
@@ -339,41 +344,33 @@ const buildPlayerSettings = (playerURI: string): PlayerSettings => {
 };
 
 const onStart = () => {
-  const gameSettings: GameSettings = {
+  const newSettings: GameSettings = {
+    ...gameSettings.value,
     black: buildPlayerSettings(blackPlayerURI.value),
     white: buildPlayerSettings(whitePlayerURI.value),
     timeLimit: {
-      timeSeconds: (readInputAsNumber(hours.value) * 60 + readInputAsNumber(minutes.value)) * 60,
-      byoyomi: readInputAsNumber(byoyomi.value),
-      increment: readInputAsNumber(increment.value),
+      timeSeconds: (hours.value * 60 + minutes.value) * 60,
+      byoyomi: byoyomi.value,
+      increment: increment.value,
     },
-    enableEngineTimeout: enableEngineTimeout.value,
-    startPosition: startPosition.value,
-    startPositionListFile: startPositionListFile.value.value,
     startPositionListOrder: startPositionListShuffle.value ? "shuffle" : "sequential",
-    maxMoves: readInputAsNumber(maxMoves.value),
-    repeat: readInputAsNumber(repeat.value),
-    jishogiRule: jishogiRule.value.value,
-    swapPlayers: swapPlayers.value,
-    enableComment: enableComment.value,
-    enableAutoSave: enableAutoSave.value,
-    humanIsFront: humanIsFront.value,
   };
   if (setDifferentTime.value) {
-    gameSettings.whiteTimeLimit = {
-      timeSeconds:
-        (readInputAsNumber(whiteHours.value) * 60 + readInputAsNumber(whiteMinutes.value)) * 60,
-      byoyomi: readInputAsNumber(whiteByoyomi.value),
-      increment: readInputAsNumber(whiteIncrement.value),
+    newSettings.whiteTimeLimit = {
+      timeSeconds: (whiteHours.value * 60 + whiteMinutes.value) * 60,
+      byoyomi: whiteByoyomi.value,
+      increment: whiteIncrement.value,
     };
+  } else {
+    delete newSettings.whiteTimeLimit;
   }
   const error = isNative()
-    ? validateGameSettings(gameSettings)
-    : validateGameSettingsForWeb(gameSettings);
+    ? validateGameSettings(newSettings)
+    : validateGameSettingsForWeb(newSettings);
   if (error) {
     useErrorStore().add(error);
   } else {
-    store.startGame(gameSettings);
+    store.startGame(newSettings);
   }
 };
 
@@ -388,28 +385,19 @@ const onUpdatePlayerSettings = (val: USIEngines) => {
 const onSwapColor = () => {
   [blackPlayerURI.value, whitePlayerURI.value] = [whitePlayerURI.value, blackPlayerURI.value];
   if (setDifferentTime.value) {
-    [hours.value.value, whiteHours.value.value] = [whiteHours.value.value, hours.value.value];
-    [minutes.value.value, whiteMinutes.value.value] = [
-      whiteMinutes.value.value,
-      minutes.value.value,
-    ];
-    [byoyomi.value.value, whiteByoyomi.value.value] = [
-      whiteByoyomi.value.value,
-      byoyomi.value.value,
-    ];
-    [increment.value.value, whiteIncrement.value.value] = [
-      whiteIncrement.value.value,
-      increment.value.value,
-    ];
+    [hours.value, whiteHours.value] = [whiteHours.value, hours.value];
+    [minutes.value, whiteMinutes.value] = [whiteMinutes.value, minutes.value];
+    [byoyomi.value, whiteByoyomi.value] = [whiteByoyomi.value, byoyomi.value];
+    [increment.value, whiteIncrement.value] = [whiteIncrement.value, increment.value];
   }
 };
 
 const onSelectStartPositionListFile = async () => {
   useBusyState().retain();
   try {
-    const sfenPath = await api.showSelectSFENDialog(startPositionListFile.value.value);
+    const sfenPath = await api.showSelectSFENDialog(gameSettings.value.startPositionListFile);
     if (sfenPath) {
-      startPositionListFile.value.value = sfenPath;
+      gameSettings.value.startPositionListFile = sfenPath;
     }
   } finally {
     useBusyState().release();


### PR DESCRIPTION
# 説明 / Description

Dialog の入力に ref を使っている箇所を v-model へ書き換える。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Centralized state management for dialog inputs, enhancing the consistency and reactivity of user interactions.
  - Streamlined data handling in dialogs for book moves, batch conversion, game settings, and piece set adjustments.
  - Simplified the auto-save directory input, leading to a cleaner and more intuitive experience.
  - Enhanced input handling for piece counts, moving to a more declarative data-binding approach.
  - Improved numeric input handling for opacity settings, ensuring values are treated as numbers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->