### PR TITLE
Remove embedded floodgate resource urls

### DIFF
--- a/src/common/links/floodgate.ts
+++ b/src/common/links/floodgate.ts
@@ -1,5 +1,2 @@
 export const floodgateBaseURL = "http://wdoor.c.u-tokyo.ac.jp";
 export const floodgateTopURL = `${floodgateBaseURL}/shogi/floodgate.html`;
-export const floodgatePlayingURL = `${floodgateBaseURL}/shogi/LATEST/playing.txt`;
-export const floodgateGameHistoryURL = `${floodgateBaseURL}/shogi/LATEST/floodgate_history_300_10F.yaml`;
-export const floodgatePlayersURL = `${floodgateBaseURL}/shogi/LATEST/floodgate-players.txt`;

--- a/src/common/links/github.ts
+++ b/src/common/links/github.ts
@@ -25,6 +25,7 @@ export const maxPVLengthSettingWikiPageURL = `${wikiPageBaseURL}${maxPVLengthTit
 export const disableHWASettingWikiPageURL = `${wikiPageBaseURL}${disableHWASettingTitle}`;
 export const licenseURL = `https://${ghDomain}/${ghAccount}/${ghRepository}/blob/main/LICENSE`;
 export const wcscGameListsURL = `https://${ghioDomain}/${ghRepository}/wcsc/game-lists.json`;
+export const floodgateResourcesURL = `https://${ghioDomain}/${ghRepository}/floodgate/resources.json`;
 
 const webAppBaseURL = `https://${ghioDomain}/${ghRepository}/webapp/index.html`;
 

--- a/src/renderer/external/floodgate.ts
+++ b/src/renderer/external/floodgate.ts
@@ -1,12 +1,16 @@
-import {
-  floodgateBaseURL,
-  floodgateGameHistoryURL,
-  floodgatePlayersURL,
-  floodgatePlayingURL,
-} from "@/common/links/floodgate";
+import { floodgateBaseURL } from "@/common/links/floodgate";
+import { floodgateResourcesURL } from "@/common/links/github";
 import api from "@/renderer/ipc/api";
 import { Color } from "tsshogi";
 import YAML from "yaml";
+
+type FloodgateResources = {
+  playingGameList?: string;
+  gameHistory?: string;
+  players?: string;
+};
+
+let floodgateResources: FloodgateResources | undefined;
 
 export type Game = {
   id: string;
@@ -28,6 +32,15 @@ export type Player = {
   name: string;
   rate: number;
 };
+
+export async function fetchFloodgateResources(): Promise<FloodgateResources> {
+  if (floodgateResources) {
+    return floodgateResources;
+  }
+  const response = await api.loadRemoteTextFile(floodgateResourcesURL);
+  floodgateResources = JSON.parse(response) as FloodgateResources;
+  return floodgateResources;
+}
 
 export async function listLatestGames(): Promise<Game[]> {
   const playing = await listPlayingGames();
@@ -66,7 +79,11 @@ function getCSAFileURL(gameID: string): string | undefined {
 }
 
 async function listPlayingGames(): Promise<Game[]> {
-  const text = await api.loadRemoteTextFile(floodgatePlayingURL);
+  const resources = await fetchFloodgateResources();
+  if (!resources.playingGameList) {
+    return [];
+  }
+  const text = await api.loadRemoteTextFile(resources.playingGameList);
   const lines = text.split("\n");
   const games: Game[] = [];
   for (const line of lines) {
@@ -101,7 +118,11 @@ async function listPlayingGames(): Promise<Game[]> {
 }
 
 async function listEndedGames(): Promise<Game[]> {
-  const yaml = await api.loadRemoteTextFile(floodgateGameHistoryURL);
+  const resources = await fetchFloodgateResources();
+  if (!resources.gameHistory) {
+    return [];
+  }
+  const yaml = await api.loadRemoteTextFile(resources.gameHistory);
   const list = YAML.parse(yaml);
   if (!Array.isArray(list)) {
     return [];
@@ -141,7 +162,11 @@ async function listEndedGames(): Promise<Game[]> {
 }
 
 export async function listPlayers(): Promise<Player[]> {
-  const text = await api.loadRemoteTextFile(floodgatePlayersURL);
+  const resources = await fetchFloodgateResources();
+  if (!resources.players) {
+    return [];
+  }
+  const text = await api.loadRemoteTextFile(resources.players);
   const lines = text.split("\n");
   const players: Player[] = [];
   for (const line of lines) {

--- a/src/tests/renderer/external/floodgate.spec.ts
+++ b/src/tests/renderer/external/floodgate.spec.ts
@@ -8,6 +8,7 @@ vi.mock("@/renderer/ipc/api.js");
 
 const mockAPI = api as Mocked<API>;
 
+const floodgateResources = fs.readFileSync("docs/floodgate/resources.json", "utf-8");
 const samplePlayingGameList = fs.readFileSync("src/tests/testdata/floodgate/playing.txt", "utf-8");
 const sampleGameHistory = fs.readFileSync(
   "src/tests/testdata/floodgate/floodgate_history_300_10F.yaml",
@@ -16,6 +17,10 @@ const sampleGameHistory = fs.readFileSync(
 const samplePlayerList = fs.readFileSync("src/tests/testdata/floodgate/players.txt", "utf-8");
 
 describe("Floodgate", () => {
+  beforeAll(() => {
+    mockAPI.loadRemoteTextFile.mockResolvedValueOnce(floodgateResources);
+  });
+
   afterEach(() => {
     vi.clearAllMocks();
   });


### PR DESCRIPTION
# 説明 / Description

直接 Floodgate の対局リストの URL を埋め込まずに GitHub Pages を経由させる。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The app now dynamically fetches Floodgate resource URLs from a centralized online source, improving flexibility in accessing updated game, history, and player data.

* **Refactor**
  * Centralized the management of Floodgate resource URLs, reducing reliance on hardcoded links and enabling smoother updates to resource locations without requiring app changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->