### PR TITLE
シンプルなSFENだけで構成された局面集の読み込みに対応

### DIFF
--- a/src/renderer/store/game.ts
+++ b/src/renderer/store/game.ts
@@ -4,6 +4,7 @@ import { Player, SearchInfo } from "@/renderer/players/player.js";
 import { defaultGameSettings, GameSettings, JishogiRule } from "@/common/settings/game.js";
 import {
   Color,
+  detectRecordFormat,
   formatMove,
   JishogiDeclarationResult,
   JishogiDeclarationRule,
@@ -135,6 +136,16 @@ export class StartPositionList {
     const maxPositions = Math.ceil(params.maxGames / (params.swapPlayers ? 2 : 1));
     if (usiList.length > maxPositions) {
       usiList.length = maxPositions;
+    }
+
+    // add "sfen " prefix to simple SFEN strings
+    for (let i = 0; i < usiList.length; i++) {
+      if (
+        !usiList[i].startsWith("sfen ") &&
+        detectRecordFormat(usiList[i]) === RecordFormatType.SFEN
+      ) {
+        usiList[i] = `sfen ${usiList[i]}`;
+      }
     }
 
     // validate USI

--- a/src/tests/renderer/store/game.spec.ts
+++ b/src/tests/renderer/store/game.spec.ts
@@ -206,6 +206,39 @@ describe("store/game", () => {
     expect(list.next()).toBe("position startpos moves 2g2f 8c8d 2f2e");
   });
 
+  it("StartPositionList/simple-sfen", async () => {
+    mockAPI.loadSFENFile.mockImplementation(async () => [
+      "ln1g3+Rl/2sk1s+P2/2ppppb1p/p1b3p2/8P/P4P3/2PPP1P2/1+r2GS3/LN+p2KGNL w GN2Ps 36",
+      "ln1g2B+Rl/2s6/pPppppk2/6p1p/9/4P1P1P/P1PPSP3/3+psK3/L+r3G1NL b SNb2gn2p 39",
+      "ln+P3s+Pl/2+R1Gsk2/p3pp1g1/4r1ppp/1NS6/6P2/PP1+bPPS1P/3+p1K3/LG3G1NL w Nb3p 72",
+      "lnsgk2+Pl/6+N2/p1pp2p1p/4p2R1/9/2P3P2/P2PPPN1P/4s1g1K/L4+r2L w 2B2SN4P2g 56",
+    ]);
+    const list = new StartPositionList();
+    expect(list.next()).toBe("position startpos");
+
+    await expect(
+      list.reset({
+        filePath: "path/to/file.sfen",
+        swapPlayers: false,
+        order: "sequential",
+        maxGames: 4,
+      }),
+    ).resolves.toBeUndefined();
+    expect(mockAPI.loadSFENFile).toBeCalledWith("path/to/file.sfen");
+    expect(list.next()).toBe(
+      "sfen ln1g3+Rl/2sk1s+P2/2ppppb1p/p1b3p2/8P/P4P3/2PPP1P2/1+r2GS3/LN+p2KGNL w GN2Ps 36",
+    );
+    expect(list.next()).toBe(
+      "sfen ln1g2B+Rl/2s6/pPppppk2/6p1p/9/4P1P1P/P1PPSP3/3+psK3/L+r3G1NL b SNb2gn2p 39",
+    );
+    expect(list.next()).toBe(
+      "sfen ln+P3s+Pl/2+R1Gsk2/p3pp1g1/4r1ppp/1NS6/6P2/PP1+bPPS1P/3+p1K3/LG3G1NL w Nb3p 72",
+    );
+    expect(list.next()).toBe(
+      "sfen lnsgk2+Pl/6+N2/p1pp2p1p/4p2R1/9/2P3P2/P2PPPN1P/4s1g1K/L4+r2L w 2B2SN4P2g 56",
+    );
+  });
+
   it("StartPositionList/empty", async () => {
     mockAPI.loadSFENFile.mockResolvedValueOnce([]);
     const list = new StartPositionList();


### PR DESCRIPTION
# 説明 / Description

`position ` や `sfen ` が書かれていないシンプルな SFEN が記述された局面集の読み込みに対応する。


そのようなファイルは例えば [やねうら王公式からクリスマスプレゼントに詰将棋500万問を謹呈](https://yaneuraou.yaneu.com/2020/12/25/christmas-present/) で配布されている。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of position strings to ensure all SFEN positions are properly prefixed, enhancing compatibility and consistency when loading game positions.  
- **Tests**
  - Added new test coverage for loading simple SFEN position strings without move sequences to ensure correct processing and prefixing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->