### PR TITLE
Fix not to include special move to ply

### DIFF
--- a/src/command/usi-csa-bridge/index.ts
+++ b/src/command/usi-csa-bridge/index.ts
@@ -193,7 +193,7 @@ async function main() {
   const returnCode = returnCodeName() === "CRLF" ? "\r\n" : "\n";
 
   function onSaveRecord() {
-    const fileName = generateRecordFileName(recordManager.record.metadata, {
+    const fileName = generateRecordFileName(recordManager.record, {
       template:
         recordFileNameTemplate() ||
         cliSettings.recordFileNameTemplate ||

--- a/src/renderer/helpers/path.ts
+++ b/src/renderer/helpers/path.ts
@@ -1,4 +1,4 @@
-import { getBlackPlayerName, getWhitePlayerName, ImmutableRecordMetadata } from "tsshogi";
+import { getBlackPlayerName, getWhitePlayerName, ImmutableRecord, Move } from "tsshogi";
 import { getDateString } from "@/common/helpers/datetime";
 import { defaultRecordFileNameTemplate } from "@/common/file/path";
 import { getDateStringFromMetadata, getRecordTitleFromMetadata } from "@/common/helpers/metadata";
@@ -34,16 +34,16 @@ function escapePath(path: string): string {
 }
 
 type RecordFileNameOptions = {
-  ply?: number;
   template?: string;
   extension?: string;
 };
 
 export function generateRecordFileName(
-  metadata: ImmutableRecordMetadata,
+  record: ImmutableRecord,
   options: RecordFileNameOptions = {},
 ): string {
   // get metadata
+  const metadata = record.metadata;
   const datetime = getDateStringFromMetadata(metadata) || getDateString().replaceAll("/", "");
   const title = getRecordTitleFromMetadata(metadata);
   const sente = getBlackPlayerName(metadata);
@@ -54,12 +54,16 @@ export function generateRecordFileName(
     .padStart(5, "0");
 
   // build parameter map
+  let ply = 0;
+  for (let node = record.first.next; node && node.move instanceof Move; node = node.next) {
+    ply = node.ply;
+  }
   const params: { [key: string]: string } = {
     datetime,
     title: title || "",
     sente: sente || "",
     gote: gote || "",
-    ply: options.ply !== undefined ? options.ply.toString() : "",
+    ply: ply.toString(),
     hex5,
   };
   for (const key in params) {

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -743,8 +743,7 @@ class Store {
 
   private onSaveRecord(): void {
     const appSettings = useAppSettings();
-    const fname = generateRecordFileName(this.recordManager.record.metadata, {
-      ply: this.recordManager.record.length,
+    const fname = generateRecordFileName(this.recordManager.record, {
       template: appSettings.recordFileNameTemplate,
       extension: appSettings.defaultRecordFileFormat,
     });
@@ -1233,8 +1232,7 @@ class Store {
         const appSettings = useAppSettings();
         const defaultPath =
           (!options?.format && path) ||
-          generateRecordFileName(this.recordManager.record.metadata, {
-            ply: this.recordManager.record.length,
+          generateRecordFileName(this.recordManager.record, {
             template: appSettings.recordFileNameTemplate,
             extension: options?.format || appSettings.defaultRecordFileFormat,
           });

--- a/src/tests/renderer/helpers/path.spec.ts
+++ b/src/tests/renderer/helpers/path.spec.ts
@@ -1,5 +1,5 @@
 import { generateRecordFileName, dirname, join, basename } from "@/renderer/helpers/path";
-import { RecordMetadata, RecordMetadataKey } from "tsshogi";
+import { Move, Record, RecordMetadataKey, SpecialMoveType } from "tsshogi";
 
 describe("helpers/path", () => {
   it("basename", () => {
@@ -22,78 +22,91 @@ describe("helpers/path", () => {
   });
 
   it("generateRecordFileName/emptyMetadata", () => {
-    const meta = new RecordMetadata();
-    expect(generateRecordFileName(meta)).toMatch(/^[0-9]{8}\.kif$/);
+    const record = new Record();
+    expect(generateRecordFileName(record)).toMatch(/^[0-9]{8}\.kif$/);
   });
 
   it("generateRecordFileName/withDate", () => {
-    const meta = new RecordMetadata();
-    meta.setStandardMetadata(RecordMetadataKey.DATE, "2022/09/30");
-    expect(generateRecordFileName(meta)).toBe("20220930.kif");
+    const record = new Record();
+    record.metadata.setStandardMetadata(RecordMetadataKey.DATE, "2022/09/30");
+    expect(generateRecordFileName(record)).toBe("20220930.kif");
   });
 
   it("generateRecordFileName/withStartDateTime", () => {
-    const meta = new RecordMetadata();
-    meta.setStandardMetadata(RecordMetadataKey.DATE, "2022/01/01");
-    meta.setStandardMetadata(RecordMetadataKey.START_DATETIME, "2022/01/02 11:30");
-    expect(generateRecordFileName(meta)).toBe("20220102_1130.kif");
+    const record = new Record();
+    record.metadata.setStandardMetadata(RecordMetadataKey.DATE, "2022/01/01");
+    record.metadata.setStandardMetadata(RecordMetadataKey.START_DATETIME, "2022/01/02 11:30");
+    expect(generateRecordFileName(record)).toBe("20220102_1130.kif");
   });
 
   it("generateRecordFileName/withTitle", () => {
-    const meta = new RecordMetadata();
-    meta.setStandardMetadata(RecordMetadataKey.DATE, "2022/01/01");
-    meta.setStandardMetadata(RecordMetadataKey.START_DATETIME, "2022/01/02 11:30");
-    meta.setStandardMetadata(RecordMetadataKey.TITLE, "My New Game");
-    expect(generateRecordFileName(meta)).toBe("20220102_1130_My New Game.kif");
+    const record = new Record();
+    record.metadata.setStandardMetadata(RecordMetadataKey.DATE, "2022/01/01");
+    record.metadata.setStandardMetadata(RecordMetadataKey.START_DATETIME, "2022/01/02 11:30");
+    record.metadata.setStandardMetadata(RecordMetadataKey.TITLE, "My New Game");
+    expect(generateRecordFileName(record)).toBe("20220102_1130_My New Game.kif");
   });
 
   it("generateRecordFileName/withTournament", () => {
-    const meta = new RecordMetadata();
-    meta.setStandardMetadata(RecordMetadataKey.DATE, "2022/01/01");
-    meta.setStandardMetadata(RecordMetadataKey.START_DATETIME, "2022/01/02 11:30");
-    meta.setStandardMetadata(RecordMetadataKey.TOURNAMENT, "My Tournament");
-    expect(generateRecordFileName(meta)).toBe("20220102_1130_My Tournament.kif");
+    const record = new Record();
+    record.metadata.setStandardMetadata(RecordMetadataKey.DATE, "2022/01/01");
+    record.metadata.setStandardMetadata(RecordMetadataKey.START_DATETIME, "2022/01/02 11:30");
+    record.metadata.setStandardMetadata(RecordMetadataKey.TOURNAMENT, "My Tournament");
+    expect(generateRecordFileName(record)).toBe("20220102_1130_My Tournament.kif");
   });
 
   it("generateRecordFileName/withPlayerName", () => {
-    const meta = new RecordMetadata();
-    meta.setStandardMetadata(RecordMetadataKey.DATE, "2022/01/01");
-    meta.setStandardMetadata(RecordMetadataKey.BLACK_NAME, "先手の人");
-    meta.setStandardMetadata(RecordMetadataKey.WHITE_NAME, "後手の人");
-    expect(generateRecordFileName(meta)).toBe("20220101_先手の人_後手の人.kif");
+    const record = new Record();
+    record.metadata.setStandardMetadata(RecordMetadataKey.DATE, "2022/01/01");
+    record.metadata.setStandardMetadata(RecordMetadataKey.BLACK_NAME, "先手の人");
+    record.metadata.setStandardMetadata(RecordMetadataKey.WHITE_NAME, "後手の人");
+    expect(generateRecordFileName(record)).toBe("20220101_先手の人_後手の人.kif");
   });
 
   it("generateRecordFileName/withTitleAndPlayerName", () => {
-    const meta = new RecordMetadata();
-    meta.setStandardMetadata(RecordMetadataKey.DATE, "2022/01/01");
-    meta.setStandardMetadata(RecordMetadataKey.TITLE, "My New Game");
-    meta.setStandardMetadata(RecordMetadataKey.BLACK_NAME, "先手の人");
-    meta.setStandardMetadata(RecordMetadataKey.WHITE_NAME, "後手の人");
-    expect(generateRecordFileName(meta)).toBe("20220101_My New Game_先手の人_後手の人.kif");
+    const record = new Record();
+    record.metadata.setStandardMetadata(RecordMetadataKey.DATE, "2022/01/01");
+    record.metadata.setStandardMetadata(RecordMetadataKey.TITLE, "My New Game");
+    record.metadata.setStandardMetadata(RecordMetadataKey.BLACK_NAME, "先手の人");
+    record.metadata.setStandardMetadata(RecordMetadataKey.WHITE_NAME, "後手の人");
+    expect(generateRecordFileName(record)).toBe("20220101_My New Game_先手の人_後手の人.kif");
   });
 
   it("generateRecordFileName/escape", () => {
-    const meta = new RecordMetadata();
-    meta.setStandardMetadata(RecordMetadataKey.DATE, "2022/01/01");
-    meta.setStandardMetadata(RecordMetadataKey.BLACK_NAME, "Foo:Bar<Baz");
-    meta.setStandardMetadata(RecordMetadataKey.WHITE_NAME, "Qux|Quux>Corge");
-    expect(generateRecordFileName(meta)).toBe("20220101_Foo_Bar_Baz_Qux_Quux_Corge.kif");
+    const record = new Record();
+    record.metadata.setStandardMetadata(RecordMetadataKey.DATE, "2022/01/01");
+    record.metadata.setStandardMetadata(RecordMetadataKey.BLACK_NAME, "Foo:Bar<Baz");
+    record.metadata.setStandardMetadata(RecordMetadataKey.WHITE_NAME, "Qux|Quux>Corge");
+    expect(generateRecordFileName(record)).toBe("20220101_Foo_Bar_Baz_Qux_Quux_Corge.kif");
   });
 
   it("generateRecordFileName/customTemplate", () => {
-    const meta = new RecordMetadata();
-    meta.setStandardMetadata(RecordMetadataKey.DATE, "2022/01/01");
-    meta.setStandardMetadata(RecordMetadataKey.TITLE, "My New Game");
-    meta.setStandardMetadata(RecordMetadataKey.BLACK_NAME, "先手の人");
-    meta.setStandardMetadata(RecordMetadataKey.WHITE_NAME, "後手の人");
+    const record = new Record();
+    record.metadata.setStandardMetadata(RecordMetadataKey.DATE, "2022/01/01");
+    record.metadata.setStandardMetadata(RecordMetadataKey.TITLE, "My New Game");
+    record.metadata.setStandardMetadata(RecordMetadataKey.BLACK_NAME, "先手の人");
+    record.metadata.setStandardMetadata(RecordMetadataKey.WHITE_NAME, "後手の人");
+    record.append(record.position.createMoveByUSI("7g7f") as Move);
+    record.append(record.position.createMoveByUSI("3c3d") as Move);
+    record.append(record.position.createMoveByUSI("2g2f") as Move);
+    record.append(SpecialMoveType.RESIGN);
     expect(
-      generateRecordFileName(meta, {
+      generateRecordFileName(record, {
         template: "棋譜-{datetime}{_title}{_sente}{_gote}-{hex5}",
         extension: ".csa",
       }),
     ).toMatch(/^棋譜-20220101_My New Game_先手の人_後手の人-[0-9A-F]{5}\.csa$/);
     expect(
-      generateRecordFileName(meta, { template: "{title_}{sente_}{gote_}{hex5}", extension: "jkf" }),
+      generateRecordFileName(record, {
+        template: "{title_}{sente_}{gote_}{hex5}",
+        extension: "jkf",
+      }),
     ).toMatch(/^My New Game_先手の人_後手の人_[0-9A-F]{5}\.jkf$/);
+    expect(
+      generateRecordFileName(record, {
+        template: "{title_}{sente_}{gote_}{ply}手",
+        extension: ".kifu",
+      }),
+    ).toMatch(/^My New Game_先手の人_後手の人_3手.kifu$/);
   });
 });


### PR DESCRIPTION
# 説明 / Description

#1162 

ファイル名テンプレートの `ply` に入る値を修正する。

- 特別な指し手を含めない。
- 常に本譜の手数を使用する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced the record saving process so that file names are now generated using the complete record data, resulting in increased accuracy and consistency.
- **Tests**
  - Updated tests to verify the improved file naming flow, ensuring that the saved records reflect the new, more comprehensive naming method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->