### PR TITLE
CSA通信対局でエンジンが起動に失敗すると「対局者の準備を待っています」の表示が消えない問題を修正

### DIFF
--- a/src/renderer/store/csa.ts
+++ b/src/renderer/store/csa.ts
@@ -171,9 +171,14 @@ export class CSAGameManager {
     this.playerBuilder = playerBuilder;
     this.repeat = 0;
     // プレイヤーを初期化する。
-    this.player = await this.playerBuilder.build(this._settings.player, (info) =>
-      this.recordManager.updateSearchInfo(SearchInfoSenderType.OPPONENT, info),
-    );
+    try {
+      this.player = await this.playerBuilder.build(this._settings.player, (info) =>
+        this.recordManager.updateSearchInfo(SearchInfoSenderType.OPPONENT, info),
+      );
+    } catch (e) {
+      this._state = CSAGameState.OFFLINE;
+      throw e;
+    }
     // サーバーへのログインと対局開始を試みる。
     // NOTICE: エラーの場合は自動的にリトライするのでこの関数の呼び元にはエラーを伝搬しない。
     this.doLogin().catch(this.onError);

--- a/src/tests/mock/player.ts
+++ b/src/tests/mock/player.ts
@@ -68,3 +68,9 @@ export function createMockPlayerBuilder(playerMap: { [uri: string]: Player }) {
     }),
   };
 }
+
+export function createErrorPlayerBuilder() {
+  return {
+    build: vi.fn().mockImplementation(() => Promise.reject(new Error("failed to create player"))),
+  };
+}


### PR DESCRIPTION
# 説明 / Description

#1168

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced error management during player login to ensure the game reliably transitions to offline mode when initialization issues occur.
  
- **Tests**
  - Added test scenarios that simulate error conditions during login, confirming that game progression is halted appropriately in case of failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->