### PR TITLE
エンジン設定比較機能で未設定のオプションが無条件で差分に出る問題を修正

### DIFF
--- a/src/common/settings/usi.ts
+++ b/src/common/settings/usi.ts
@@ -58,7 +58,7 @@ export type USIEngineOption = {
 );
 
 export function getUSIEngineOptionCurrentValue(
-  option: USIEngineOption | null | undefined,
+  option: USIEngineOption | undefined,
 ): string | number | undefined {
   if (!option || option.type === "button") {
     return;
@@ -282,8 +282,8 @@ function isValidOptionValue(option: USIEngineOption): boolean {
 
 export type USIEngineOptionDiff = {
   name: string;
-  leftValue: string | number | undefined;
-  rightValue: string | number | undefined;
+  leftValue?: string | number;
+  rightValue?: string | number;
   mergeable: boolean;
 };
 
@@ -292,25 +292,25 @@ export function compareUSIEngineOptions(left: USIEngine, right: USIEngine): USIE
   function append(leftOption?: USIEngineOption, rightOption?: USIEngineOption) {
     const leftHasValue = leftOption && leftOption.type !== "button";
     const rightHasValue = rightOption && rightOption.type !== "button";
-    if (leftHasValue && rightHasValue && leftOption.value !== rightOption.value) {
+    const leftValue = getUSIEngineOptionCurrentValue(leftOption);
+    const rightValue = getUSIEngineOptionCurrentValue(rightOption);
+    if (leftHasValue && rightHasValue && leftValue !== rightValue) {
       result.push({
         name: leftOption.name,
-        leftValue: getUSIEngineOptionCurrentValue(leftOption),
-        rightValue: getUSIEngineOptionCurrentValue(rightOption),
+        leftValue,
+        rightValue,
         mergeable: leftOption.type === rightOption.type,
       });
     } else if (leftHasValue && !rightHasValue) {
       result.push({
         name: leftOption.name,
-        leftValue: getUSIEngineOptionCurrentValue(leftOption),
-        rightValue: undefined,
+        leftValue,
         mergeable: false,
       });
     } else if (!leftHasValue && rightHasValue) {
       result.push({
         name: rightOption.name,
-        leftValue: undefined,
-        rightValue: getUSIEngineOptionCurrentValue(rightOption),
+        rightValue,
         mergeable: false,
       });
     }

--- a/src/tests/common/settings/usi.spec.ts
+++ b/src/tests/common/settings/usi.spec.ts
@@ -79,7 +79,7 @@ describe("settings/usi", () => {
         default: "<empty>",
       }),
     ).toBe("");
-    expect(getUSIEngineOptionCurrentValue(null)).toBeUndefined();
+    expect(getUSIEngineOptionCurrentValue(undefined)).toBeUndefined();
   });
 
   it("getUSIEnginePonder", () => {
@@ -633,6 +633,10 @@ describe("settings/usi", () => {
         StringA: { name: "StringA", type: "string", order: 4, value: "foo" },
         StringB: { name: "StringB", type: "string", order: 5, value: "bar" },
         Depth: { name: "Depth", type: "spin", order: 6, default: 1, value: 2 }, // only lhs
+        NumberA: { name: "NumberA", type: "spin", order: 7, default: 1, value: 2 },
+        NumberB: { name: "NumberB", type: "spin", order: 8, default: 1 }, // default value
+        NumberC: { name: "NumberC", type: "spin", order: 9, default: 1, value: 2 },
+        NumberD: { name: "NumberD", type: "spin", order: 10, default: 1 }, // default value
       },
     };
     const rhs: USIEngine = {
@@ -646,16 +650,22 @@ describe("settings/usi", () => {
         StringA: { name: "StringA", type: "string", order: 4, value: "foo" }, // equal
         StringB: { name: "StringB", type: "string", order: 5, value: "baz" }, // different value
         ResignValue: { name: "ResignValue", type: "spin", order: 6, default: 1, value: -3000 }, // only rhs
+        NumberA: { name: "NumberA", type: "spin", order: 7, default: 1 }, // default value
+        NumberB: { name: "NumberB", type: "spin", order: 8, default: 1, value: 2 },
+        NumberC: { name: "NumberC", type: "spin", order: 9, default: 2 }, // default value
+        NumberD: { name: "NumberD", type: "spin", order: 10, default: 2, value: 1 },
       },
     };
     const result = compareUSIEngineOptions(lhs, rhs);
     expect(result).toStrictEqual([
       { name: "USI_Hash", leftValue: 64, rightValue: 32, mergeable: true },
-      { name: "Log", leftValue: undefined, rightValue: "true", mergeable: false },
+      { name: "Log", rightValue: "true", mergeable: false },
       { name: "Book", leftValue: "book.db", rightValue: "standard.db", mergeable: false },
       { name: "StringB", leftValue: "bar", rightValue: "baz", mergeable: true },
-      { name: "Depth", leftValue: 2, rightValue: undefined, mergeable: false },
-      { name: "ResignValue", leftValue: undefined, rightValue: -3000, mergeable: false },
+      { name: "Depth", leftValue: 2, mergeable: false },
+      { name: "NumberA", leftValue: 2, rightValue: 1, mergeable: true },
+      { name: "NumberB", leftValue: 1, rightValue: 2, mergeable: true },
+      { name: "ResignValue", rightValue: -3000, mergeable: false },
     ]);
   });
 


### PR DESCRIPTION
# 説明 / Description

#1261 

エンジンを追加してから一度もオプション設定画面を開いていない場合、各オプションはデフォルト値だけを持ち値は未指定という扱いになる。
その状態で他のエンジンと比較をすると、デフォルト値が相手の設定値と一致していても差分に表示されてしまう。
デフォルト値しかない場合はその値で比較を行い、比較相手の値と等しければ差分に出さないようにする。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for engine option comparisons, including additional numeric options and more detailed value scenarios.
  * Updated tests to reflect changes in how undefined values are handled.

* **Refactor**
  * Improved internal logic for comparing engine options, centralizing value retrieval and updating type handling for option values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->