### PR TITLE
初心者AIに千日手回避処理を追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14391,9 +14391,9 @@
       "license": "0BSD"
     },
     "node_modules/tsshogi": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/tsshogi/-/tsshogi-1.8.0.tgz",
-      "integrity": "sha512-ObIC7NwN9DmHBHYnAqERYYwfHr/E86MDtwg1NZk4LVse4LOSAJphoEmxjr11oZjNqrTq/nCUdFe0eJM1TH58Hw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/tsshogi/-/tsshogi-1.8.1.tgz",
+      "integrity": "sha512-HG5KBM6nrxh028bWqRPLHq/ADuxCNkfUoWQUaAQXmij/qiLBWa8lffrwaW8E9eg3zlkYs0HmpPcgIzHEVXCJXQ==",
       "license": "MIT"
     },
     "node_modules/type-check": {


### PR DESCRIPTION
# 説明 / Description

連続王手の千日手で負けるケースが思った以上に発生するので、同一局面を回避させる。
ただし、1手先を確認するだけなので相手の手で千日手に至るケースを完全に防げるわけではない。

#996 

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced move validation now includes checks to prevent repeated moves, leading to more robust gameplay.
  
- **Refactor**
  - Streamlined internal move processing for improved consistency and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->