### PR TITLE
Extract electron-builder raw config from build scripts

### DIFF
--- a/.electron-builder.config.mjs
+++ b/.electron-builder.config.mjs
@@ -1,0 +1,85 @@
+import fs from "node:fs";
+
+/**
+ * @type {import('electron-builder').Configuration}
+ * @see https://www.electron.build/configuration
+ */
+const config = {
+  productName: "ShogiHome",
+  extraMetadata: {
+    main: "dist/packed/background.js",
+  },
+  extends: null,
+  files: [
+    "dist/assets",
+    "dist/arrow",
+    "dist/board",
+    "dist/character",
+    "dist/icon",
+    "dist/piece",
+    "dist/sound",
+    "dist/index.html",
+    "dist/prompt.html",
+    "dist/monitor.html",
+    "dist/layout-manager.html",
+    "dist/packed",
+    "!node_modules/**/*",
+  ],
+  afterPack: function (context) {
+    if (context.electronPlatformName === "darwin") {
+      return;
+    }
+    const localeDir = context.appOutDir + "/locales/";
+    for (const file of fs.readdirSync(localeDir)) {
+      switch (file) {
+        case "en-US.pak":
+        case "ja.pak":
+          break;
+        default:
+          fs.unlinkSync(localeDir + file);
+          break;
+      }
+    }
+  },
+  win: {
+    fileAssociations: {
+      name: "Kifu",
+      ext: ["kif", "kifu", "ki2", "ki2u", "csa", "jkf"],
+    },
+  },
+  nsis: {
+    allowElevation: false,
+    packElevateHelper: false,
+  },
+  mac: {
+    electronLanguages: ["en", "ja"],
+    fileAssociations: {
+      name: "Kifu",
+      ext: ["kif", "kifu", "ki2", "ki2u", "csa", "jkf"],
+    },
+    extendInfo: {
+      CFBundleDocumentTypes: [
+        {
+          CFBundleTypeExtensions: ["kif", "kifu", "ki2", "ki2u", "csa", "jkf"],
+          CFBundleTypeName: "Kifu",
+          CFBundleTypeRole: "Editor",
+          LSHandlerRank: "Owner",
+        },
+      ],
+    },
+  },
+  linux: {
+    target: "AppImage",
+    fileAssociations: [
+      { name: "KIF", ext: "kif" },
+      { name: "KIFU", ext: "kifu" },
+      { name: "KI2", ext: "ki2" },
+      { name: "KI2U", ext: "ki2u" },
+      { name: "CSA", ext: "csa" },
+      { name: "JKF", ext: "jkf" },
+    ],
+  },
+  publish: null,
+};
+
+export default config;

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,90 +1,9 @@
 /* eslint-disable no-console */
 import * as builder from "electron-builder";
-import fs from "node:fs";
+// eslint-disable-next-line no-restricted-imports
+import config from "../.electron-builder.config";
 
 const target = process.argv[2];
-
-/**
- * @type {import('electron-builder').Configuration}
- * @see https://www.electron.build/configuration/configuration
- */
-const config = {
-  productName: "ShogiHome",
-  extraMetadata: {
-    main: "dist/packed/background.js",
-  },
-  extends: null,
-  files: [
-    "dist/assets",
-    "dist/arrow",
-    "dist/board",
-    "dist/character",
-    "dist/icon",
-    "dist/piece",
-    "dist/sound",
-    "dist/index.html",
-    "dist/prompt.html",
-    "dist/monitor.html",
-    "dist/layout-manager.html",
-    "dist/packed",
-    "!node_modules/**/*",
-  ],
-  afterPack: function (context) {
-    if (context.electronPlatformName === "darwin") {
-      return;
-    }
-    const localeDir = context.appOutDir + "/locales/";
-    for (const file of fs.readdirSync(localeDir)) {
-      switch (file) {
-        case "en-US.pak":
-        case "ja.pak":
-          break;
-        default:
-          fs.unlinkSync(localeDir + file);
-          break;
-      }
-    }
-  },
-  win: {
-    fileAssociations: {
-      name: "Kifu",
-      ext: ["kif", "kifu", "ki2", "ki2u", "csa", "jkf"],
-    },
-  },
-  nsis: {
-    allowElevation: false,
-    packElevateHelper: false,
-  },
-  mac: {
-    electronLanguages: ["en", "ja"],
-    fileAssociations: {
-      name: "Kifu",
-      ext: ["kif", "kifu", "ki2", "ki2u", "csa", "jkf"],
-    },
-    extendInfo: {
-      CFBundleDocumentTypes: [
-        {
-          CFBundleTypeExtensions: ["kif", "kifu", "ki2", "ki2u", "csa", "jkf"],
-          CFBundleTypeName: "Kifu",
-          CFBundleTypeRole: "Editor",
-          LSHandlerRank: "Owner",
-        },
-      ],
-    },
-  },
-  linux: {
-    target: "AppImage",
-    fileAssociations: [
-      { name: "KIF", ext: "kif" },
-      { name: "KIFU", ext: "kifu" },
-      { name: "KI2", ext: "ki2" },
-      { name: "KI2U", ext: "ki2u" },
-      { name: "CSA", ext: "csa" },
-      { name: "JKF", ext: "jkf" },
-    ],
-  },
-  publish: null,
-};
 
 switch (target) {
   case "portable":


### PR DESCRIPTION
# 説明 / Description

現在 nixpkgs へのパッケージングPRを出しています。
その際パッケージング側での独自パッチを減らす為に、こちらで electron-builder の純粋な config 部分を別ファイルへ切り出せると大変助かるのですがどうでしょうか？

https://github.com/NixOS/nixpkgs/pull/402203#discussion_r2063055856

背景として、NixOS では一般的に npm install 等でダウンロードしてくる electron をそのままは起動できない(他のディストリビューションでは大体動くであろうAppImageですら、そのままだと起動できません)ということ、また同じメジャーバージョンの electron を使うアプリケーション間では electron 部分を共有することで配布するパッケージのサイズを小さく抑えているといった事情があります。
このため各アプリケーションの build スクリプトをそのままでは流用できないのですが、electron-builder CLI が受け取れる形の config ファイルが上流プロジェクト内にあると、設定の大半を共有してもらうことが可能です。
この形式のファイルを置いてあるプロジェクト例としては podman-desktop が挙げられます。 https://github.com/podman-desktop/podman-desktop/blob/4e3de0df818368b325688da80fc8c4cf27b6ad62/.electron-builder.config.cjs

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [x] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Moved Electron Builder configuration to a dedicated external file for improved organization and maintainability. No changes to the build process or user-facing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->