### PR TITLE
Remove backup directory menu

### DIFF
--- a/src/background/file/history.ts
+++ b/src/background/file/history.ts
@@ -10,7 +10,6 @@ import {
 } from "@/common/file/history.js";
 import { getAppLogger } from "@/background/log.js";
 import AsyncLock from "async-lock";
-import { openPath } from "@/background/helpers/electron.js";
 import { exists } from "@/background/helpers/file.js";
 import { writeFileAtomic } from "./atomic.js";
 import { getBlackPlayerName, getWhitePlayerName, importKIF, Record } from "tsshogi";
@@ -20,11 +19,10 @@ const historyMaxLength = 20;
 
 const userDir = getAppPath("userData");
 const historyPath = path.join(userDir, "record_file_history.json");
-const backupDir = path.join(userDir, "backup/kifu");
 
-export function openBackupDirectory(): Promise<void> {
-  return openPath(backupDir);
-}
+// 現在はこのディレクトリに書き出していないが、
+// 古いバージョンで作られたファイルが残っている可能性があるので参照や削除の実装は残しておく
+const backupDir = path.join(userDir, "backup/kifu");
 
 const lock = new AsyncLock();
 

--- a/src/background/window/menu.ts
+++ b/src/background/window/menu.ts
@@ -24,7 +24,6 @@ import { t } from "@/common/i18n/index.js";
 import { InitialPositionSFEN } from "tsshogi";
 import { getAppPath } from "@/background/proc/path-electron.js";
 import { chromiumLicensePath, electronLicensePath } from "@/background/proc/path.js";
-import { openBackupDirectory } from "@/background/file/history.js";
 import { openCacheDirectory } from "@/background/image/cache.js";
 import { refreshCustomPieceImages, sendTestNotification } from "./debug.js";
 import { LogType } from "@/common/log.js";
@@ -413,12 +412,6 @@ function createMenuTemplate(window: BrowserWindow) {
           label: t.cache,
           click: () => {
             openCacheDirectory().catch(sendError);
-          },
-        },
-        {
-          label: t.backup,
-          click: () => {
-            openBackupDirectory().catch(sendError);
           },
         },
         {

--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -81,7 +81,6 @@ export const en: Texts = {
   thisIsTestNotification: "This is a test notification.",
   app: "App",
   log: "Log",
-  backup: "Backup",
   cache: "Cache",
   help: "Help",
   openWebsite: "Open Website",

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -81,7 +81,6 @@ export const ja: Texts = {
   thisIsTestNotification: "これは通知のテストです。",
   app: "アプリ",
   log: "ログ",
-  backup: "バックアップ",
   cache: "キャッシュ",
   help: "ヘルプ",
   openWebsite: "Webサイトを開く",

--- a/src/common/i18n/locales/vi.ts
+++ b/src/common/i18n/locales/vi.ts
@@ -81,7 +81,6 @@ export const vi: Texts = {
   thisIsTestNotification: "Đây là thông báo thử",
   app: "Ứng dụng",
   log: "Log",
-  backup: "Sao lưu",
   cache: "Bộ nhớ đệm",
   help: "Trợ giúp",
   openWebsite: "Mở trang web",

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -78,7 +78,6 @@ export const zh_tw: Texts = {
   thisIsTestNotification: "這是測試用的通知。",
   app: "軟體",
   log: "紀錄檔",
-  backup: "備份",
   cache: "快取",
   help: "協助",
   openWebsite: "官方網站",

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -76,7 +76,6 @@ export type Texts = {
   thisIsTestNotification: string;
   app: string;
   log: string;
-  backup: string;
   cache: string;
   help: string;
   openWebsite: string;


### PR DESCRIPTION
# 説明 / Description

旧バックアップディレクトリを開くメニューを削除する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- None.

- **Bug Fixes**
	- None.

- **Chores**
	- Removed the menu option and related functionality for accessing the backup folder.
	- Deleted backup-related text entries from all supported languages.
	- Cleaned up unused backup-related code and type definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->