### PR TITLE
Use GitHub CLI instead of action-gh-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           path: dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,12 @@ jobs:
         with:
           path: dist
           merge-multiple: true
-      - uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
-        with:
-          name: ShogiHome ${{ github.ref_name }}
-          files: dist/release-*.zip
-          draft: true
+      - name: Create GitHub Release
+        run: |
+          gh release create "$TAG_NAME" \
+            --title "ShogiHome $TAG_NAME" \
+            --draft \
+            dist/release-*.zip
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}


### PR DESCRIPTION
# 説明 / Description

Release の作成に GitHub 公式の CLI コマンドを使用する。

https://docs.github.com/ja/actions/writing-workflows/choosing-what-your-workflow-does/using-github-cli-in-workflows
https://cli.github.com/manual/gh_release_create

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the release workflow to use the GitHub CLI for creating releases, removing reliance on a third-party action. This change does not affect user-facing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->