### PR TITLE
通信対局でエンジンを再起動する設定の場合に起動がタイムアウトすると再試行されない問題を修正

### DIFF
--- a/src/renderer/store/csa.ts
+++ b/src/renderer/store/csa.ts
@@ -192,9 +192,15 @@ export class CSAGameManager {
         await this.player.close();
         this.player = undefined;
       }
-      this.player = await this.playerBuilder.build(this._settings.player, (info) =>
-        this.recordManager.updateSearchInfo(SearchInfoSenderType.OPPONENT, info),
-      );
+      try {
+        this.player = await this.playerBuilder.build(this._settings.player, (info) =>
+          this.recordManager.updateSearchInfo(SearchInfoSenderType.OPPONENT, info),
+        );
+      } catch (e) {
+        this._state = CSAGameState.LOGIN_FAILED;
+        this.close(ReloginBehavior.RELOGIN_WITH_INTERVAL);
+        throw e;
+      }
     }
     await this.doLogin();
   }


### PR DESCRIPTION
# 説明 / Description

CSA プロトコルによる通信対局では、連続対局において 1 局ごとにエンジンを再起動するオプションがある。
これを有効化した場合には毎局起動しなおすことになるが、再起動時にタイムアウトが発生すると再試行が実行されない。
加えて、画面が遷移しないままになってしまうため、操作ができなくなる。

初回起動時の動作は #1169 で修正していたが、再起動には適用されていなかった。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling during player relogin to ensure proper game state updates and cleanup if login fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->