### PR TITLE
.sfenファイルからの定跡手取り込みに対応

### DIFF
--- a/src/background/window/ipc.ts
+++ b/src/background/window/ipc.ts
@@ -123,6 +123,7 @@ import {
 } from "@/background/book/index.js";
 import { BookLoadingMode, BookLoadingOptions, BookMove } from "@/common/book.js";
 import { Message } from "@/common/message.js";
+import { RecordFileFormat } from "@/common/file/record.js";
 
 const isWindows = process.platform === "win32";
 
@@ -191,21 +192,24 @@ ipcMain.on(Background.OPEN_WEB_BROWSER, (event, url: string) => {
   shell.openExternal(url);
 });
 
-ipcMain.handle(Background.SHOW_OPEN_RECORD_DIALOG, async (event): Promise<string> => {
-  validateIPCSender(event.senderFrame);
-  const appSettings = await loadAppSettings();
-  getAppLogger().debug("show open-record dialog");
-  const ret = await showOpenDialog(["openFile"], appSettings.lastRecordFilePath, [
-    {
-      name: t.recordFile,
-      extensions: ["kif", "kifu", "ki2", "ki2u", "csa", "jkf"],
-    },
-  ]);
-  if (ret) {
-    updateAppSettings({ lastRecordFilePath: ret });
-  }
-  return ret;
-});
+ipcMain.handle(
+  Background.SHOW_OPEN_RECORD_DIALOG,
+  async (event, formats: RecordFileFormat[]): Promise<string> => {
+    validateIPCSender(event.senderFrame);
+    const appSettings = await loadAppSettings();
+    getAppLogger().debug("show open-record dialog");
+    const ret = await showOpenDialog(["openFile"], appSettings.lastRecordFilePath, [
+      {
+        name: t.recordFile,
+        extensions: formats.map((format) => format.slice(1)),
+      },
+    ]);
+    if (ret) {
+      updateAppSettings({ lastRecordFilePath: ret });
+    }
+    return ret;
+  },
+);
 
 ipcMain.handle(Background.OPEN_RECORD, async (event, path: string) => {
   validateIPCSender(event.senderFrame);

--- a/src/common/book.ts
+++ b/src/common/book.ts
@@ -16,6 +16,7 @@ export type BookLoadingOptions = {
 export type BookImportSummary = {
   successFileCount: number; // 正常に読み込んだファイルの数
   errorFileCount: number; // 読み込みエラーが発生したファイルの数
+  skippedFileCount: number; // 読み込みをスキップしたファイルの数
   entryCount: number; // 新規に登録された定跡手の数
   duplicateCount: number; // 重複した定跡手の数
 };

--- a/src/common/file/record.ts
+++ b/src/common/file/record.ts
@@ -22,6 +22,17 @@ export enum RecordFileFormat {
   JKF = ".jkf",
 }
 
+export function getStandardRecordFileFormats() {
+  return [
+    RecordFileFormat.KIF,
+    RecordFileFormat.KIFU,
+    RecordFileFormat.KI2,
+    RecordFileFormat.KI2U,
+    RecordFileFormat.CSA,
+    RecordFileFormat.JKF,
+  ];
+}
+
 export function detectRecordFileFormatByPath(path: string): RecordFileFormat | undefined {
   const lowerCase = path.toLowerCase();
   for (const ext of Object.values(RecordFileFormat)) {

--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -710,7 +710,6 @@ export const en: Texts = {
   anyBookMovesAreUnsavedDoYouReallyWantToDiscardThemAndCloseTheApp:
     "Any book moves are unsaved. Do you really want to discard them and close the app?",
   sourceRecordFileNotSet: "Source record file is not set.",
-  sfenFileImportIsNotSupported: "SFEN file import is not supported.",
   sourceDirectoryNotSet: "Source directory is not set.",
   minPlyMustBeLessThanMaxPly: "Min ply must be less than max ply.",
   playerNameNotSet: "Player name is not set.",

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -711,7 +711,6 @@ export const ja: Texts = {
   anyBookMovesAreUnsavedDoYouReallyWantToDiscardThemAndCloseTheApp:
     "保存されていない定跡があります。破棄してアプリを終了しますか？",
   sourceRecordFileNotSet: "棋譜ファイルが指定されていません。",
-  sfenFileImportIsNotSupported: ".sfen はサポートされていません。",
   sourceDirectoryNotSet: "フォルダを選択してください。",
   minPlyMustBeLessThanMaxPly: "最小手数は最大手数より小さくしてください。",
   playerNameNotSet: "対局者名が設定されていません。",

--- a/src/common/i18n/locales/vi.ts
+++ b/src/common/i18n/locales/vi.ts
@@ -708,7 +708,6 @@ export const vi: Texts = {
   anyBookMovesAreUnsavedDoYouReallyWantToDiscardThemAndCloseTheApp:
     "Có các nước định thức chưa lưu. Bạn có muốn hủy bỏ chúng và đóng ứng dụng?",
   sourceRecordFileNotSet: "Chưa chỉ định tệp kỳ phổ gốc.",
-  sfenFileImportIsNotSupported: "Không hỗ trợ định dạng .sfen.",
   sourceDirectoryNotSet: "Vui lòng chọn một tập tin.",
   minPlyMustBeLessThanMaxPly: "Số nước ít nhất phải nhỏ hơn số nước lớn nhất.",
   playerNameNotSet: "Tên người chơi chưa được đặt.",

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -696,7 +696,6 @@ export const zh_tw: Texts = {
   anyBookMovesAreUnsavedDoYouReallyWantToDiscardThemAndCloseTheApp:
     "存在尚未保存的定跡。您確定要捨棄並關閉本程式嗎？",
   sourceRecordFileNotSet: "尚未指定棋譜檔案。",
-  sfenFileImportIsNotSupported: "尚未支援 .sfen 檔案。",
   sourceDirectoryNotSet: "請選擇目錄。",
   minPlyMustBeLessThanMaxPly: "最小手數應小於最大手數。",
   playerNameNotSet: "尚未設定對局者名稱。",

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -682,7 +682,6 @@ export type Texts = {
   bookMovesWereImported: string;
   anyBookMovesAreUnsavedDoYouReallyWantToDiscardThemAndCloseTheApp: string;
   sourceRecordFileNotSet: string;
-  sfenFileImportIsNotSupported: string;
   sourceDirectoryNotSet: string;
   minPlyMustBeLessThanMaxPly: string;
   playerNameNotSet: string;

--- a/src/common/settings/book.ts
+++ b/src/common/settings/book.ts
@@ -1,4 +1,4 @@
-import { detectRecordFileFormatByPath, RecordFileFormat } from "@/common/file/record.js";
+import { detectRecordFileFormatByPath } from "@/common/file/record.js";
 import { t } from "@/common/i18n/index.js";
 
 export enum SourceType {
@@ -43,9 +43,6 @@ export function validateBookImportSettings(settings: BookImportSettings): Error 
     const format = detectRecordFileFormatByPath(settings.sourceRecordFile);
     if (!format) {
       return new Error(t.unexpectedRecordFileExtension(settings.sourceRecordFile));
-    }
-    if (format === RecordFileFormat.SFEN) {
-      return new Error(t.sfenFileImportIsNotSupported);
     }
   } else if (settings.sourceType === SourceType.DIRECTORY) {
     if (!settings.sourceDirectory) {

--- a/src/renderer/ipc/api.ts
+++ b/src/renderer/ipc/api.ts
@@ -13,7 +13,7 @@ import { MateSearchSettings } from "@/common/settings/mate.js";
 import { BatchConversionSettings } from "@/common/settings/conversion.js";
 import { BatchConversionResult } from "@/common/file/conversion.js";
 import { RecordFileHistory } from "@/common/file/history.js";
-import { InitialRecordFileRequest } from "@/common/file/record.js";
+import { InitialRecordFileRequest, RecordFileFormat } from "@/common/file/record.js";
 import { VersionStatus } from "@/common/version.js";
 import { SessionStates } from "@/common/advanced/monitor.js";
 import { PromptTarget } from "@/common/advanced/prompt.js";
@@ -54,7 +54,7 @@ export interface API {
 
   // Record File
   fetchInitialRecordFileRequest(): Promise<InitialRecordFileRequest>;
-  showOpenRecordDialog(): Promise<string>;
+  showOpenRecordDialog(formats: RecordFileFormat[]): Promise<string>;
   showSaveRecordDialog(defaultPath: string): Promise<string>;
   showSaveMergedRecordDialog(defaultPath: string): Promise<string>;
   openRecord(path: string): Promise<Uint8Array>;

--- a/src/renderer/ipc/bridge.ts
+++ b/src/renderer/ipc/bridge.ts
@@ -3,6 +3,7 @@ import { PromptTarget } from "@/common/advanced/prompt.js";
 import { BookLoadingMode } from "@/common/book.js";
 import { MenuEvent } from "@/common/control/menu.js";
 import { AppState, ResearchState } from "@/common/control/state.js";
+import { RecordFileFormat } from "@/common/file/record";
 import { CSAGameResult, CSASpecialMove } from "@/common/game/csa.js";
 import { GameResult } from "@/common/game/result.js";
 import { LogLevel, LogType } from "@/common/log.js";
@@ -39,7 +40,7 @@ export interface Bridge {
 
   // Record File
   fetchInitialRecordFileRequest(): Promise<string>;
-  showOpenRecordDialog(): Promise<string>;
+  showOpenRecordDialog(formats: RecordFileFormat[]): Promise<string>;
   showSaveRecordDialog(defaultPath: string): Promise<string>;
   showSaveMergedRecordDialog(defaultPath: string): Promise<string>;
   openRecord(path: string): Promise<Uint8Array>;

--- a/src/renderer/ipc/preload.ts
+++ b/src/renderer/ipc/preload.ts
@@ -101,8 +101,8 @@ const api: Bridge = {
   async fetchInitialRecordFileRequest(): Promise<string> {
     return await ipcRenderer.invoke(Background.FETCH_INITIAL_RECORD_FILE_REQUEST);
   },
-  async showOpenRecordDialog(): Promise<string> {
-    return await ipcRenderer.invoke(Background.SHOW_OPEN_RECORD_DIALOG);
+  async showOpenRecordDialog(formats: string[]): Promise<string> {
+    return await ipcRenderer.invoke(Background.SHOW_OPEN_RECORD_DIALOG, formats);
   },
   async showSaveRecordDialog(defaultPath: string): Promise<string> {
     return await ipcRenderer.invoke(Background.SHOW_SAVE_RECORD_DIALOG, defaultPath);

--- a/src/renderer/ipc/web.ts
+++ b/src/renderer/ipc/web.ts
@@ -167,10 +167,10 @@ export const webAPI: Bridge = {
   async fetchInitialRecordFileRequest(): Promise<string> {
     return "null";
   },
-  async showOpenRecordDialog(): Promise<string> {
+  async showOpenRecordDialog(formats: string[]): Promise<string> {
     const input = document.createElement("input");
     input.setAttribute("type", "file");
-    input.setAttribute("accept", ".kif,.ki2,.kifu,.ki2u,.csa,.jkf");
+    input.setAttribute("accept", formats.join(","));
     return new Promise<string>((resolve, reject) => {
       input.click();
       input.onchange = () => {

--- a/src/renderer/store/book.ts
+++ b/src/renderer/store/book.ts
@@ -207,6 +207,7 @@ export class BookStore {
                   children: [
                     `${t.success}: ${summary.successFileCount}`,
                     `${t.failed}: ${summary.errorFileCount}`,
+                    `${t.skipped}: ${summary.skippedFileCount}`,
                   ],
                 },
                 {

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -56,7 +56,11 @@ import { useAppSettings } from "./settings.js";
 import { t } from "@/common/i18n/index.js";
 import { MateSearchManager } from "./mate.js";
 import { detectUnsupportedRecordProperties } from "@/renderer/helpers/record.js";
-import { RecordFileFormat, detectRecordFileFormatByPath } from "@/common/file/record.js";
+import {
+  RecordFileFormat,
+  detectRecordFileFormatByPath,
+  getStandardRecordFileFormats,
+} from "@/common/file/record.js";
 import { setOnStartSearchHandler, setOnUpdateUSIInfoHandler } from "@/renderer/players/usi.js";
 import { useErrorStore } from "./error.js";
 import { useBusyState } from "./busy.js";
@@ -1190,7 +1194,7 @@ class Store {
     useBusyState().retain();
     Promise.resolve()
       .then(() => {
-        return path || api.showOpenRecordDialog();
+        return path || api.showOpenRecordDialog(getStandardRecordFileFormats());
       })
       .then((path) => {
         if (!path) {

--- a/src/renderer/view/dialog/AddBookMovesDialog.vue
+++ b/src/renderer/view/dialog/AddBookMovesDialog.vue
@@ -144,6 +144,7 @@ import {
   validateBookImportSettings,
 } from "@/common/settings/book";
 import DialogFrame from "./DialogFrame.vue";
+import { RecordFileFormat, getStandardRecordFileFormats } from "@/common/file/record";
 
 type InMemoryMove = {
   type: "move";
@@ -268,7 +269,10 @@ const openDirectory = () => {
 const selectRecordFile = async () => {
   busyState.retain();
   try {
-    const path = await api.showOpenRecordDialog();
+    const path = await api.showOpenRecordDialog([
+      ...getStandardRecordFileFormats(),
+      RecordFileFormat.SFEN,
+    ]);
     if (path) {
       settings.value.sourceRecordFile = path;
     }

--- a/src/tests/background/book/index.spec.ts
+++ b/src/tests/background/book/index.spec.ts
@@ -340,10 +340,11 @@ sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1
           sourceDirectory: "src/tests/testdata/book/source",
         },
         summary: {
-          successFileCount: 4,
+          successFileCount: 5,
           errorFileCount: 0,
-          entryCount: 34,
-          duplicateCount: 2,
+          skippedFileCount: 0,
+          entryCount: 43,
+          duplicateCount: 4,
         },
         includedSFEN: [
           "ln1gk1snl/1rs3gb1/p1ppppppp/9/1p5P1/P8/1PPPPPP1P/1BG3SR1/LNS1KG1NL w - 1",
@@ -360,9 +361,10 @@ sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1
           maxPly: 5,
         },
         summary: {
-          successFileCount: 4,
+          successFileCount: 5,
           errorFileCount: 0,
-          entryCount: 15,
+          skippedFileCount: 0,
+          entryCount: 23,
           duplicateCount: 1,
         },
         includedSFEN: ["lnsgkgsnl/1r5b1/p1ppppppp/9/1p5P1/9/PPPPPPP1P/1B5R1/LNSGKGSNL b - 1"],
@@ -382,6 +384,7 @@ sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1
         summary: {
           successFileCount: 4,
           errorFileCount: 0,
+          skippedFileCount: 1, // .sfen file is skipped
           entryCount: 10,
           duplicateCount: 0,
         },
@@ -400,6 +403,7 @@ sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1
         summary: {
           successFileCount: 1,
           errorFileCount: 0,
+          skippedFileCount: 0,
           entryCount: 10,
           duplicateCount: 0,
         },
@@ -416,6 +420,7 @@ sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1
         summary: {
           successFileCount: 1,
           errorFileCount: 0,
+          skippedFileCount: 0,
           entryCount: 5,
           duplicateCount: 0,
         },
@@ -432,6 +437,7 @@ sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1
         summary: {
           successFileCount: 1,
           errorFileCount: 0,
+          skippedFileCount: 0,
           entryCount: 5,
           duplicateCount: 0,
         },

--- a/src/tests/common/settings/book.spec.ts
+++ b/src/tests/common/settings/book.spec.ts
@@ -82,7 +82,7 @@ describe("settings/book", () => {
         maxPly: 100,
         playerCriteria: PlayerCriteria.ALL,
       }),
-    ).toBeInstanceOf(Error);
+    ).toBeUndefined();
     expect(
       validateBookImportSettings({
         sourceType: SourceType.FILE,

--- a/src/tests/testdata/book/source/src05.sfen
+++ b/src/tests/testdata/book/source/src05.sfen
@@ -1,0 +1,2 @@
+position startpos moves 7g7f 7a6b 2h7h 5c5d 7i6h
+position startpos moves 7g7f 2c2d 2g2f 3c3d 5i6h 5c5d


### PR DESCRIPTION
# 説明 / Description

#1253 

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - File open dialogs for record files now allow specifying supported file formats, improving flexibility and user experience when selecting files.
  - Import summaries now include counts of skipped files, providing clearer feedback on import results.

- **Bug Fixes**
  - Improved handling and filtering of SFEN files during import, including stricter player name filtering and early skipping of unsupported cases.
  - Validation no longer rejects SFEN files, enabling their import.

- **Refactor**
  - Modularized the logic for importing book moves, resulting in clearer and more maintainable code.

- **Documentation**
  - Removed unused translation keys related to unsupported SFEN file imports from all supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->