### PR TITLE
ポートレイト表示で後手の駒台のドロップシャドウが盤の前面に表示される問題を修正

### DIFF
--- a/src/renderer/view/primitive/BoardView.vue
+++ b/src/renderer/view/primitive/BoardView.vue
@@ -1,6 +1,28 @@
 <template>
   <div>
     <div class="frame" :style="main.frame.style" @click="clickFrame()">
+      <!-- 後手の駒台 -->
+      <div class="hand" :style="main.whiteHandStyle">
+        <div
+          class="hand-background"
+          :class="{ 'drop-shadows': dropShadows }"
+          :style="whiteHand.backgroundStyle"
+        >
+          <img v-if="whiteHand.textureImagePath" class="full" :src="whiteHand.textureImagePath" />
+        </div>
+        <div
+          v-for="pointer in whiteHand.pointers"
+          :key="pointer.id"
+          :style="pointer.backgroundStyle"
+        ></div>
+        <div v-for="piece in whiteHand.pieces" :key="piece.id" :style="piece.style">
+          <img class="piece-image" :src="piece.imagePath" />
+        </div>
+        <div v-for="number in whiteHand.numbers" :key="number.id" :style="number.style">
+          {{ number.character }}
+        </div>
+      </div>
+
       <!-- 盤面 -->
       <div class="board" :style="main.boardStyle">
         <div v-if="board.background.textureImagePath" :style="board.background.style">
@@ -40,28 +62,6 @@
           <img class="piece-image" :src="piece.imagePath" />
         </div>
         <div v-for="number in blackHand.numbers" :key="number.id" :style="number.style">
-          {{ number.character }}
-        </div>
-      </div>
-
-      <!-- 後手の駒台 -->
-      <div class="hand" :style="main.whiteHandStyle">
-        <div
-          class="hand-background"
-          :class="{ 'drop-shadows': dropShadows }"
-          :style="whiteHand.backgroundStyle"
-        >
-          <img v-if="whiteHand.textureImagePath" class="full" :src="whiteHand.textureImagePath" />
-        </div>
-        <div
-          v-for="pointer in whiteHand.pointers"
-          :key="pointer.id"
-          :style="pointer.backgroundStyle"
-        ></div>
-        <div v-for="piece in whiteHand.pieces" :key="piece.id" :style="piece.style">
-          <img class="piece-image" :src="piece.imagePath" />
-        </div>
-        <div v-for="number in whiteHand.numbers" :key="number.id" :style="number.style">
           {{ number.character }}
         </div>
       </div>


### PR DESCRIPTION
# 説明 / Description

#1262 

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Changed the layout to display the white player's hand above the board instead of below it. The appearance and content of the hand remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->