### PR TITLE
棋譜の操作ボタンの縦幅に下限を設ける改善

### DIFF
--- a/src/renderer/view/primitive/RecordView.vue
+++ b/src/renderer/view/primitive/RecordView.vue
@@ -283,6 +283,7 @@ onUpdated(() => {
 .control {
   width: 100%;
   height: 8.6%;
+  min-height: 23px;
 }
 .control button {
   height: 100%;


### PR DESCRIPTION
# 説明 / Description

カスタムレイアウト利用時に棋譜の操作ボタン `|<` `<` `>` `>|` の縦幅が小さくなりすぎる場合があるので下限値を設ける。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved layout consistency by setting a minimum height for control containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->