### PR TITLE
連続対局結果に手番ごとの勝ち数を追加

### DIFF
--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -111,6 +111,8 @@ export const en: Texts = {
   gameProgress: "Game Progress",
   allGamesCompleted: "All Games Completed",
   wins: "Wins",
+  winsOnBlack: "Wins(Black)",
+  winsOnWhite: "Wins(White)",
   draws: "Draws",
   validGames: "Valid Games",
   invalidGames: "Invalid Games",

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -111,6 +111,8 @@ export const ja: Texts = {
   gameProgress: "対局の経過",
   allGamesCompleted: "連続対局終了",
   wins: "勝ち数",
+  winsOnBlack: "勝ち数(先手)",
+  winsOnWhite: "勝ち数(後手)",
   draws: "引き分け",
   validGames: "有効対局数",
   invalidGames: "無効対局数",

--- a/src/common/i18n/locales/vi.ts
+++ b/src/common/i18n/locales/vi.ts
@@ -111,6 +111,8 @@ export const vi: Texts = {
   gameProgress: "Tiến triển ván đấu",
   allGamesCompleted: "Tất cả các ván đã kết thúc",
   wins: "Thắng",
+  winsOnBlack: "勝ち数(先手)", // TODO: Translate
+  winsOnWhite: "勝ち数(後手)", // TODO: Translate
   draws: "Hòa",
   validGames: "Ván hợp lệ",
   invalidGames: "Ván không hợp lệ",

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -108,6 +108,8 @@ export const zh_tw: Texts = {
   gameProgress: "對局過程",
   allGamesCompleted: "連續對局結束",
   wins: "勝利數目",
+  winsOnBlack: "勝ち数(先手)", // TODO: Translate
+  winsOnWhite: "勝ち数(後手)", // TODO: Translate
   draws: "平手數目",
   validGames: "有效對局數",
   invalidGames: "無效對局數",

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -106,6 +106,8 @@ export type Texts = {
   gameProgress: string;
   allGamesCompleted: string;
   wins: string;
+  winsOnBlack: string;
+  winsOnWhite: string;
   draws: string;
   validGames: string;
   invalidGames: string;

--- a/src/renderer/store/game.ts
+++ b/src/renderer/store/game.ts
@@ -43,6 +43,8 @@ enum GameState {
 export type PlayerGameResults = {
   name: string;
   win: number;
+  winBlack: number;
+  winWhite: number;
 };
 
 export type GameResults = {
@@ -111,8 +113,8 @@ type ErrorCallback = (e: unknown) => void;
 
 function newGameResults(name1: string, name2: string): GameResults {
   return {
-    player1: { name: name1, win: 0 },
-    player2: { name: name2, win: 0 },
+    player1: { name: name1, win: 0, winBlack: 0, winWhite: 0 },
+    player2: { name: name2, win: 0, winBlack: 0, winWhite: 0 },
     draw: 0,
     invalid: 0,
     total: 0,
@@ -689,9 +691,11 @@ export class GameManager {
     switch (gameResult) {
       case GameResult.WIN:
         this._results.player1.win++;
+        this._results.player1.winBlack++;
         break;
       case GameResult.LOSE:
         this._results.player2.win++;
+        this._results.player2.winWhite++;
         break;
       case GameResult.DRAW:
         this._results.draw++;

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -85,11 +85,19 @@ function getMessageAttachmentsByGameResults(results: GameResults): Attachment[] 
       items: [
         {
           text: results.player1.name,
-          children: [`${t.wins}: ${results.player1.win}`],
+          children: [
+            `${t.wins}: ${results.player1.win}`,
+            `${t.winsOnBlack}: ${results.player1.winBlack}`,
+            `${t.winsOnWhite}: ${results.player1.winWhite}`,
+          ],
         },
         {
           text: results.player2.name,
-          children: [`${t.wins}: ${results.player2.win}`],
+          children: [
+            `${t.wins}: ${results.player2.win}`,
+            `${t.winsOnBlack}: ${results.player2.winBlack}`,
+            `${t.winsOnWhite}: ${results.player2.winWhite}`,
+          ],
         },
         { text: `${t.draws}: ${results.draw}` },
         { text: `${t.validGames}: ${results.total - results.invalid}` },

--- a/src/tests/renderer/store/game.spec.ts
+++ b/src/tests/renderer/store/game.spec.ts
@@ -83,8 +83,8 @@ describe("store/game", () => {
 
   it("statistics/case1", async () => {
     const statistics = calculateGameStatistics({
-      player1: { name: "Player1", win: 15 },
-      player2: { name: "Player2", win: 3 },
+      player1: { name: "Player1", win: 15, winBlack: 8, winWhite: 7 },
+      player2: { name: "Player2", win: 3, winBlack: 1, winWhite: 2 },
       draw: 2,
       invalid: 1,
       total: 21,
@@ -103,8 +103,8 @@ describe("store/game", () => {
 
   it("statistics/case2", async () => {
     const statistics = calculateGameStatistics({
-      player1: { name: "Player1", win: 9 },
-      player2: { name: "Player2", win: 1 },
+      player1: { name: "Player1", win: 9, winBlack: 5, winWhite: 4 },
+      player2: { name: "Player2", win: 1, winBlack: 0, winWhite: 1 },
       draw: 2,
       invalid: 1,
       total: 13,
@@ -123,8 +123,8 @@ describe("store/game", () => {
 
   it("statistics/case3", async () => {
     const statistics = calculateGameStatistics({
-      player1: { name: "Player1", win: 76 },
-      player2: { name: "Player2", win: 21 },
+      player1: { name: "Player1", win: 76, winBlack: 31, winWhite: 45 },
+      player2: { name: "Player2", win: 21, winBlack: 9, winWhite: 12 },
       draw: 2,
       invalid: 1,
       total: 100,
@@ -288,8 +288,8 @@ describe("store/game", () => {
       mockPlayerBuilder,
       (gameResults, specialMoveType) => {
         expect(gameResults).toStrictEqual({
-          player1: { name: "USI Engine 01", win: 1 },
-          player2: { name: "USI Engine 02", win: 0 },
+          player1: { name: "USI Engine 01", win: 1, winBlack: 1, winWhite: 0 },
+          player2: { name: "USI Engine 02", win: 0, winBlack: 0, winWhite: 0 },
           draw: 0,
           invalid: 0,
           total: 1,
@@ -410,8 +410,8 @@ describe("store/game", () => {
       mockPlayerBuilder,
       (gameResults, specialMoveType) => {
         expect(gameResults).toStrictEqual({
-          player1: { name: "USI Engine 01", win: 0 },
-          player2: { name: "USI Engine 02", win: 0 },
+          player1: { name: "USI Engine 01", win: 0, winBlack: 0, winWhite: 0 },
+          player2: { name: "USI Engine 02", win: 0, winBlack: 0, winWhite: 0 },
           draw: 0,
           invalid: 1,
           total: 1,
@@ -486,8 +486,8 @@ describe("store/game", () => {
       mockPlayerBuilder,
       (gameResults, specialMoveType) => {
         expect(gameResults).toStrictEqual({
-          player1: { name: "USI Engine 02", win: 0 },
-          player2: { name: "USI Engine 01", win: 2 },
+          player1: { name: "USI Engine 02", win: 0, winBlack: 0, winWhite: 0 },
+          player2: { name: "USI Engine 01", win: 2, winBlack: 1, winWhite: 1 },
           draw: 0,
           invalid: 0,
           total: 2,
@@ -551,8 +551,8 @@ describe("store/game", () => {
       mockPlayerBuilder,
       (gameResults, specialMoveType) => {
         expect(gameResults).toStrictEqual({
-          player1: { name: "USI Engine 01", win: 2 },
-          player2: { name: "USI Engine 02", win: 0 },
+          player1: { name: "USI Engine 01", win: 2, winBlack: 2, winWhite: 0 },
+          player2: { name: "USI Engine 02", win: 0, winBlack: 0, winWhite: 0 },
           draw: 0,
           invalid: 0,
           total: 2,
@@ -607,8 +607,8 @@ describe("store/game", () => {
       mockPlayerBuilder,
       (gameResults, specialMoveType) => {
         expect(gameResults).toStrictEqual({
-          player1: { name: "USI Engine 01", win: 0 },
-          player2: { name: "USI Engine 02", win: 0 },
+          player1: { name: "USI Engine 01", win: 0, winBlack: 0, winWhite: 0 },
+          player2: { name: "USI Engine 02", win: 0, winBlack: 0, winWhite: 0 },
           draw: 1,
           invalid: 0,
           total: 1,
@@ -664,8 +664,8 @@ describe("store/game", () => {
       mockPlayerBuilder,
       (gameResults, specialMoveType) => {
         expect(gameResults).toStrictEqual({
-          player1: { name: "USI Engine 01", win: 0 },
-          player2: { name: "USI Engine 02", win: 0 },
+          player1: { name: "USI Engine 01", win: 0, winBlack: 0, winWhite: 0 },
+          player2: { name: "USI Engine 02", win: 0, winBlack: 0, winWhite: 0 },
           draw: 1,
           invalid: 0,
           total: 1,
@@ -721,8 +721,8 @@ describe("store/game", () => {
       mockPlayerBuilder,
       (gameResults, specialMoveType) => {
         expect(gameResults).toStrictEqual({
-          player1: { name: "USI Engine 01", win: 1 },
-          player2: { name: "USI Engine 02", win: 0 },
+          player1: { name: "USI Engine 01", win: 1, winBlack: 1, winWhite: 0 },
+          player2: { name: "USI Engine 02", win: 0, winBlack: 0, winWhite: 0 },
           draw: 0,
           invalid: 0,
           total: 1,
@@ -763,8 +763,8 @@ describe("store/game", () => {
       mockPlayerBuilder,
       (gameResults, specialMoveType) => {
         expect(gameResults).toStrictEqual({
-          player1: { name: "USI Engine 01", win: 0 },
-          player2: { name: "USI Engine 02", win: 1 },
+          player1: { name: "USI Engine 01", win: 0, winBlack: 0, winWhite: 0 },
+          player2: { name: "USI Engine 02", win: 1, winBlack: 0, winWhite: 1 },
           draw: 0,
           invalid: 0,
           total: 1,
@@ -805,8 +805,8 @@ describe("store/game", () => {
       mockPlayerBuilder,
       (gameResults, specialMoveType) => {
         expect(gameResults).toStrictEqual({
-          player1: { name: "USI Engine 01", win: 0 },
-          player2: { name: "USI Engine 02", win: 1 },
+          player1: { name: "USI Engine 01", win: 0, winBlack: 0, winWhite: 0 },
+          player2: { name: "USI Engine 02", win: 1, winBlack: 0, winWhite: 1 },
           draw: 0,
           invalid: 0,
           total: 1,
@@ -846,8 +846,8 @@ describe("store/game", () => {
       mockPlayerBuilder,
       (gameResults, specialMoveType) => {
         expect(gameResults).toStrictEqual({
-          player1: { name: "USI Engine 01", win: 1 },
-          player2: { name: "USI Engine 02", win: 0 },
+          player1: { name: "USI Engine 01", win: 1, winBlack: 1, winWhite: 0 },
+          player2: { name: "USI Engine 02", win: 0, winBlack: 0, winWhite: 0 },
           draw: 0,
           invalid: 0,
           total: 1,
@@ -887,8 +887,8 @@ describe("store/game", () => {
       mockPlayerBuilder,
       (gameResults, specialMoveType) => {
         expect(gameResults).toStrictEqual({
-          player1: { name: "USI Engine 01", win: 0 },
-          player2: { name: "USI Engine 02", win: 1 },
+          player1: { name: "USI Engine 01", win: 0, winBlack: 0, winWhite: 0 },
+          player2: { name: "USI Engine 02", win: 1, winBlack: 0, winWhite: 1 },
           draw: 0,
           invalid: 0,
           total: 1,
@@ -925,8 +925,8 @@ describe("store/game", () => {
       mockPlayerBuilder,
       (gameResults, specialMoveType) => {
         expect(gameResults).toStrictEqual({
-          player1: { name: "USI Engine 01", win: 1 },
-          player2: { name: "USI Engine 02", win: 0 },
+          player1: { name: "USI Engine 01", win: 1, winBlack: 1, winWhite: 0 },
+          player2: { name: "USI Engine 02", win: 0, winBlack: 0, winWhite: 0 },
           draw: 0,
           invalid: 0,
           total: 1,
@@ -997,8 +997,8 @@ describe("store/game", () => {
       mockPlayerBuilder,
       (gameResults, specialMoveType) => {
         expect(gameResults).toStrictEqual({
-          player1: { name: "USI Engine 02", win: 2 },
-          player2: { name: "USI Engine 01", win: 2 },
+          player1: { name: "USI Engine 02", win: 2, winBlack: 2, winWhite: 0 },
+          player2: { name: "USI Engine 01", win: 2, winBlack: 2, winWhite: 0 },
           draw: 0,
           invalid: 0,
           total: 4,


### PR DESCRIPTION
# 説明 / Description

#1135 

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated
  - [x] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced game statistics now display separate win counts for Black and White, providing players with a more detailed view of their performance.
  - Updated localizations in multiple languages include the new win labels for Black and White, ensuring clear and consistent presentation across supported regions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->