### PR TITLE
ブラウザ版(スマホ)において、ダブルタップによるズームを無効化する

### DIFF
--- a/src/renderer/css/basic.css
+++ b/src/renderer/css/basic.css
@@ -1,5 +1,6 @@
 body {
   margin: 0;
+  touch-action: manipulation;
 }
 
 body::-webkit-scrollbar {


### PR DESCRIPTION
# 説明 / Description

ブラウザ版をスマートフォンで起動した際、指し手を前後に送る矢印ボタンを連打すると、「ダブルタップ」と判定されてしまい、意図せず画面がズームしてしまうという挙動になっており、不便に感じていました。

<details>
<summary>動画</summary>

https://github.com/user-attachments/assets/ecb5682a-07e3-4ea3-bb49-5c17087452cd
</details>

CSS にて [touch-action: manipulation](https://developer.mozilla.org/ja/docs/Web/CSS/touch-action) を指定することにより、連打してもズームされなくなりました。

<details>
<summary>動画</summary>

https://github.com/user-attachments/assets/4880f9ac-014d-423e-bb1f-1eca66ccc696
</details>

また、駒をタップで掴んでから他の地点に動かすとき、修正前は掴む→動かすの動作を素早く行った場合、駒が動いてくれないということがありました。

<details>
<summary>動画</summary>

https://github.com/user-attachments/assets/5764aaed-a73f-4f35-91ce-fcdfa1bd7b93
</details>

修正後は、素早く掴む→動かすの動作を行った場合でも、正しく駒が動くようになりました。

<details>
<summary>動画</summary>

https://github.com/user-attachments/assets/fc0cf5ad-6980-42a2-8953-4d39bbf25e2e
</details>

# 環境 / Environment

上記の動作確認は、iPhone 16 Pro (iOS 18.5) で行っています。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [x] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved touch interaction responsiveness on mobile devices by optimizing touch behavior for the entire page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->