### PR TITLE
棋譜ファイル関連機能の強化

### DIFF
--- a/src/command/usi-csa-bridge/index.ts
+++ b/src/command/usi-csa-bridge/index.ts
@@ -193,13 +193,13 @@ async function main() {
   const returnCode = returnCodeName() === "CRLF" ? "\r\n" : "\n";
 
   function onSaveRecord() {
-    const fileName = generateRecordFileName(
-      recordManager.record.metadata,
-      recordFileNameTemplate() ||
+    const fileName = generateRecordFileName(recordManager.record.metadata, {
+      template:
+        recordFileNameTemplate() ||
         cliSettings.recordFileNameTemplate ||
         defaultRecordFileNameTemplate,
-      recordFileFormat() || cliSettings.recordFileFormat || RecordFileFormat.KIF,
-    );
+      extension: recordFileFormat() || cliSettings.recordFileFormat || RecordFileFormat.KIF,
+    });
     const dir = recordDir();
     const filePath = path.join(dir, fileName);
     fs.promises

--- a/src/common/file/history.ts
+++ b/src/common/file/history.ts
@@ -22,6 +22,10 @@ export type BackupEntry = {
 
 export type BackupEntryV2 = {
   class: HistoryClass.BACKUP_V2;
+  title?: string;
+  blackPlayerName?: string;
+  whitePlayerName?: string;
+  ply?: number;
   kif: string;
 };
 

--- a/src/common/helpers/metadata.ts
+++ b/src/common/helpers/metadata.ts
@@ -1,0 +1,22 @@
+import { ImmutableRecordMetadata, RecordMetadataKey } from "tsshogi";
+
+export function getDateStringFromMetadata(metadata: ImmutableRecordMetadata): string | undefined {
+  const datetime =
+    metadata.getStandardMetadata(RecordMetadataKey.START_DATETIME) ||
+    metadata.getStandardMetadata(RecordMetadataKey.DATE);
+  if (datetime) {
+    return datetime.trim().replaceAll(" ", "_").replaceAll("/", "").replaceAll(":", "");
+  }
+}
+
+export function getRecordTitleFromMetadata(metadata: ImmutableRecordMetadata): string | undefined {
+  return (
+    metadata.getStandardMetadata(RecordMetadataKey.TITLE) ||
+    metadata.getStandardMetadata(RecordMetadataKey.TOURNAMENT) ||
+    metadata.getStandardMetadata(RecordMetadataKey.OPUS_NAME) ||
+    metadata.getStandardMetadata(RecordMetadataKey.OPUS_NO) ||
+    metadata.getStandardMetadata(RecordMetadataKey.PLACE) ||
+    metadata.getStandardMetadata(RecordMetadataKey.POSTED_ON) ||
+    metadata.getStandardMetadata(RecordMetadataKey.AUTHOR)
+  );
+}

--- a/src/renderer/helpers/path.ts
+++ b/src/renderer/helpers/path.ts
@@ -1,11 +1,7 @@
-import {
-  RecordMetadataKey,
-  getBlackPlayerName,
-  getWhitePlayerName,
-  ImmutableRecordMetadata,
-} from "tsshogi";
+import { getBlackPlayerName, getWhitePlayerName, ImmutableRecordMetadata } from "tsshogi";
 import { getDateString } from "@/common/helpers/datetime";
 import { defaultRecordFileNameTemplate } from "@/common/file/path";
+import { getDateStringFromMetadata, getRecordTitleFromMetadata } from "@/common/helpers/metadata";
 
 export function basename(path: string): string {
   return path.substring(Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\")) + 1);
@@ -37,31 +33,14 @@ function escapePath(path: string): string {
   return path.replaceAll(/[<>:"/\\|?*]/g, "_");
 }
 
-function getDateStringByMeta(metadata: ImmutableRecordMetadata): string {
-  const datetime =
-    metadata.getStandardMetadata(RecordMetadataKey.START_DATETIME) ||
-    metadata.getStandardMetadata(RecordMetadataKey.DATE);
-  if (datetime) {
-    return datetime.trim().replaceAll(" ", "_").replaceAll("/", "").replaceAll(":", "");
-  }
-  return getDateString().replaceAll("/", "");
-}
-
 export function generateRecordFileName(
   metadata: ImmutableRecordMetadata,
   template?: string,
   extension?: string,
 ): string {
   // get metadata
-  const datetime = getDateStringByMeta(metadata);
-  const title =
-    metadata.getStandardMetadata(RecordMetadataKey.TITLE) ||
-    metadata.getStandardMetadata(RecordMetadataKey.TOURNAMENT) ||
-    metadata.getStandardMetadata(RecordMetadataKey.OPUS_NAME) ||
-    metadata.getStandardMetadata(RecordMetadataKey.OPUS_NO) ||
-    metadata.getStandardMetadata(RecordMetadataKey.PLACE) ||
-    metadata.getStandardMetadata(RecordMetadataKey.POSTED_ON) ||
-    metadata.getStandardMetadata(RecordMetadataKey.AUTHOR);
+  const datetime = getDateStringFromMetadata(metadata) || getDateString().replaceAll("/", "");
+  const title = getRecordTitleFromMetadata(metadata);
   const sente = getBlackPlayerName(metadata);
   const gote = getWhitePlayerName(metadata);
   const hex5 = Math.floor(Math.random() * 0x100000)

--- a/src/renderer/helpers/path.ts
+++ b/src/renderer/helpers/path.ts
@@ -33,10 +33,15 @@ function escapePath(path: string): string {
   return path.replaceAll(/[<>:"/\\|?*]/g, "_");
 }
 
+type RecordFileNameOptions = {
+  ply?: number;
+  template?: string;
+  extension?: string;
+};
+
 export function generateRecordFileName(
   metadata: ImmutableRecordMetadata,
-  template?: string,
-  extension?: string,
+  options: RecordFileNameOptions = {},
 ): string {
   // get metadata
   const datetime = getDateStringFromMetadata(metadata) || getDateString().replaceAll("/", "");
@@ -54,6 +59,7 @@ export function generateRecordFileName(
     title: title || "",
     sente: sente || "",
     gote: gote || "",
+    ply: options.ply !== undefined ? options.ply.toString() : "",
     hex5,
   };
   for (const key in params) {
@@ -63,15 +69,15 @@ export function generateRecordFileName(
   }
 
   // generate file name
-  let ret = template || defaultRecordFileNameTemplate;
+  let ret = options.template || defaultRecordFileNameTemplate;
   ret = escapePath(ret);
   for (const key in params) {
     const value = params[key];
     ret = escapePath(ret.replaceAll("{" + key + "}", value));
   }
   ret = ret.trim();
-  if (extension) {
-    ret = ret + (extension.startsWith(".") ? extension : "." + extension);
+  if (options.extension) {
+    ret = ret + (options.extension.startsWith(".") ? options.extension : "." + options.extension);
   } else {
     ret = ret + ".kif";
   }

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -743,11 +743,11 @@ class Store {
 
   private onSaveRecord(): void {
     const appSettings = useAppSettings();
-    const fname = generateRecordFileName(
-      this.recordManager.record.metadata,
-      appSettings.recordFileNameTemplate,
-      appSettings.defaultRecordFileFormat,
-    );
+    const fname = generateRecordFileName(this.recordManager.record.metadata, {
+      ply: this.recordManager.record.length,
+      template: appSettings.recordFileNameTemplate,
+      extension: appSettings.defaultRecordFileFormat,
+    });
     const path = join(appSettings.autoSaveDirectory, fname);
     this.saveRecordByPath(path).catch((e) => {
       useErrorStore().add(e);
@@ -1233,11 +1233,11 @@ class Store {
         const appSettings = useAppSettings();
         const defaultPath =
           (!options?.format && path) ||
-          generateRecordFileName(
-            this.recordManager.record.metadata,
-            appSettings.recordFileNameTemplate,
-            options?.format || appSettings.defaultRecordFileFormat,
-          );
+          generateRecordFileName(this.recordManager.record.metadata, {
+            ply: this.recordManager.record.length,
+            template: appSettings.recordFileNameTemplate,
+            extension: options?.format || appSettings.defaultRecordFileFormat,
+          });
         return api.showSaveRecordDialog(defaultPath);
       })
       .then((path) => {

--- a/src/renderer/view/dialog/RecordFileHistoryDialog.vue
+++ b/src/renderer/view/dialog/RecordFileHistoryDialog.vue
@@ -36,6 +36,18 @@
           <div v-if="entry.class === HistoryClass.USER" class="file-path">
             {{ entry.userFilePath }}
           </div>
+          <div
+            v-if="
+              entry.class === HistoryClass.BACKUP_V2 &&
+              (entry.title || entry.blackPlayerName || entry.whitePlayerName || entry.ply)
+            "
+            class="file-path"
+          >
+            <span v-if="entry.title">{{ entry.title }} / </span>
+            <span v-if="entry.blackPlayerName">{{ entry.blackPlayerName }} / </span>
+            <span v-if="entry.whitePlayerName">{{ entry.whitePlayerName }} / </span>
+            <span>{{ entry.ply || 0 }}手</span>
+          </div>
         </div>
       </div>
       <div class="main-buttons">

--- a/src/tests/renderer/helpers/path.spec.ts
+++ b/src/tests/renderer/helpers/path.spec.ts
@@ -87,10 +87,13 @@ describe("helpers/path", () => {
     meta.setStandardMetadata(RecordMetadataKey.BLACK_NAME, "先手の人");
     meta.setStandardMetadata(RecordMetadataKey.WHITE_NAME, "後手の人");
     expect(
-      generateRecordFileName(meta, "棋譜-{datetime}{_title}{_sente}{_gote}-{hex5}", ".csa"),
+      generateRecordFileName(meta, {
+        template: "棋譜-{datetime}{_title}{_sente}{_gote}-{hex5}",
+        extension: ".csa",
+      }),
     ).toMatch(/^棋譜-20220101_My New Game_先手の人_後手の人-[0-9A-F]{5}\.csa$/);
-    expect(generateRecordFileName(meta, "{title_}{sente_}{gote_}{hex5}", "jkf")).toMatch(
-      /^My New Game_先手の人_後手の人_[0-9A-F]{5}\.jkf$/,
-    );
+    expect(
+      generateRecordFileName(meta, { template: "{title_}{sente_}{gote_}{hex5}", extension: "jkf" }),
+    ).toMatch(/^My New Game_先手の人_後手の人_[0-9A-F]{5}\.jkf$/);
   });
 });


### PR DESCRIPTION
# 説明 / Description

#1162 

- 棋譜ファイル名テンプレートに手数を含められるようにする。
- 自動バックアップの一覧に表題や対局者名、手数を表示する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Backup history entries now include additional details such as record title, player names, and move count for improved clarity.
  - Record file naming has been enhanced with a streamlined, customizable configuration.
  - Metadata extraction now covers a broader set of fields, ensuring more consistent display of record dates and titles.

- **Refactor**
  - Consolidated backup entry processing and file naming parameters to simplify configuration and improve maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->