### PR TITLE
Create a new instance window in the front (MacOS)

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -125,7 +125,7 @@ async function installElectronDevTools() {
 // opens a new MacOS App Instance using shell command.
 function openNewInstance() {
   const appPath = app.getPath("exe").replace("/Contents/MacOS/ShogiHome", "");
-  const child = spawn("open", ["-jn", appPath], { detached: true, stdio: "ignore" });
+  const child = spawn("open", ["-n", appPath], { detached: true, stdio: "ignore" });
   child.unref();
 }
 


### PR DESCRIPTION

# 説明 / Description

このPR は https://github.com/sunfish-shogi/shogihome/issues/1217 を修正します。
MacOS で新規ウィンドウを作成する時に、新規ウィンドウが最前面に表示されるようになります。

This PR fixes behavior of creating a new instance from MacOS Dock menu. The new window will be placed in front.

This commit removes `-j` option that was passed to `open` command. Only `-n` option is required for creating a new MacOS App instance.

`open -h` says:
```
      -n, --new             Open a new instance of the application even if one is already running.
      -j, --hide            Launches the app hidden.
```


# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [x] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility when launching new application instances on macOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->