### PR TITLE
検討機能に候補手の数（MultiPV）を上書きするオプションを追加

### DIFF
--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -152,6 +152,7 @@ export const en: Texts = {
   startMateSearch: "Start Mate Search",
   stopMateSearch: "Stop Mate Search",
   noMateFound: "No mate.",
+  timePerPosition: "Time per Position",
   timeout: "Timeout",
   foulWin: "Foul Win",
   foulLose: "Foul Lose",

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -152,6 +152,7 @@ export const ja: Texts = {
   startMateSearch: "詰み探索開始",
   stopMateSearch: "詰み探索終了",
   noMateFound: "詰みが見つかりませんでした。",
+  timePerPosition: "思考時間",
   timeout: "時間切れ",
   foulWin: "反則勝ち",
   foulLose: "反則負け",

--- a/src/common/i18n/locales/vi.ts
+++ b/src/common/i18n/locales/vi.ts
@@ -152,6 +152,7 @@ export const vi: Texts = {
   startMateSearch: "Bắt đầu tìm chiếu hết",
   stopMateSearch: "Dừng tìm chiếu hết",
   noMateFound: "Không có chiếu hết.",
+  timePerPosition: "思考時間", // TODO: Translate
   timeout: "Hết giờ",
   foulWin: "Thắng do nước đi phạm luật",
   foulLose: "Thua do nước đi phạm luật",

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -149,6 +149,7 @@ export const zh_tw: Texts = {
   startMateSearch: "開始詰搜尋",
   stopMateSearch: "結束詰搜尋",
   noMateFound: "在目前的盤面中找不到詰。",
+  timePerPosition: "思考時間", // TODO: Translate
   timeout: "時間耗盡",
   foulWin: "反則勝利",
   foulLose: "反則敗北",

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -147,6 +147,7 @@ export type Texts = {
   startMateSearch: string;
   stopMateSearch: string;
   noMateFound: string;
+  timePerPosition: string;
   timeout: string;
   foulWin: string;
   foulLose: string;

--- a/src/common/settings/research.ts
+++ b/src/common/settings/research.ts
@@ -10,12 +10,16 @@ export type ResearchSettings = {
   secondaries?: SecondaryResearchSettings[];
   enableMaxSeconds: boolean;
   maxSeconds: number;
+  overrideMultiPV: boolean;
+  multiPV: number;
 };
 
 export function defaultResearchSettings(): ResearchSettings {
   return {
     enableMaxSeconds: false,
     maxSeconds: 10,
+    overrideMultiPV: false,
+    multiPV: 1,
   };
 }
 

--- a/src/renderer/store/research.ts
+++ b/src/renderer/store/research.ts
@@ -2,7 +2,7 @@ import { ResearchSettings, defaultResearchSettings } from "@/common/settings/res
 import { USIPlayer } from "@/renderer/players/usi.js";
 import { SearchInfo } from "@/renderer/players/player.js";
 import { ImmutableRecord } from "tsshogi";
-import { USIEngine } from "@/common/settings/usi.js";
+import { MultiPV, USIEngine, USIMultiPV } from "@/common/settings/usi.js";
 import { SearchInfoSenderType } from "./record.js";
 import { useAppSettings } from "./settings.js";
 import { Lazy } from "@/renderer/helpers/lazy.js";
@@ -80,7 +80,15 @@ export class ResearchManager {
     const appSettings = useAppSettings();
     const usiEngines = [settings.usi, ...(settings.secondaries?.map((s) => s.usi) || [])];
     this.engines = usiEngines.map((usi, index) => {
-      const usiEngine = usi as USIEngine;
+      const options = usi!.options;
+      if (settings.overrideMultiPV) {
+        if (options[USIMultiPV]?.type === "spin") {
+          options[USIMultiPV].value = settings.multiPV;
+        } else if (options[MultiPV]?.type === "spin") {
+          options[MultiPV].value = settings.multiPV;
+        }
+      }
+      const usiEngine: USIEngine = { ...usi!, options };
       const type = getSenderTypeByIndex(index);
       return {
         usi: new USIPlayer(usiEngine, appSettings.engineTimeoutSeconds, (info) => {

--- a/src/renderer/view/dialog/ResearchDialog.vue
+++ b/src/renderer/view/dialog/ResearchDialog.vue
@@ -31,17 +31,26 @@
       </button>
       <div class="form-group">
         <div class="form-item">
-          <ToggleButton v-model:value="enableMaxSeconds" />
-          <div class="form-item-small-label">{{ t.toPrefix }}</div>
+          <div class="form-item-label-wide">{{ t.timePerPosition }}</div>
+          <ToggleButton v-model:value="researchSettings.enableMaxSeconds" />
           <input
-            ref="maxSeconds"
-            :value="researchSettings.maxSeconds"
+            v-model.number="researchSettings.maxSeconds"
             class="number"
             type="number"
             min="1"
-            :disabled="!enableMaxSeconds"
+            :disabled="!researchSettings.enableMaxSeconds"
           />
-          <div class="form-item-small-label">{{ t.secondsSuffix }}{{ t.toSuffix }}</div>
+        </div>
+        <div class="form-item">
+          <div class="form-item-label-wide">{{ t.suggestionsCount }}</div>
+          <ToggleButton v-model:value="researchSettings.overrideMultiPV" />
+          <input
+            v-model.number="researchSettings.multiPV"
+            class="number"
+            type="number"
+            min="1"
+            :disabled="!researchSettings.overrideMultiPV"
+          />
         </div>
       </div>
       <div class="main-buttons">
@@ -68,7 +77,6 @@ import { getPredefinedUSIEngineTag, USIEngines } from "@/common/settings/usi";
 import { useStore } from "@/renderer/store";
 import { onMounted, ref } from "vue";
 import PlayerSelector from "@/renderer/view/dialog/PlayerSelector.vue";
-import { readInputAsNumber } from "@/renderer/helpers/form";
 import ToggleButton from "@/renderer/view/primitive/ToggleButton.vue";
 import Icon from "@/renderer/view/primitive/Icon.vue";
 import { IconType } from "@/renderer/assets/icons";
@@ -82,8 +90,6 @@ const researchSettings = ref(defaultResearchSettings());
 const engines = ref(new USIEngines());
 const engineURI = ref("");
 const secondaryEngineURIs = ref([] as string[]);
-const enableMaxSeconds = ref(false);
-const maxSeconds = ref();
 
 busyState.retain();
 
@@ -94,7 +100,6 @@ onMounted(async () => {
     engineURI.value = researchSettings.value.usi?.uri || "";
     secondaryEngineURIs.value =
       researchSettings.value.secondaries?.map((engine) => engine.usi?.uri || "") || [];
-    enableMaxSeconds.value = researchSettings.value.enableMaxSeconds;
   } catch (e) {
     useErrorStore().add(e);
     store.destroyModalDialog();
@@ -112,18 +117,17 @@ const onStart = () => {
       usi: secondary,
     });
   }
-  const researchSettings: ResearchSettings = {
+  const newSettings: ResearchSettings = {
+    ...researchSettings.value,
     usi: engine,
     secondaries: secondaries,
-    enableMaxSeconds: enableMaxSeconds.value,
-    maxSeconds: readInputAsNumber(maxSeconds.value),
   };
-  const e = validateResearchSettings(researchSettings);
+  const e = validateResearchSettings(newSettings);
   if (e) {
     useErrorStore().add(e);
     return;
   }
-  store.startResearch(researchSettings);
+  store.startResearch(newSettings);
 };
 
 const onCancel = () => {

--- a/src/tests/common/settings/research.spec.ts
+++ b/src/tests/common/settings/research.spec.ts
@@ -23,6 +23,8 @@ describe("settings/research", () => {
       secondaries: [],
       enableMaxSeconds: false,
       maxSeconds: 10,
+      overrideMultiPV: false,
+      multiPV: 1,
     };
     const result = normalizeResearchSettings(settings);
     expect(result).toStrictEqual(settings);
@@ -45,6 +47,8 @@ describe("settings/research", () => {
       secondaries: [],
       enableMaxSeconds: false,
       maxSeconds: 10,
+      overrideMultiPV: false,
+      multiPV: 1,
     };
     expect(validateResearchSettings(settings)).toBeUndefined();
   });
@@ -54,6 +58,8 @@ describe("settings/research", () => {
       secondaries: [],
       enableMaxSeconds: false,
       maxSeconds: 10,
+      overrideMultiPV: false,
+      multiPV: 1,
     };
     expect(validateResearchSettings(settings)).toBeInstanceOf(Error);
   });
@@ -75,6 +81,8 @@ describe("settings/research", () => {
       secondaries: [{}],
       enableMaxSeconds: false,
       maxSeconds: 10,
+      overrideMultiPV: false,
+      multiPV: 1,
     };
     expect(validateResearchSettings(settings)).toBeInstanceOf(Error);
   });

--- a/src/tests/mock/research.ts
+++ b/src/tests/mock/research.ts
@@ -5,12 +5,16 @@ export const researchSettings: ResearchSettings = {
   usi: testUSIEngine,
   enableMaxSeconds: false,
   maxSeconds: 5,
+  overrideMultiPV: false,
+  multiPV: 1,
 };
 
 export const researchSettingsMax5Seconds: ResearchSettings = {
   usi: testUSIEngine,
   enableMaxSeconds: true,
   maxSeconds: 5,
+  overrideMultiPV: false,
+  multiPV: 1,
 };
 
 export const researchSettingsSecondaryEngines: ResearchSettings = {
@@ -18,4 +22,6 @@ export const researchSettingsSecondaryEngines: ResearchSettings = {
   secondaries: [{ usi: testUSIEngine }, { usi: testUSIEngine }],
   enableMaxSeconds: false,
   maxSeconds: 5,
+  overrideMultiPV: false,
+  multiPV: 1,
 };

--- a/src/tests/renderer/store/index.spec.ts
+++ b/src/tests/renderer/store/index.spec.ts
@@ -456,7 +456,7 @@ describe("store/index", () => {
     expect(store.researchState).toBe(ResearchState.RUNNING);
     expect(mockAPI.saveResearchSettings).toBeCalledTimes(1);
     expect(mockUSIPlayer).toBeCalledTimes(1);
-    expect(mockUSIPlayer.mock.calls[0][0]).toBe(researchSettings.usi);
+    expect(mockUSIPlayer.mock.calls[0][0]).toStrictEqual(researchSettings.usi);
     expect(mockUSIPlayer.prototype.launch).toBeCalledTimes(1);
     // FIXME: 遅延実行の導入によってすぐに呼ばれなくなった。
     //expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(1);

--- a/src/tests/renderer/store/research.spec.ts
+++ b/src/tests/renderer/store/research.spec.ts
@@ -173,4 +173,39 @@ describe("store/research", () => {
     expect(mockAPI.usiStop).toBeCalledTimes(0);
     expect(manager.getMultiPV(101)).toBeUndefined();
   });
+
+  it("overrideMultiPV", async () => {
+    vi.useFakeTimers();
+    mockAPI.usiLaunch.mockResolvedValueOnce(101);
+    mockAPI.usiGoInfinite.mockResolvedValue();
+    mockAPI.usiStop.mockResolvedValue();
+    mockAPI.usiSetOption.mockResolvedValue();
+    const manager = new ResearchManager();
+    await manager.launch({
+      ...researchSettings,
+      overrideMultiPV: true,
+      multiPV: 4,
+      usi: {
+        ...(researchSettings.usi as USIEngine),
+        options: {
+          MultiPV: {
+            name: "MultiPV",
+            order: 1,
+            type: "spin",
+            default: 1,
+            value: 1,
+          } as USIEngineOption,
+        },
+      },
+    });
+    expect(mockAPI.usiLaunch).toBeCalledTimes(1);
+    expect(mockAPI.usiLaunch.mock.calls[0][0].options["MultiPV"]).toStrictEqual({
+      name: "MultiPV",
+      order: 1,
+      type: "spin",
+      default: 1,
+      value: 4,
+    });
+    expect(manager.getMultiPV(101)).toBe(4);
+  });
 });


### PR DESCRIPTION
# 説明 / Description

#1216

<img width="502" alt="スクリーンショット 2025-05-18 21 42 21" src="https://github.com/user-attachments/assets/313b9776-1ab3-4c79-a387-dfbc1d9efde4" />


# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added options to override the number of suggestions (MultiPV) in research settings.
  - Updated the research dialog to allow users to set and control the number of suggestions provided per position.

- **Localization**
  - Added translations for "Time per Position" in English, Japanese, Vietnamese, and Traditional Chinese.

- **Bug Fixes**
  - Improved state management in the research dialog for more consistent and unified settings control.

- **Tests**
  - Extended and added tests to cover the new MultiPV override functionality and ensure correct behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->