### PR TITLE
思考コメントに常にエンジン名を入れる改修

### DIFF
--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -42,6 +42,7 @@
     <PVPreviewDialog
       v-if="store.pvPreview"
       :position="store.pvPreview.position"
+      :name="store.pvPreview.engineName"
       :multi-pv="store.pvPreview.multiPV"
       :depth="store.pvPreview.depth"
       :selective-depth="store.pvPreview.selectiveDepth"

--- a/src/renderer/store/csa.ts
+++ b/src/renderer/store/csa.ts
@@ -399,11 +399,13 @@ export class CSAGameManager {
     // コメントを記録する。
     const appSettings = useAppSettings();
     if (isMyMove && this.searchInfo && this.settings.enableComment) {
+      const engineName = this.gameSummary.players[move.color].playerName;
       this.recordManager.appendSearchComment(
         SearchInfoSenderType.PLAYER,
         appSettings.searchCommentFormat,
         this.searchInfo,
         CommentBehavior.APPEND,
+        { engineName },
       );
     }
 

--- a/src/renderer/store/game.ts
+++ b/src/renderer/store/game.ts
@@ -501,11 +501,13 @@ export class GameManager {
     // コメントを追加する。
     if (info && this.settings.enableComment) {
       const appSettings = useAppSettings();
+      const engineName = this.settings[move.color].name;
       this.recordManager.appendSearchComment(
         SearchInfoSenderType.PLAYER,
         appSettings.searchCommentFormat,
         info,
         CommentBehavior.APPEND,
+        { engineName },
       );
     }
     // 駒音を鳴らす。

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -68,6 +68,7 @@ import { Attachment, ListItem } from "@/common/message.js";
 
 export type PVPreview = {
   position: ImmutablePosition;
+  engineName?: string;
   multiPV?: number;
   depth?: number;
   selectiveDepth?: number;

--- a/src/renderer/view/dialog/PVPreviewDialog.vue
+++ b/src/renderer/view/dialog/PVPreviewDialog.vue
@@ -95,6 +95,11 @@ const props = defineProps({
     type: Object as PropType<ImmutablePosition>,
     required: true,
   },
+  name: {
+    type: String,
+    required: false,
+    default: undefined,
+  },
   multiPv: {
     type: Number,
     required: false,
@@ -204,6 +209,9 @@ const getDisplayScore = (score: number, color: Color, evaluationViewFrom: Evalua
 
 const info = computed(() => {
   const elements = [];
+  if (props.name) {
+    elements.push(`${props.name}`);
+  }
   if (props.depth !== undefined) {
     elements.push(`深さ=${props.depth}`);
   }
@@ -270,6 +278,7 @@ const insertToComment = () => {
       pv: props.pv,
     },
     CommentBehavior.APPEND,
+    { engineName: props.name },
   );
   messageStore.enqueue({
     text: t.insertedComment,

--- a/src/renderer/view/tab/EngineAnalyticsElement.vue
+++ b/src/renderer/view/tab/EngineAnalyticsElement.vue
@@ -250,6 +250,7 @@ const showPreview = (ite: USIInfo) => {
   }
   useStore().showPVPreviewDialog({
     position,
+    engineName: props.monitor.name,
     multiPV: ite.multiPV,
     depth: ite.depth,
     selectiveDepth: ite.selectiveDepth,

--- a/src/tests/renderer/store/csa.spec.ts
+++ b/src/tests/renderer/store/csa.spec.ts
@@ -205,11 +205,11 @@ describe("store/csa", () => {
     expect(mockHandlers.onError).toBeCalledTimes(0);
     expect(recordManager.record.moves).toHaveLength(6);
     expect(recordManager.record.moves[1].comment).toBe(
-      "互角\n*評価値=82\n*読み筋=△３四歩▲２六歩△８四歩\n",
+      "互角\n*評価値=82\n*読み筋=△３四歩▲２六歩△８四歩\n*エンジン=me\n",
     );
     expect(recordManager.record.moves[2].comment).toBe("");
     expect(recordManager.record.moves[3].comment).toBe(
-      "互角\n*評価値=78\n*読み筋=△８四歩▲２五歩△８五歩\n",
+      "互角\n*評価値=78\n*読み筋=△８四歩▲２五歩△８五歩\n*エンジン=me\n",
     );
     expect(recordManager.record.moves[4].comment).toBe("");
     expect(recordManager.record.moves[5].move).toStrictEqual(specialMove(SpecialMoveType.RESIGN));
@@ -316,11 +316,11 @@ describe("store/csa", () => {
     expect(mockHandlers.onError).toBeCalledTimes(0);
     expect(recordManager.record.moves).toHaveLength(6);
     expect(recordManager.record.moves[1].comment).toBe(
-      "互角\n*評価値=82\n*読み筋=△３四歩▲２六歩△８四歩\n",
+      "互角\n*評価値=82\n*読み筋=△３四歩▲２六歩△８四歩\n*エンジン=me\n",
     );
     expect(recordManager.record.moves[2].comment).toBe("");
     expect(recordManager.record.moves[3].comment).toBe(
-      "互角\n*評価値=78\n*読み筋=△８四歩▲２五歩△８五歩\n",
+      "互角\n*評価値=78\n*読み筋=△８四歩▲２五歩△８五歩\n*エンジン=me\n",
     );
     expect(recordManager.record.moves[4].comment).toBe("");
     expect(recordManager.record.moves[5].move).toStrictEqual(specialMove(SpecialMoveType.RESIGN));
@@ -627,11 +627,11 @@ describe("store/csa", () => {
     expect(mockHandlers.onError).toBeCalledTimes(0);
     expect(recordManager.record.moves).toHaveLength(6);
     expect(recordManager.record.moves[1].comment).toBe(
-      "互角\n*評価値=82\n*読み筋=△３四歩▲２六歩△８四歩\n",
+      "互角\n*評価値=82\n*読み筋=△３四歩▲２六歩△８四歩\n*エンジン=me\n",
     );
     expect(recordManager.record.moves[2].comment).toBe("");
     expect(recordManager.record.moves[3].comment).toBe(
-      "互角\n*評価値=78\n*読み筋=△８四歩▲２五歩△８五歩\n",
+      "互角\n*評価値=78\n*読み筋=△８四歩▲２五歩△８五歩\n*エンジン=me\n",
     );
     expect(recordManager.record.moves[4].comment).toBe("");
     expect(recordManager.record.moves[5].move).toStrictEqual(specialMove(SpecialMoveType.RESIGN));

--- a/src/tests/renderer/store/game.spec.ts
+++ b/src/tests/renderer/store/game.spec.ts
@@ -303,13 +303,13 @@ describe("store/game", () => {
         expect(mockHandlers.onStopBeep).toBeCalledTimes(8);
         expect(recordManager.record.usi).toBe("position startpos moves 7g7f 3c3d 2g2f");
         expect(recordManager.record.moves[1].comment).toBe(
-          "互角\n*評価値=82\n*読み筋=△３四歩▲２六歩△８四歩\n",
+          "互角\n*評価値=82\n*読み筋=△３四歩▲２六歩△８四歩\n*エンジン=USI Engine 01\n",
         );
         expect(recordManager.record.moves[2].comment).toBe(
-          "互角\n*評価値=64\n*読み筋=▲２六歩△８四歩\n",
+          "互角\n*評価値=64\n*読み筋=▲２六歩△８四歩\n*エンジン=USI Engine 02\n",
         );
         expect(recordManager.record.moves[3].comment).toBe(
-          "互角\n*評価値=78\n*読み筋=△８四歩▲２五歩△８五歩\n",
+          "互角\n*評価値=78\n*読み筋=△８四歩▲２五歩△８五歩\n*エンジン=USI Engine 01\n",
         );
         expect(mockHandlers.onError).not.toBeCalled();
       },


### PR DESCRIPTION
# 説明 / Description

これまで解析機能以外では思考コメントにエンジン名が入らなかったが、対局や再現からもエンジン名が記録されるようにする。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The engine name is now displayed in the principal variation (PV) preview dialog for increased clarity during analysis.
  - When inserting search comments, the engine name is included for better traceability.

- **Bug Fixes**
  - None.

- **Tests**
  - Updated test cases to verify that move comments now include the engine name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->