### PR TITLE
棋譜解析機能に降順オプションを追加

### DIFF
--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -318,6 +318,7 @@ export const en: Texts = {
   byoyomi: "Byoyomi",
   increments: "Increments",
   startEndCriteria: "Start/End Criteria",
+  descending: "Descending",
   endCriteria1Move: "End Criteria for 1 Move",
   outputSettings: "Output Settings",
   noOutputs: "No Outputs",

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -318,6 +318,7 @@ export const ja: Texts = {
   byoyomi: "秒読み",
   increments: "増加",
   startEndCriteria: "開始・終了条件",
+  descending: "逆順",
   endCriteria1Move: "局面ごとの終了条件",
   outputSettings: "出力設定",
   noOutputs: "出力しない",

--- a/src/common/i18n/locales/vi.ts
+++ b/src/common/i18n/locales/vi.ts
@@ -318,6 +318,7 @@ export const vi: Texts = {
   byoyomi: "Byoyomi",
   increments: "Cộng thời gian",
   startEndCriteria: "Điều kiện bắt đầu/kết thúc",
+  descending: "逆順", // TODO: Translate
   endCriteria1Move: "Điều kiện kết thúc cho mỗi nước đi",
   outputSettings: "Tùy chọn xuất",
   noOutputs: "Không xuất",

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -315,6 +315,7 @@ export const zh_tw: Texts = {
   byoyomi: "讀秒",
   increments: "增秒",
   startEndCriteria: "開始・結束條件",
+  descending: "逆順", // TODO: Translate
   endCriteria1Move: "局面結束條件",
   outputSettings: "輸出設定",
   noOutputs: "不輸出",

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -313,6 +313,7 @@ export type Texts = {
   byoyomi: string;
   increments: string;
   startEndCriteria: string;
+  descending: string;
   endCriteria1Move: string;
   outputSettings: string;
   noOutputs: string;

--- a/src/common/settings/analysis.ts
+++ b/src/common/settings/analysis.ts
@@ -40,6 +40,7 @@ export type AnalysisSettings = {
   startCriteria: StartCriteria;
   endCriteria: EndCriteria;
   perMoveCriteria: PerMoveCriteria;
+  descending: boolean;
   commentBehavior: CommentBehavior;
 };
 
@@ -48,6 +49,7 @@ export function defaultAnalysisSettings(): AnalysisSettings {
     startCriteria: defaultStartCriteria(),
     endCriteria: defaultEndCriteria(),
     perMoveCriteria: defaultPerMoveCriteria(),
+    descending: false,
     commentBehavior: CommentBehavior.INSERT,
   };
 }

--- a/src/common/settings/analysis.ts
+++ b/src/common/settings/analysis.ts
@@ -70,3 +70,28 @@ export function normalizeAnalysisSettings(settings: AnalysisSettings): AnalysisS
     },
   };
 }
+
+export function validateAnalysisSettings(settings: AnalysisSettings): Error | undefined {
+  if (
+    settings.startCriteria.enableNumber &&
+    (settings.startCriteria.number <= 0 || settings.startCriteria.number % 1 !== 0)
+  ) {
+    return new Error("開始手数は1以上の整数を指定してください。"); // TODO: i18n
+  }
+  if (
+    settings.endCriteria.enableNumber &&
+    (settings.endCriteria.number <= 0 || settings.endCriteria.number % 1 !== 0)
+  ) {
+    return new Error("終了手数は1以上の整数を指定してください。"); // TODO: i18n
+  }
+  if (
+    settings.startCriteria.enableNumber &&
+    settings.endCriteria.enableNumber &&
+    settings.startCriteria.number > settings.endCriteria.number
+  ) {
+    return new Error("終了手数が開始手数より小さくなっています。"); // TODO: i18n
+  }
+  if (settings.perMoveCriteria.maxSeconds < 0) {
+    return new Error("1手あたりの思考時間に負の値が指定されています。"); // TODO: i18n
+  }
+}

--- a/src/renderer/store/score.ts
+++ b/src/renderer/store/score.ts
@@ -7,13 +7,13 @@ export function getSituationText(score: number): string {
     return "先手有利";
   } else if (score >= 200) {
     return "先手有望";
-  } else if (score >= -200) {
+  } else if (score > -200) {
     return "互角";
-  } else if (score >= -400) {
+  } else if (score > -400) {
     return "後手有望";
-  } else if (score >= -600) {
+  } else if (score > -600) {
     return "後手有利";
-  } else if (score >= -1500) {
+  } else if (score > -1500) {
     return "後手優勢";
   } else {
     return "後手勝勢";

--- a/src/renderer/view/dialog/AnalysisDialog.vue
+++ b/src/renderer/view/dialog/AnalysisDialog.vue
@@ -16,28 +16,28 @@
       <div class="form-group">
         <div>{{ t.startEndCriteria }}</div>
         <div class="form-item">
-          <ToggleButton v-model:value="enableStartNumber" />
+          <ToggleButton v-model:value="settings.startCriteria.enableNumber" />
           <div class="form-item-small-label">{{ t.fromPrefix }}{{ t.plyPrefix }}</div>
           <input
-            ref="startNumber"
+            v-model.number="settings.startCriteria.number"
             class="small"
             type="number"
             min="1"
             step="1"
-            :disabled="!enableStartNumber"
+            :disabled="!settings.startCriteria.enableNumber"
           />
           <div class="form-item-small-label">{{ t.plySuffix }}{{ t.fromSuffix }}</div>
         </div>
         <div class="form-item">
-          <ToggleButton v-model:value="enableEndNumber" />
+          <ToggleButton v-model:value="settings.endCriteria.enableNumber" />
           <div class="form-item-small-label">{{ t.toPrefix }}{{ t.plyPrefix }}</div>
           <input
-            ref="endNumber"
+            v-model.number="settings.endCriteria.number"
             class="small"
             type="number"
             min="1"
             step="1"
-            :disabled="!enableEndNumber"
+            :disabled="!settings.endCriteria.enableNumber"
           />
           <div class="form-item-small-label">{{ t.plySuffix }}{{ t.toSuffix }}</div>
         </div>
@@ -46,7 +46,13 @@
         <div>{{ t.endCriteria1Move }}</div>
         <div class="form-item">
           <div class="form-item-small-label">{{ t.toPrefix }}</div>
-          <input ref="maxSecondsPerMove" class="small" type="number" min="0" step="1" />
+          <input
+            v-model.number="settings.perMoveCriteria.maxSeconds"
+            class="small"
+            type="number"
+            min="0"
+            step="1"
+          />
           <div class="form-item-small-label">{{ t.secondsSuffix }}{{ t.toSuffix }}</div>
         </div>
       </div>
@@ -55,7 +61,7 @@
         <div class="form-item">
           <div class="form-item-label-wide">{{ t.moveComments }}</div>
           <HorizontalSelector
-            v-model:value="commentBehavior"
+            v-model:value="settings.commentBehavior"
             class="selector"
             :items="[
               { value: CommentBehavior.NONE, label: t.noOutputs },
@@ -81,9 +87,8 @@
 <script setup lang="ts">
 import { t } from "@/common/i18n";
 import { showModalDialog } from "@/renderer/helpers/dialog.js";
-import { readInputAsNumber } from "@/renderer/helpers/form.js";
 import api from "@/renderer/ipc/api";
-import { AnalysisSettings } from "@/common/settings/analysis";
+import { defaultAnalysisSettings } from "@/common/settings/analysis";
 import { CommentBehavior } from "@/common/settings/comment";
 import { USIEngineLabel, USIEngines } from "@/common/settings/usi";
 import { useStore } from "@/renderer/store";
@@ -98,12 +103,7 @@ import { useBusyState } from "@/renderer/store/busy";
 const store = useStore();
 const busyState = useBusyState();
 const dialog = ref();
-const enableStartNumber = ref(false);
-const startNumber = ref();
-const enableEndNumber = ref(false);
-const endNumber = ref();
-const maxSecondsPerMove = ref();
-const commentBehavior = ref(CommentBehavior.NONE);
+const settings = ref(defaultAnalysisSettings());
 const engines = ref(new USIEngines());
 const engineURI = ref("");
 
@@ -113,15 +113,9 @@ onMounted(async () => {
   showModalDialog(dialog.value, onCancel);
   installHotKeyForDialog(dialog.value);
   try {
-    const analysisSettings = await api.loadAnalysisSettings();
+    settings.value = await api.loadAnalysisSettings();
     engines.value = await api.loadUSIEngines();
-    engineURI.value = analysisSettings.usi?.uri || "";
-    enableStartNumber.value = analysisSettings.startCriteria.enableNumber;
-    startNumber.value.value = analysisSettings.startCriteria.number;
-    enableEndNumber.value = analysisSettings.endCriteria.enableNumber;
-    endNumber.value.value = analysisSettings.endCriteria.number;
-    maxSecondsPerMove.value.value = analysisSettings.perMoveCriteria.maxSeconds;
-    commentBehavior.value = analysisSettings.commentBehavior;
+    engineURI.value = settings.value.usi?.uri || "";
   } catch (e) {
     useErrorStore().add(e);
     store.destroyModalDialog();
@@ -140,22 +134,10 @@ const onStart = () => {
     return;
   }
   const engine = engines.value.getEngine(engineURI.value);
-  const analysisSettings: AnalysisSettings = {
+  store.startAnalysis({
+    ...settings.value,
     usi: engine,
-    startCriteria: {
-      enableNumber: enableStartNumber.value,
-      number: readInputAsNumber(startNumber.value),
-    },
-    endCriteria: {
-      enableNumber: enableEndNumber.value,
-      number: readInputAsNumber(endNumber.value),
-    },
-    perMoveCriteria: {
-      maxSeconds: readInputAsNumber(maxSecondsPerMove.value),
-    },
-    commentBehavior: commentBehavior.value,
-  };
-  store.startAnalysis(analysisSettings);
+  });
 };
 
 const onCancel = () => {

--- a/src/renderer/view/dialog/AnalysisDialog.vue
+++ b/src/renderer/view/dialog/AnalysisDialog.vue
@@ -88,7 +88,7 @@
 import { t } from "@/common/i18n";
 import { showModalDialog } from "@/renderer/helpers/dialog.js";
 import api from "@/renderer/ipc/api";
-import { defaultAnalysisSettings } from "@/common/settings/analysis";
+import { defaultAnalysisSettings, validateAnalysisSettings } from "@/common/settings/analysis";
 import { CommentBehavior } from "@/common/settings/comment";
 import { USIEngineLabel, USIEngines } from "@/common/settings/usi";
 import { useStore } from "@/renderer/store";
@@ -134,10 +134,16 @@ const onStart = () => {
     return;
   }
   const engine = engines.value.getEngine(engineURI.value);
-  store.startAnalysis({
+  const newSettings = {
     ...settings.value,
     usi: engine,
-  });
+  };
+  const error = validateAnalysisSettings(newSettings);
+  if (error) {
+    useErrorStore().add(error);
+    return;
+  }
+  store.startAnalysis(newSettings);
 };
 
 const onCancel = () => {

--- a/src/renderer/view/dialog/AnalysisDialog.vue
+++ b/src/renderer/view/dialog/AnalysisDialog.vue
@@ -41,6 +41,9 @@
           />
           <div class="form-item-small-label">{{ t.plySuffix }}{{ t.toSuffix }}</div>
         </div>
+        <div class="form-item">
+          <ToggleButton v-model:value="settings.descending" :label="t.descending" />
+        </div>
       </div>
       <div class="form-group">
         <div>{{ t.endCriteria1Move }}</div>

--- a/src/tests/common/settings/analysis.spec.ts
+++ b/src/tests/common/settings/analysis.spec.ts
@@ -1,4 +1,8 @@
-import { AnalysisSettings, normalizeAnalysisSettings } from "@/common/settings/analysis";
+import {
+  AnalysisSettings,
+  normalizeAnalysisSettings,
+  validateAnalysisSettings,
+} from "@/common/settings/analysis";
 import { CommentBehavior } from "@/common/settings/comment";
 import * as uri from "@/common/uri";
 
@@ -32,5 +36,70 @@ describe("settings/analysis", () => {
     };
     const result = normalizeAnalysisSettings(settings);
     expect(result).toEqual(settings);
+  });
+
+  it("validate", () => {
+    expect(
+      validateAnalysisSettings({
+        startCriteria: { enableNumber: false, number: 0 },
+        endCriteria: { enableNumber: false, number: 0 },
+        perMoveCriteria: { maxSeconds: 0 },
+        commentBehavior: CommentBehavior.INSERT,
+      }),
+    ).toBeUndefined();
+
+    expect(
+      validateAnalysisSettings({
+        startCriteria: { enableNumber: true, number: 30 },
+        endCriteria: { enableNumber: true, number: 120 },
+        perMoveCriteria: { maxSeconds: 0 },
+        commentBehavior: CommentBehavior.INSERT,
+      }),
+    ).toBeUndefined();
+
+    expect(
+      validateAnalysisSettings({
+        startCriteria: { enableNumber: true, number: 30 },
+        endCriteria: { enableNumber: true, number: 30 },
+        perMoveCriteria: { maxSeconds: 0 },
+        commentBehavior: CommentBehavior.INSERT,
+      }),
+    ).toBeUndefined();
+
+    expect(
+      validateAnalysisSettings({
+        startCriteria: { enableNumber: true, number: 0 },
+        endCriteria: { enableNumber: false, number: 0 },
+        perMoveCriteria: { maxSeconds: 0 },
+        commentBehavior: CommentBehavior.INSERT,
+      }),
+    ).toBeInstanceOf(Error);
+
+    expect(
+      validateAnalysisSettings({
+        startCriteria: { enableNumber: false, number: 0 },
+        endCriteria: { enableNumber: true, number: 0 },
+        perMoveCriteria: { maxSeconds: 0 },
+        commentBehavior: CommentBehavior.INSERT,
+      }),
+    ).toBeInstanceOf(Error);
+
+    expect(
+      validateAnalysisSettings({
+        startCriteria: { enableNumber: true, number: 30 },
+        endCriteria: { enableNumber: true, number: 29 },
+        perMoveCriteria: { maxSeconds: 0 },
+        commentBehavior: CommentBehavior.INSERT,
+      }),
+    ).toBeInstanceOf(Error);
+
+    expect(
+      validateAnalysisSettings({
+        startCriteria: { enableNumber: true, number: 30 },
+        endCriteria: { enableNumber: true, number: 120 },
+        perMoveCriteria: { maxSeconds: -1 },
+        commentBehavior: CommentBehavior.INSERT,
+      }),
+    ).toBeInstanceOf(Error);
   });
 });

--- a/src/tests/common/settings/analysis.spec.ts
+++ b/src/tests/common/settings/analysis.spec.ts
@@ -32,6 +32,7 @@ describe("settings/analysis", () => {
       perMoveCriteria: {
         maxSeconds: 10,
       },
+      descending: true,
       commentBehavior: CommentBehavior.APPEND,
     };
     const result = normalizeAnalysisSettings(settings);
@@ -44,6 +45,7 @@ describe("settings/analysis", () => {
         startCriteria: { enableNumber: false, number: 0 },
         endCriteria: { enableNumber: false, number: 0 },
         perMoveCriteria: { maxSeconds: 0 },
+        descending: false,
         commentBehavior: CommentBehavior.INSERT,
       }),
     ).toBeUndefined();
@@ -53,6 +55,7 @@ describe("settings/analysis", () => {
         startCriteria: { enableNumber: true, number: 30 },
         endCriteria: { enableNumber: true, number: 120 },
         perMoveCriteria: { maxSeconds: 0 },
+        descending: true,
         commentBehavior: CommentBehavior.INSERT,
       }),
     ).toBeUndefined();
@@ -62,6 +65,7 @@ describe("settings/analysis", () => {
         startCriteria: { enableNumber: true, number: 30 },
         endCriteria: { enableNumber: true, number: 30 },
         perMoveCriteria: { maxSeconds: 0 },
+        descending: true,
         commentBehavior: CommentBehavior.INSERT,
       }),
     ).toBeUndefined();
@@ -71,6 +75,7 @@ describe("settings/analysis", () => {
         startCriteria: { enableNumber: true, number: 0 },
         endCriteria: { enableNumber: false, number: 0 },
         perMoveCriteria: { maxSeconds: 0 },
+        descending: true,
         commentBehavior: CommentBehavior.INSERT,
       }),
     ).toBeInstanceOf(Error);
@@ -80,6 +85,7 @@ describe("settings/analysis", () => {
         startCriteria: { enableNumber: false, number: 0 },
         endCriteria: { enableNumber: true, number: 0 },
         perMoveCriteria: { maxSeconds: 0 },
+        descending: true,
         commentBehavior: CommentBehavior.INSERT,
       }),
     ).toBeInstanceOf(Error);
@@ -89,6 +95,7 @@ describe("settings/analysis", () => {
         startCriteria: { enableNumber: true, number: 30 },
         endCriteria: { enableNumber: true, number: 29 },
         perMoveCriteria: { maxSeconds: 0 },
+        descending: true,
         commentBehavior: CommentBehavior.INSERT,
       }),
     ).toBeInstanceOf(Error);
@@ -98,6 +105,7 @@ describe("settings/analysis", () => {
         startCriteria: { enableNumber: true, number: 30 },
         endCriteria: { enableNumber: true, number: 120 },
         perMoveCriteria: { maxSeconds: -1 },
+        descending: true,
         commentBehavior: CommentBehavior.INSERT,
       }),
     ).toBeInstanceOf(Error);

--- a/src/tests/mock/analysis.ts
+++ b/src/tests/mock/analysis.ts
@@ -26,5 +26,6 @@ export const analysisSettings: AnalysisSettings = {
   perMoveCriteria: {
     maxSeconds: 1,
   },
+  descending: false,
   commentBehavior: CommentBehavior.APPEND,
 };

--- a/src/tests/renderer/store/analysis.spec.ts
+++ b/src/tests/renderer/store/analysis.spec.ts
@@ -3,6 +3,7 @@ import { RecordManager } from "@/renderer/store/record";
 import { analysisSettings as baseAnalysisSettings } from "@/tests/mock/analysis";
 import { USIPlayer } from "@/renderer/players/usi";
 import { MockedClass } from "vitest";
+import { CommentBehavior } from "@/common/settings/comment";
 
 vi.mock("@/renderer/players/usi");
 
@@ -25,15 +26,22 @@ describe("store/analysis", () => {
     mockUSIPlayer.prototype.close.mockResolvedValue();
     const recordManager = new RecordManager();
     recordManager.importRecord(
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f 8c8d",
+      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f 8c8d resign",
     );
-    const analysisSettings = JSON.parse(JSON.stringify(baseAnalysisSettings));
-    analysisSettings.startCriteria.enableNumber = false;
-    analysisSettings.endCriteria.enableNumber = false;
     const onFinish = vi.fn();
     const onError = vi.fn();
     const manager = new AnalysisManager(recordManager).on("finish", onFinish).on("error", onError);
-    await manager.start(analysisSettings);
+    await manager.start({
+      ...baseAnalysisSettings,
+      startCriteria: {
+        enableNumber: false,
+        number: 0,
+      },
+      endCriteria: {
+        enableNumber: false,
+        number: 0,
+      },
+    });
     expect(mockUSIPlayer).toBeCalledTimes(1);
     expect(mockUSIPlayer.prototype.launch).toBeCalled();
     expect(mockUSIPlayer.prototype.startResearch).not.toBeCalled();
@@ -93,5 +101,335 @@ describe("store/analysis", () => {
     expect(recordManager.record.current.comment).toBe(
       "互角\n#評価値=50\n#エンジン=my usi engine\n",
     );
+    recordManager.changePly(5);
+    expect(recordManager.record.current.comment).toBe("");
+  });
+
+  it("with-limits", async () => {
+    mockUSIPlayer.prototype.launch.mockResolvedValue();
+    mockUSIPlayer.prototype.startResearch.mockResolvedValue();
+    mockUSIPlayer.prototype.stop.mockResolvedValue();
+    mockUSIPlayer.prototype.close.mockResolvedValue();
+    const recordManager = new RecordManager();
+    recordManager.importRecord(
+      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f 8c8d 2f2d 8d8e",
+    );
+    const onFinish = vi.fn();
+    const onError = vi.fn();
+    const manager = new AnalysisManager(recordManager).on("finish", onFinish).on("error", onError);
+    await manager.start({
+      ...baseAnalysisSettings,
+      startCriteria: {
+        enableNumber: true,
+        number: 2,
+      },
+      endCriteria: {
+        enableNumber: true,
+        number: 4,
+      },
+    });
+    expect(mockUSIPlayer).toBeCalledTimes(1);
+    expect(mockUSIPlayer.prototype.launch).toBeCalled();
+    expect(mockUSIPlayer.prototype.startResearch).not.toBeCalled();
+    vi.runOnlyPendingTimers();
+    expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(1);
+    manager.updateSearchInfo({
+      usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f",
+      score: 10,
+    });
+    vi.runOnlyPendingTimers();
+    expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(2);
+    manager.updateSearchInfo({
+      usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d",
+      score: 20,
+    });
+    vi.runOnlyPendingTimers();
+    expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(3);
+    manager.updateSearchInfo({
+      usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f",
+      score: 30,
+    });
+    vi.runOnlyPendingTimers();
+    expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(4);
+    manager.updateSearchInfo({
+      usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f 8c8d",
+      score: 40,
+    });
+    vi.runOnlyPendingTimers();
+    expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(4);
+    expect(mockUSIPlayer.prototype.stop).not.toBeCalled();
+    expect(mockUSIPlayer.prototype.close).toBeCalledTimes(1);
+    expect(onFinish).toBeCalledTimes(1);
+    expect(onError).not.toBeCalled();
+    recordManager.changePly(1);
+    expect(recordManager.record.current.comment).toBe("");
+    recordManager.changePly(2);
+    expect(recordManager.record.current.comment).toBe(
+      "互角\n#評価値=20\n#エンジン=my usi engine\n",
+    );
+    recordManager.changePly(3);
+    expect(recordManager.record.current.comment).toBe(
+      "互角\n#評価値=30\n#エンジン=my usi engine\n",
+    );
+    recordManager.changePly(4);
+    expect(recordManager.record.current.comment).toBe(
+      "互角\n#評価値=40\n#エンジン=my usi engine\n",
+    );
+    recordManager.changePly(5);
+    expect(recordManager.record.current.comment).toBe("");
+    recordManager.changePly(6);
+    expect(recordManager.record.current.comment).toBe("");
+  });
+
+  it("descending-open-end", async () => {
+    mockUSIPlayer.prototype.launch.mockResolvedValue();
+    mockUSIPlayer.prototype.startResearch.mockResolvedValue();
+    mockUSIPlayer.prototype.stop.mockResolvedValue();
+    mockUSIPlayer.prototype.close.mockResolvedValue();
+    const recordManager = new RecordManager();
+    recordManager.importRecord(
+      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f 8c8d resign",
+    );
+    const onFinish = vi.fn();
+    const onError = vi.fn();
+    const manager = new AnalysisManager(recordManager).on("finish", onFinish).on("error", onError);
+    await manager.start({
+      ...baseAnalysisSettings,
+      startCriteria: {
+        enableNumber: false,
+        number: 0,
+      },
+      endCriteria: {
+        enableNumber: false,
+        number: 0,
+      },
+      descending: true,
+    });
+    expect(mockUSIPlayer).toBeCalledTimes(1);
+    expect(mockUSIPlayer.prototype.launch).toBeCalled();
+    expect(mockUSIPlayer.prototype.startResearch).not.toBeCalled();
+    vi.runOnlyPendingTimers();
+    expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(1);
+    manager.updateSearchInfo({
+      usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f 8c8d",
+      score: 10,
+    });
+    vi.runOnlyPendingTimers();
+    expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(2);
+    manager.updateSearchInfo({
+      usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f",
+      score: 20,
+    });
+    vi.runOnlyPendingTimers();
+    expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(3);
+    manager.updateSearchInfo({
+      usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d",
+      score: 30,
+    });
+    vi.runOnlyPendingTimers();
+    expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(4);
+    manager.updateSearchInfo({
+      usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f",
+      score: 40,
+    });
+    vi.runOnlyPendingTimers();
+    expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(5);
+    manager.updateSearchInfo({
+      usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1",
+      score: 50,
+    });
+    vi.runOnlyPendingTimers();
+    expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(5);
+    expect(mockUSIPlayer.prototype.stop).not.toBeCalled();
+    expect(mockUSIPlayer.prototype.close).toBeCalledTimes(1);
+    expect(onFinish).toBeCalledTimes(1);
+    expect(onError).not.toBeCalled();
+    recordManager.changePly(0);
+    expect(recordManager.record.current.comment).toBe("");
+    recordManager.changePly(1);
+    expect(recordManager.record.current.comment).toBe(
+      "互角\n#評価値=40\n#エンジン=my usi engine\n",
+    );
+    recordManager.changePly(2);
+    expect(recordManager.record.current.comment).toBe(
+      "互角\n#評価値=30\n#エンジン=my usi engine\n",
+    );
+    recordManager.changePly(3);
+    expect(recordManager.record.current.comment).toBe(
+      "互角\n#評価値=20\n#エンジン=my usi engine\n",
+    );
+    recordManager.changePly(4);
+    expect(recordManager.record.current.comment).toBe(
+      "互角\n#評価値=10\n#エンジン=my usi engine\n",
+    );
+    recordManager.changePly(5);
+    expect(recordManager.record.current.comment).toBe("");
+  });
+
+  it("descending-with-limits", async () => {
+    mockUSIPlayer.prototype.launch.mockResolvedValue();
+    mockUSIPlayer.prototype.startResearch.mockResolvedValue();
+    mockUSIPlayer.prototype.stop.mockResolvedValue();
+    mockUSIPlayer.prototype.close.mockResolvedValue();
+    const recordManager = new RecordManager();
+    recordManager.importRecord(
+      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f 8c8d 2f2e 8d8e",
+    );
+    const onFinish = vi.fn();
+    const onError = vi.fn();
+    const manager = new AnalysisManager(recordManager).on("finish", onFinish).on("error", onError);
+    await manager.start({
+      ...baseAnalysisSettings,
+      startCriteria: {
+        enableNumber: true,
+        number: 3,
+      },
+      endCriteria: {
+        enableNumber: true,
+        number: 5,
+      },
+      descending: true,
+    });
+    expect(mockUSIPlayer).toBeCalledTimes(1);
+    expect(mockUSIPlayer.prototype.launch).toBeCalled();
+    expect(mockUSIPlayer.prototype.startResearch).not.toBeCalled();
+    vi.runOnlyPendingTimers();
+    expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(1);
+    manager.updateSearchInfo({
+      usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f 8c8d 2f2e",
+      score: 10,
+    });
+    vi.runOnlyPendingTimers();
+    expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(2);
+    manager.updateSearchInfo({
+      usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f 8c8d",
+      score: 20,
+    });
+    vi.runOnlyPendingTimers();
+    expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(3);
+    manager.updateSearchInfo({
+      usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f",
+      score: 30,
+    });
+    vi.runOnlyPendingTimers();
+    expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(4);
+    manager.updateSearchInfo({
+      usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d",
+      score: 40,
+    });
+    vi.runOnlyPendingTimers();
+    expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(4);
+    expect(mockUSIPlayer.prototype.stop).not.toBeCalled();
+    expect(mockUSIPlayer.prototype.close).toBeCalledTimes(1);
+    expect(onFinish).toBeCalledTimes(1);
+    expect(onError).not.toBeCalled();
+    recordManager.changePly(0);
+    expect(recordManager.record.current.comment).toBe("");
+    recordManager.changePly(1);
+    expect(recordManager.record.current.comment).toBe("");
+    recordManager.changePly(2);
+    expect(recordManager.record.current.comment).toBe("");
+    recordManager.changePly(3);
+    expect(recordManager.record.current.comment).toBe(
+      "互角\n#評価値=30\n#エンジン=my usi engine\n",
+    );
+    recordManager.changePly(4);
+    expect(recordManager.record.current.comment).toBe(
+      "互角\n#評価値=20\n#エンジン=my usi engine\n",
+    );
+    recordManager.changePly(5);
+    expect(recordManager.record.current.comment).toBe(
+      "互角\n#評価値=10\n#エンジン=my usi engine\n",
+    );
+    recordManager.changePly(6);
+    expect(recordManager.record.current.comment).toBe("");
+  });
+
+  describe("comment-behavior", () => {
+    const testCases = [
+      {
+        commentBehavior: CommentBehavior.APPEND,
+        expectedComments: [
+          "初手\n互角\n#評価値=20\n#エンジン=my usi engine\n",
+          "2手目\n互角\n#評価値=30\n#エンジン=my usi engine\n",
+        ],
+      },
+      {
+        commentBehavior: CommentBehavior.INSERT,
+        expectedComments: [
+          "互角\n#評価値=20\n#エンジン=my usi engine\n\n初手",
+          "互角\n#評価値=30\n#エンジン=my usi engine\n\n2手目",
+        ],
+      },
+      {
+        commentBehavior: CommentBehavior.OVERWRITE,
+        expectedComments: [
+          "互角\n#評価値=20\n#エンジン=my usi engine\n",
+          "互角\n#評価値=30\n#エンジン=my usi engine\n",
+        ],
+      },
+      {
+        commentBehavior: CommentBehavior.NONE,
+        expectedComments: ["初手", "2手目"],
+      },
+    ];
+    for (const testCase of testCases) {
+      it(`${testCase.commentBehavior}`, async () => {
+        mockUSIPlayer.prototype.launch.mockResolvedValue();
+        mockUSIPlayer.prototype.startResearch.mockResolvedValue();
+        mockUSIPlayer.prototype.stop.mockResolvedValue();
+        mockUSIPlayer.prototype.close.mockResolvedValue();
+        const recordManager = new RecordManager();
+        recordManager.importRecord(
+          "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d",
+        );
+        recordManager.changePly(1);
+        recordManager.updateComment("初手");
+        recordManager.changePly(2);
+        recordManager.updateComment("2手目");
+        const onFinish = vi.fn();
+        const onError = vi.fn();
+        const manager = new AnalysisManager(recordManager)
+          .on("finish", onFinish)
+          .on("error", onError);
+        await manager.start({
+          ...baseAnalysisSettings,
+          commentBehavior: testCase.commentBehavior,
+        });
+        expect(mockUSIPlayer).toBeCalledTimes(1);
+        expect(mockUSIPlayer.prototype.launch).toBeCalled();
+        expect(mockUSIPlayer.prototype.startResearch).not.toBeCalled();
+        vi.runOnlyPendingTimers();
+        expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(1);
+        manager.updateSearchInfo({
+          usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1",
+          score: 10,
+        });
+        vi.runOnlyPendingTimers();
+        expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(2);
+        manager.updateSearchInfo({
+          usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f",
+          score: 20,
+        });
+        vi.runOnlyPendingTimers();
+        expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(3);
+        manager.updateSearchInfo({
+          usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d",
+          score: 30,
+        });
+        vi.runOnlyPendingTimers();
+        expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(3);
+        expect(mockUSIPlayer.prototype.stop).not.toBeCalled();
+        expect(mockUSIPlayer.prototype.close).toBeCalledTimes(1);
+        expect(onFinish).toBeCalledTimes(1);
+        expect(onError).not.toBeCalled();
+        recordManager.changePly(0);
+        expect(recordManager.record.current.comment).toBe("");
+        recordManager.changePly(1);
+        expect(recordManager.record.current.comment).toBe(testCase.expectedComments[0]);
+        recordManager.changePly(2);
+        expect(recordManager.record.current.comment).toBe(testCase.expectedComments[1]);
+      });
+    }
   });
 });

--- a/src/tests/renderer/store/analysis.spec.ts
+++ b/src/tests/renderer/store/analysis.spec.ts
@@ -350,27 +350,36 @@ describe("store/analysis", () => {
       {
         commentBehavior: CommentBehavior.APPEND,
         expectedComments: [
-          "初手\n互角\n#評価値=20\n#エンジン=my usi engine\n",
-          "2手目\n互角\n#評価値=30\n#エンジン=my usi engine\n",
+          "初手\n互角\n#評価値=-10\n#エンジン=my usi engine\n",
+          "2手目\n【緩手】\n先手有望\n#評価値=200\n#エンジン=my usi engine\n",
+          "【疑問手】\n後手有望\n#評価値=-200\n#エンジン=my usi engine\n",
+          "【悪手】\n先手有利\n#評価値=400\n#エンジン=my usi engine\n",
+          "【大悪手】\n後手優勢\n#評価値=-1000\n#エンジン=my usi engine\n",
         ],
       },
       {
         commentBehavior: CommentBehavior.INSERT,
         expectedComments: [
-          "互角\n#評価値=20\n#エンジン=my usi engine\n\n初手",
-          "互角\n#評価値=30\n#エンジン=my usi engine\n\n2手目",
+          "互角\n#評価値=-10\n#エンジン=my usi engine\n\n初手",
+          "【緩手】\n先手有望\n#評価値=200\n#エンジン=my usi engine\n\n2手目",
+          "【疑問手】\n後手有望\n#評価値=-200\n#エンジン=my usi engine\n",
+          "【悪手】\n先手有利\n#評価値=400\n#エンジン=my usi engine\n",
+          "【大悪手】\n後手優勢\n#評価値=-1000\n#エンジン=my usi engine\n",
         ],
       },
       {
         commentBehavior: CommentBehavior.OVERWRITE,
         expectedComments: [
-          "互角\n#評価値=20\n#エンジン=my usi engine\n",
-          "互角\n#評価値=30\n#エンジン=my usi engine\n",
+          "互角\n#評価値=-10\n#エンジン=my usi engine\n",
+          "【緩手】\n先手有望\n#評価値=200\n#エンジン=my usi engine\n",
+          "【疑問手】\n後手有望\n#評価値=-200\n#エンジン=my usi engine\n",
+          "【悪手】\n先手有利\n#評価値=400\n#エンジン=my usi engine\n",
+          "【大悪手】\n後手優勢\n#評価値=-1000\n#エンジン=my usi engine\n",
         ],
       },
       {
         commentBehavior: CommentBehavior.NONE,
-        expectedComments: ["初手", "2手目"],
+        expectedComments: ["初手", "2手目", "", "", ""],
       },
     ];
     for (const testCase of testCases) {
@@ -381,7 +390,7 @@ describe("store/analysis", () => {
         mockUSIPlayer.prototype.close.mockResolvedValue();
         const recordManager = new RecordManager();
         recordManager.importRecord(
-          "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d",
+          "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f 8c8d 2f2e",
         );
         recordManager.changePly(1);
         recordManager.updateComment("初手");
@@ -409,26 +418,44 @@ describe("store/analysis", () => {
         expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(2);
         manager.updateSearchInfo({
           usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f",
-          score: 20,
+          score: -10,
         });
         vi.runOnlyPendingTimers();
         expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(3);
         manager.updateSearchInfo({
           usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d",
-          score: 30,
+          score: 200,
         });
         vi.runOnlyPendingTimers();
-        expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(3);
+        expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(4);
+        manager.updateSearchInfo({
+          usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f",
+          score: -200,
+        });
+        vi.runOnlyPendingTimers();
+        expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(5);
+        manager.updateSearchInfo({
+          usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f 8c8d",
+          score: 400,
+        });
+        vi.runOnlyPendingTimers();
+        expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(6);
+        manager.updateSearchInfo({
+          usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f 8c8d 2f2e",
+          score: -1000,
+        });
+        vi.runOnlyPendingTimers();
+        expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(6);
         expect(mockUSIPlayer.prototype.stop).not.toBeCalled();
         expect(mockUSIPlayer.prototype.close).toBeCalledTimes(1);
         expect(onFinish).toBeCalledTimes(1);
         expect(onError).not.toBeCalled();
         recordManager.changePly(0);
         expect(recordManager.record.current.comment).toBe("");
-        recordManager.changePly(1);
-        expect(recordManager.record.current.comment).toBe(testCase.expectedComments[0]);
-        recordManager.changePly(2);
-        expect(recordManager.record.current.comment).toBe(testCase.expectedComments[1]);
+        for (let i = 0; i < testCase.expectedComments.length; i++) {
+          recordManager.changePly(i + 1);
+          expect(recordManager.record.current.comment).toBe(testCase.expectedComments[i]);
+        }
       });
     }
   });


### PR DESCRIPTION
# 説明 / Description

#1105 
棋譜を終局から逆順で解析する機能を追加する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated
  - [x] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new "Descending" option in analysis settings with updated multilingual support.
  
- **Refactor**
  - Streamlined analysis processing and unified settings management in the user interface.
  
- **Tests**
  - Enhanced test coverage to validate the new descending order option and improved settings validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->