### PR TITLE
盤と駒台にドロップシャドウを追加

### DIFF
--- a/src/renderer/view/primitive/BoardView.vue
+++ b/src/renderer/view/primitive/BoardView.vue
@@ -6,7 +6,7 @@
         <div v-if="board.background.textureImagePath" :style="board.background.style">
           <img class="full" :src="board.background.textureImagePath" />
         </div>
-        <div :style="board.background.style">
+        <div class="board-background" :style="board.background.style">
           <BoardGrid class="full" :color="boardGridColor || board.background.gridColor" />
         </div>
         <div v-for="square in board.squares" :key="square.id" :style="square.backgroundStyle"></div>
@@ -20,7 +20,7 @@
 
       <!-- 先手の駒台 -->
       <div class="hand" :style="main.blackHandStyle">
-        <div :style="blackHand.backgroundStyle">
+        <div class="hand-background" :style="blackHand.backgroundStyle">
           <img v-if="blackHand.textureImagePath" class="full" :src="blackHand.textureImagePath" />
         </div>
         <div
@@ -38,7 +38,7 @@
 
       <!-- 後手の駒台 -->
       <div class="hand" :style="main.whiteHandStyle">
-        <div :style="whiteHand.backgroundStyle">
+        <div class="hand-background" :style="whiteHand.backgroundStyle">
           <img v-if="whiteHand.textureImagePath" class="full" :src="whiteHand.textureImagePath" />
         </div>
         <div
@@ -635,8 +635,14 @@ const whitePlayerTimeSeverity = computed(() => {
 .board > * {
   position: absolute;
 }
+.board-background {
+  box-shadow: 3px 3px 6px var(--shadow-color);
+}
 .hand > * {
   position: absolute;
+}
+.hand-background {
+  box-shadow: 3px 3px 6px var(--shadow-color);
 }
 .player-name {
   background-color: var(--text-bg-color);


### PR DESCRIPTION
# 説明 / Description

デザインの組み合わせによっては境界が曖昧になってしまうので、ドロップシャドウを付けて改善する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Introduced new background and shadow effects for the board and hand areas to enhance visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->