### PR TITLE
新規作成直後のカスタムプロファイルで編集画面の表示と実際のダイアログの位置が異なる問題を修正

### DIFF
--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -139,7 +139,7 @@ onMounted(() => {
 });
 
 const dialogPosition = computed(() =>
-  !store.customLayout || store.customLayout.dialogPosition === DialogPosition.CENTER
+  !store.customLayout?.dialogPosition || store.customLayout.dialogPosition === DialogPosition.CENTER
     ? "dialog-position-center"
     : store.customLayout.dialogPosition === DialogPosition.LEFT
       ? "dialog-position-left"


### PR DESCRIPTION
# 説明 / Description

内部的に dialogPosition フィールドが undefined の場合に、編集画面は「中央」が選択された状態になるが、実際のダイアログは右寄せになっている問題を修正する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dialog positioning logic to handle cases where custom layout settings may be missing or incomplete, ensuring more reliable display of dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->