### PR TITLE
Fix to use finally block

### DIFF
--- a/src/renderer/view/dialog/LoadRemoteFileDialog.vue
+++ b/src/renderer/view/dialog/LoadRemoteFileDialog.vue
@@ -318,9 +318,9 @@ onMounted(async () => {
     }
   } finally {
     busyState.release();
+    watch(tab, onUpdateTab, { immediate: true });
+    watch(wcscEdition, updateWCSCGameList);
   }
-  watch(tab, onUpdateTab, { immediate: true });
-  watch(wcscEdition, updateWCSCGameList);
 });
 </script>
 


### PR DESCRIPTION
# 説明 / Description

`watch` が必ず実行されるように finally ブロック内に記述するよう修正する。

関連: #1192 

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of file loading dialog by ensuring interface updates occur only after initialization is complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->