### PR TITLE
Fix double click action

### DIFF
--- a/src/renderer/view/primitive/BoardView.vue
+++ b/src/renderer/view/primitive/BoardView.vue
@@ -69,7 +69,7 @@
           :key="square.id"
           :style="square.style"
           @click.stop.prevent="clickSquare(square.file, square.rank)"
-          @dblclick.stop.prevent="clickSquareDouble(square.file, square.rank)"
+          @dblclick.stop.prevent="clickSquareR(square.file, square.rank)"
           @contextmenu.stop.prevent="clickSquareR(square.file, square.rank)"
         ></div>
         <div
@@ -86,6 +86,7 @@
           class="not-promote"
           :style="board.doNotPromote.style"
           @click.stop.prevent="clickNotPromote()"
+          @doubleclick.stop.prevent="clickNotPromote()"
         >
           <img class="piece-image" :src="board.doNotPromote.imagePath" draggable="false" />
         </div>
@@ -444,14 +445,6 @@ const clickSquareR = (file: number, rank: number) => {
   const square = new Square(file, rank);
   if (props.allowEdit && props.position.board.at(square)) {
     emit("edit", { rotate: square });
-  }
-};
-
-const clickSquareDouble = (file: number, rank: number) => {
-  if (props.allowEdit) {
-    clickSquareR(file, rank);
-  } else {
-    clickSquare(file, rank);
   }
 };
 


### PR DESCRIPTION
# 説明 / Description

#1208 の変更では効果がなかったので元に戻す。
また、 #1207 で不成の側が選択漏れだったので修正する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added double-click support to the "do not promote" option.

- **Refactor**
  - Updated board square double-click behavior for consistency. Double-clicking a square now always triggers the same action as a right-click.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->