### PR TITLE
モバイル版で成・不成を素早く操作するとキャンセル扱いになる問題

### DIFF
--- a/src/renderer/view/primitive/BoardView.vue
+++ b/src/renderer/view/primitive/BoardView.vue
@@ -77,6 +77,7 @@
           class="promote"
           :style="board.promote.style"
           @click.stop.prevent="clickPromote()"
+          @doubleclick.stop.prevent="clickPromote()"
         >
           <img class="piece-image" :src="board.promote.imagePath" draggable="false" />
         </div>


### PR DESCRIPTION
# 説明 / Description

#1187 

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Promotion can now be triggered by double-clicking in addition to single-clicking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->