### PR TITLE
レーティング差推定の引き分け0.5勝換算を廃止

### DIFF
--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -118,7 +118,6 @@ export const en: Texts = {
   invalidGames: "Invalid Games",
   eloRatingDiff: "Elo Rating Diff",
   ignoreDraws: "Ignore Draws",
-  drawCountAsHalfWins: "Draws Count as Half Wins",
   zValue: "Z Value",
   significance5pc: "5% Significance",
   significance1pc: "1% Significance",

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -118,7 +118,6 @@ export const ja: Texts = {
   invalidGames: "無効対局数",
   eloRatingDiff: "レーティング差",
   ignoreDraws: "引き分け無効",
-  drawCountAsHalfWins: "引き分け0.5勝",
   zValue: "Z値",
   significance5pc: "有意水準5%",
   significance1pc: "有意水準1%",

--- a/src/common/i18n/locales/vi.ts
+++ b/src/common/i18n/locales/vi.ts
@@ -118,7 +118,6 @@ export const vi: Texts = {
   invalidGames: "Ván không hợp lệ",
   eloRatingDiff: "Khoảng cách Elo",
   ignoreDraws: "Bỏ qua ván hòa",
-  drawCountAsHalfWins: "Hòa bằng nửa ván thắng",
   zValue: "Giá trị Z",
   significance5pc: "Độ nổi bật 5%",
   significance1pc: "Độ nổi bật 1%",

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -115,7 +115,6 @@ export const zh_tw: Texts = {
   invalidGames: "無效對局數",
   eloRatingDiff: "等級分相差",
   ignoreDraws: "忽略平手對局",
-  drawCountAsHalfWins: "平手作0.5勝",
   zValue: "Z值",
   significance5pc: "顯著性水準5%",
   significance1pc: "顯著性水準1%",

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -113,7 +113,6 @@ export type Texts = {
   invalidGames: string;
   eloRatingDiff: string;
   ignoreDraws: string;
-  drawCountAsHalfWins: string;
   zValue: string;
   significance5pc: string;
   significance1pc: string;

--- a/src/renderer/store/game.ts
+++ b/src/renderer/store/game.ts
@@ -59,9 +59,6 @@ export type GameStatistics = {
   rating: number;
   ratingLower: number;
   ratingUpper: number;
-  ratingWithDraw: number;
-  ratingWithDrawLower: number;
-  ratingWithDrawUpper: number;
   npIsGreaterThan5: boolean;
   zValue: number;
   significance5pc: boolean;
@@ -70,30 +67,17 @@ export type GameStatistics = {
 
 export function calculateGameStatistics(results: GameResults): GameStatistics {
   const n = results.player1.win + results.player2.win;
-  const nWithDraw = n + results.draw;
   const wins = Math.max(results.player1.win, results.player2.win);
   const winRate = wins / n;
   const winRateCI = calculateWinRateConfidenceInterval(Z_VALUE_95, winRate, n);
-  const winRateWithDraw = (wins + results.draw * 0.5) / nWithDraw;
-  const winRateWithDrawCI = calculateWinRateConfidenceInterval(
-    Z_VALUE_95,
-    winRateWithDraw,
-    nWithDraw,
-  );
   const rating = calculateEloRatingFromWinRate(winRate);
   const ratingLower = calculateEloRatingFromWinRate(winRate - winRateCI);
   const ratingUpper = calculateEloRatingFromWinRate(winRate + winRateCI);
-  const ratingWithDraw = calculateEloRatingFromWinRate(winRateWithDraw);
-  const ratingWithDrawLower = calculateEloRatingFromWinRate(winRateWithDraw - winRateWithDrawCI);
-  const ratingWithDrawUpper = calculateEloRatingFromWinRate(winRateWithDraw + winRateWithDrawCI);
   const zValue = Math.abs(calculateZValue(results.player1.win, n, 0.5));
   return {
     rating,
     ratingLower,
     ratingUpper,
-    ratingWithDraw,
-    ratingWithDrawLower,
-    ratingWithDrawUpper,
     npIsGreaterThan5: n > 10,
     zValue,
     significance5pc: zValue > Z_VALUE_95,

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -110,13 +110,6 @@ function getMessageAttachmentsByGameResults(results: GameResults): Attachment[] 
           ],
         },
         {
-          text: `${t.eloRatingDiff} (${t.drawCountAsHalfWins})`,
-          children: [
-            `${statistics.ratingWithDraw.toFixed(2)}`,
-            `95% CI: [${statistics.ratingWithDrawLower.toFixed(1)}, ${statistics.ratingWithDrawUpper.toFixed(1)}]`,
-          ],
-        },
-        {
           text: "二項検定", // TODO: i18n
           children: [
             `np > 5: ${statistics.npIsGreaterThan5 ? "True" : "False"}`,

--- a/src/tests/renderer/store/game.spec.ts
+++ b/src/tests/renderer/store/game.spec.ts
@@ -92,9 +92,6 @@ describe("store/game", () => {
     expect(statistics.rating.toPrecision(6)).toBe("279.588");
     expect(statistics.ratingLower.toPrecision(6)).toBe("116.129");
     expect(statistics.ratingUpper.toPrecision(6)).toBe("NaN");
-    expect(statistics.ratingWithDraw.toPrecision(6)).toBe("240.824");
-    expect(statistics.ratingWithDrawLower.toPrecision(6)).toBe("88.5114");
-    expect(statistics.ratingWithDrawUpper.toPrecision(6)).toBe("638.632");
     expect(statistics.zValue.toPrecision(6)).toBe("2.82843");
     expect(statistics.npIsGreaterThan5).toBeTruthy();
     expect(statistics.significance5pc).toBeTruthy();
@@ -113,9 +110,6 @@ describe("store/game", () => {
     expect(statistics.rating.toPrecision(6)).toBe("381.697");
     expect(statistics.ratingLower.toPrecision(6)).toBe("158.982");
     expect(statistics.ratingUpper.toPrecision(6)).toBe("NaN");
-    expect(statistics.ratingWithDraw.toPrecision(6)).toBe("279.588");
-    expect(statistics.ratingWithDrawLower.toPrecision(6)).toBe("86.8675");
-    expect(statistics.ratingWithDrawUpper.toPrecision(6)).toBe("NaN");
     expect(statistics.zValue.toPrecision(6)).toBe("2.52982");
     expect(statistics.significance5pc).toBeTruthy();
     expect(statistics.significance1pc).toBeFalsy();
@@ -133,9 +127,6 @@ describe("store/game", () => {
     expect(statistics.rating.toPrecision(6)).toBe("223.438");
     expect(statistics.ratingLower.toPrecision(6)).toBe("148.469");
     expect(statistics.ratingUpper.toPrecision(6)).toBe("323.370");
-    expect(statistics.ratingWithDraw.toPrecision(6)).toBe("217.627");
-    expect(statistics.ratingWithDrawLower.toPrecision(6)).toBe("143.798");
-    expect(statistics.ratingWithDrawUpper.toPrecision(6)).toBe("314.877");
     expect(statistics.zValue.toPrecision(6)).toBe("5.58440");
     expect(statistics.significance5pc).toBeTruthy();
     expect(statistics.significance1pc).toBeTruthy();


### PR DESCRIPTION
# 説明 / Description

#1196 

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed display and calculation of ELO ratings that included draws as half wins from game statistics and related summaries.
- **Tests**
  - Updated tests to remove validation of draw-inclusive rating statistics.
- **Chores**
  - Removed unused translation keys related to draws counting as half wins from all supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->