### PR TITLE
起動直後のカスタムレイアウトを引数で指定する機能

### DIFF
--- a/src/background/headless/command.ts
+++ b/src/background/headless/command.ts
@@ -1,4 +1,4 @@
-export type Headless = {
+export type HeadlessModeOperation = {
   operation: "addEngine";
   path: string;
   name: string;

--- a/src/background/headless/invoke.ts
+++ b/src/background/headless/invoke.ts
@@ -1,10 +1,10 @@
 import path from "node:path";
 import { loadUSIEngines, saveUSIEngines } from "@/background/settings.js";
 import { getAppLogger } from "@/background/log.js";
-import { Headless } from "./command.js";
+import { HeadlessModeOperation } from "./command.js";
 import { getUSIEngineInfo } from "@/background/usi/index.js";
 
-export async function invoke(headless: Headless) {
+export async function invoke(headless: HeadlessModeOperation) {
   switch (headless.operation) {
     case "addEngine":
       await addEngine(headless.path, headless.name, headless.timeout);

--- a/src/background/proc/args.ts
+++ b/src/background/proc/args.ts
@@ -1,70 +1,84 @@
-import { InitialRecordFileRequest } from "@/common/file/record.js";
-import { getAppLogger } from "@/background/log.js";
 import { isSupportedRecordFilePath } from "@/background/file/extensions.js";
-import { Headless } from "@/background/headless/command.js";
+import { HeadlessModeOperation } from "@/background/headless/command.js";
+import { ProcessArgs as GUIArgs } from "@/common/ipc/process.js";
+import { LayoutProfile } from "@/common/settings/layout.js";
+import { loadLayoutProfileListSync } from "@/background/settings.js";
 
-let initialFilePath = "";
+type ProcessArgs = ({ type: "headless" } & HeadlessModeOperation) | ({ type: "gui" } & GUIArgs);
 
-export function setInitialFilePath(path: string): void {
-  initialFilePath = path;
-}
-
-export function fetchInitialRecordFileRequest(): InitialRecordFileRequest {
-  // macOS
-  if (isSupportedRecordFilePath(initialFilePath)) {
-    getAppLogger().debug(`record path from open-file event: ${initialFilePath}`);
-    return { path: initialFilePath };
-  }
-
-  let path = null;
-  let ply = undefined;
-  // Option:
-  //   ShogiGUI/KifuExplorer style:
-  //     -n <ply>
-  //   KifuBase style:
-  //     +<ply>
-  for (const arg of process.argv) {
+export function parseProcessArgs(args: string[]): ProcessArgs | Error {
+  // GUI mode option:
+  //   /path/to/record.<extension>
+  //       path to record file
+  //
+  //   -n <ply>
+  //       ShogiGUI/KifuExplorer style ply
+  //
+  //   +<ply>
+  //     KifuBase style ply
+  //
+  //   --layout-profile <profile>
+  //     layout profile
+  //
+  // Headless mode option:
+  //   --add-engine <path> <name> <timeout>
+  //     add USI engine
+  //
+  let path;
+  let ply;
+  let layoutProfile: LayoutProfile | undefined;
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    const nextArg = args[i + 1];
     if (isSupportedRecordFilePath(arg)) {
+      // 棋譜ファイル
       path = arg;
-    } else if (!isNaN(Number(arg))) {
-      ply = Number(arg);
+    } else if (arg === "-n" && !isNaN(Number(nextArg))) {
+      // 手数 (ShogiGUI/KifuExplorer style)
+      ply = Number(nextArg);
+      i++;
     } else if (/^\+\d+$/.test(arg)) {
+      // 手数 (KifuBase style)
       ply = Number(arg.substring(1));
-    }
-  }
-  return path ? { path, ply } : null;
-}
-
-export function parseHeadlessArgs(): Headless | null | Error {
-  for (let i = 0; i < process.argv.length; i++) {
-    switch (process.argv[i]) {
-      // Add a USI engine
-      // --add-engine <path> <name> <timeout>
-      case "--add-engine": {
-        const usage = "Usage: --add-engine <path> <name> <timeout>";
-        if (i + 3 >= process.argv.length) {
-          return new Error(usage);
-        }
-        const path = process.argv[++i];
-        if (!path) {
-          return new Error("Empty engine path");
-        }
-        const name = process.argv[++i];
-        if (!name) {
-          return new Error("Empty engine name");
-        }
-        const timeout = Number(process.argv[++i]);
-        if (isNaN(timeout) || timeout < 0) {
-          return new Error("Invalid timeout value");
-        }
-        return {
-          operation: "addEngine",
-          path,
-          name,
-          timeout,
-        };
+    } else if (arg === "--layout-profile" && nextArg) {
+      // レイアウトプロファイル
+      const layoutProfileList = loadLayoutProfileListSync();
+      layoutProfile = layoutProfileList.profiles.find((profile) => profile.uri === nextArg);
+      if (!layoutProfile) {
+        return new Error(`Invalid layout profile: ${nextArg}`);
       }
+      i++;
+    } else if (arg === "--add-engine") {
+      // エンジン追加
+      const usage = "Usage: --add-engine <path> <name> <timeout>";
+      if (args.length < i + 4) {
+        return new Error(usage);
+      }
+      const path = args[++i];
+      if (!path) {
+        return new Error("Empty engine path");
+      }
+      const name = args[++i];
+      if (!name) {
+        return new Error("Empty engine name");
+      }
+      const timeout = Number(args[++i]);
+      if (isNaN(timeout) || timeout < 0) {
+        return new Error("Invalid timeout value");
+      }
+      return {
+        type: "headless",
+        operation: "addEngine",
+        path,
+        name,
+        timeout,
+      };
     }
   }
-  return null;
+  return {
+    type: "gui",
+    path,
+    ply,
+    layoutProfile,
+  };
 }

--- a/src/background/settings.ts
+++ b/src/background/settings.ts
@@ -260,6 +260,13 @@ export async function loadLayoutProfileList(): Promise<LayoutProfileList> {
   return JSON.parse(await fs.promises.readFile(layoutProfileListPath, "utf8"));
 }
 
+export function loadLayoutProfileListSync(): LayoutProfileList {
+  if (!fs.existsSync(layoutProfileListPath)) {
+    return emptyLayoutProfileList();
+  }
+  return JSON.parse(fs.readFileSync(layoutProfileListPath, "utf8"));
+}
+
 const bookImportSettingsPath = path.join(rootDir, "book_import.json");
 
 export async function saveBookImportSettings(settings: BookImportSettings): Promise<void> {

--- a/src/command/common/preload.ts
+++ b/src/command/common/preload.ts
@@ -36,6 +36,9 @@ const bridge: Bridge = {
   updateAppState(): void {
     // DO NOTHING
   },
+  async fetchProcessArgs(): Promise<string> {
+    return "null";
+  },
   onClosable(): void {
     // Do Nothing
   },
@@ -112,9 +115,6 @@ const bridge: Bridge = {
   },
 
   // Record File
-  async fetchInitialRecordFileRequest(): Promise<string> {
-    return "null";
-  },
   async showOpenRecordDialog(): Promise<string> {
     throw new Error("This feature is not available on command line tool");
   },
@@ -335,7 +335,7 @@ const bridge: Bridge = {
   updateLayoutProfileList(): void {
     // Do Nothing
   },
-  onUpdateLayoutProfileList(): void {
+  onUpdateLayoutProfile(): void {
     // Do Nothing
   },
 

--- a/src/common/file/record.ts
+++ b/src/common/file/record.ts
@@ -129,8 +129,3 @@ export function exportRecordAsBuffer(
   }
   return { data, garbled };
 }
-
-export type InitialRecordFileRequest = {
-  path: string;
-  ply?: number;
-} | null;

--- a/src/common/ipc/channel.ts
+++ b/src/common/ipc/channel.ts
@@ -1,5 +1,5 @@
 export enum Background {
-  FETCH_INITIAL_RECORD_FILE_REQUEST = "fetchInitialRecordFileRequest",
+  FETCH_PROCESS_ARGS = "fetchProcessArgs",
   UPDATE_APP_STATE = "updateAppState",
   OPEN_EXPLORER = "openExplorer",
   OPEN_WEB_BROWSER = "openWebBrowser",
@@ -106,6 +106,6 @@ export enum Renderer {
   CSA_GAME_RESULT = "csaGameResult",
   CSA_CLOSE = "csaClose",
   PROMPT_COMMAND = "promptCommand",
-  UPDATE_LAYOUT_PROFILE_LIST = "updateLayoutProfileList",
+  UPDATE_LAYOUT_PROFILE = "updateLayoutProfile",
   PROGRESS = "progress",
 }

--- a/src/common/ipc/process.ts
+++ b/src/common/ipc/process.ts
@@ -1,0 +1,7 @@
+import { LayoutProfile } from "@/common/settings/layout.js";
+
+export type ProcessArgs = {
+  path?: string;
+  ply?: number;
+  layoutProfile?: LayoutProfile;
+};

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -85,14 +85,18 @@ Promise.allSettled([
     .catch((e) => {
       useErrorStore().add(new Error("アプリ設定の読み込み中にエラーが発生しました: " + e));
     }),
-  // 起動時パラメータで指定された棋譜の読み込み
+  // 起動時パラメータの取得
   api
-    .fetchInitialRecordFileRequest()
-    .then((request) => {
-      if (request) {
-        store.openRecord(request.path, {
-          ply: request.ply,
-        });
+    .fetchProcessArgs()
+    .then((args) => {
+      api.log(LogLevel.DEBUG, `args: ${JSON.stringify(args)}`);
+      // 棋譜の読み込み
+      if (args?.path) {
+        store.openRecord(args.path, { ply: args.ply });
+      }
+      // レイアウトの設定
+      if (args?.layoutProfile) {
+        store.updateLayoutProfile(args.layoutProfile);
       }
     })
     .catch((e) => {

--- a/src/renderer/ipc/api.ts
+++ b/src/renderer/ipc/api.ts
@@ -13,7 +13,7 @@ import { MateSearchSettings } from "@/common/settings/mate.js";
 import { BatchConversionSettings } from "@/common/settings/conversion.js";
 import { BatchConversionResult } from "@/common/file/conversion.js";
 import { RecordFileHistory } from "@/common/file/history.js";
-import { InitialRecordFileRequest, RecordFileFormat } from "@/common/file/record.js";
+import { RecordFileFormat } from "@/common/file/record.js";
 import { VersionStatus } from "@/common/version.js";
 import { SessionStates } from "@/common/advanced/monitor.js";
 import { PromptTarget } from "@/common/advanced/prompt.js";
@@ -23,6 +23,7 @@ import { TimeStates } from "@/common/game/time.js";
 import { LayoutProfileList } from "@/common/settings/layout.js";
 import { BookImportSummary, BookLoadingMode, BookLoadingOptions, BookMove } from "@/common/book.js";
 import { BookImportSettings } from "@/common/settings/book.js";
+import { ProcessArgs } from "@/common/ipc/process.js";
 
 type AppInfo = {
   appVersion?: string;
@@ -31,6 +32,7 @@ type AppInfo = {
 export interface API {
   // Core
   updateAppState(appState: AppState, researchState: ResearchState, busy: boolean): void;
+  fetchProcessArgs(): Promise<ProcessArgs>;
 
   // Settings
   loadAppSettings(): Promise<AppSettings>;
@@ -53,7 +55,6 @@ export interface API {
   saveBookImportSettings(settings: BookImportSettings): Promise<void>;
 
   // Record File
-  fetchInitialRecordFileRequest(): Promise<InitialRecordFileRequest>;
   showOpenRecordDialog(formats: RecordFileFormat[]): Promise<string>;
   showSaveRecordDialog(defaultPath: string): Promise<string>;
   showSaveMergedRecordDialog(defaultPath: string): Promise<string>;
@@ -158,6 +159,11 @@ export const bridge: Bridge = getWindowObject().electronShogiAPI || webAPI;
 const api: API = {
   ...bridge,
 
+  // Core
+  async fetchProcessArgs(): Promise<ProcessArgs> {
+    return JSON.parse(await bridge.fetchProcessArgs());
+  },
+
   // Settings
   async loadAppSettings(): Promise<AppSettings> {
     return JSON.parse(await bridge.loadAppSettings());
@@ -218,9 +224,6 @@ const api: API = {
   },
 
   // Record File
-  async fetchInitialRecordFileRequest(): Promise<InitialRecordFileRequest> {
-    return JSON.parse(await bridge.fetchInitialRecordFileRequest());
-  },
   async convertRecordFiles(settings: BatchConversionSettings): Promise<BatchConversionResult> {
     return JSON.parse(await bridge.convertRecordFiles(JSON.stringify(settings)));
   },

--- a/src/renderer/ipc/bridge.ts
+++ b/src/renderer/ipc/bridge.ts
@@ -11,6 +11,7 @@ import { LogLevel, LogType } from "@/common/log.js";
 export interface Bridge {
   // Core
   updateAppState(appState: AppState, researchState: ResearchState, busy: boolean): void;
+  fetchProcessArgs(): Promise<string>;
   onClosable(): void;
   onClose(callback: (confirmations: string[]) => void): void;
   onSendError(callback: (e: string) => void): void;
@@ -39,7 +40,6 @@ export interface Bridge {
   onUpdateAppSettings(callback: (json: string) => void): void;
 
   // Record File
-  fetchInitialRecordFileRequest(): Promise<string>;
   showOpenRecordDialog(formats: RecordFileFormat[]): Promise<string>;
   showSaveRecordDialog(defaultPath: string): Promise<string>;
   showSaveMergedRecordDialog(defaultPath: string): Promise<string>;
@@ -130,7 +130,7 @@ export interface Bridge {
   // Layout
   loadLayoutProfileList(): Promise<[string, string]>;
   updateLayoutProfileList(uri: string, profileList: string): void;
-  onUpdateLayoutProfileList(callback: (uri: string, json: string) => void): void;
+  onUpdateLayoutProfile(callback: (json: string | null) => void): void;
 
   // Log
   openLogFile(logType: LogType): void;

--- a/src/renderer/ipc/preload.ts
+++ b/src/renderer/ipc/preload.ts
@@ -15,6 +15,9 @@ const api: Bridge = {
   updateAppState(appState: AppState, researchState: ResearchState, busy: boolean): void {
     ipcRenderer.send(Background.UPDATE_APP_STATE, appState, researchState, busy);
   },
+  async fetchProcessArgs(): Promise<string> {
+    return await ipcRenderer.invoke(Background.FETCH_PROCESS_ARGS);
+  },
   onClosable(): void {
     ipcRenderer.send(Background.ON_CLOSABLE);
   },
@@ -98,9 +101,6 @@ const api: Bridge = {
   },
 
   // Record File
-  async fetchInitialRecordFileRequest(): Promise<string> {
-    return await ipcRenderer.invoke(Background.FETCH_INITIAL_RECORD_FILE_REQUEST);
-  },
   async showOpenRecordDialog(formats: string[]): Promise<string> {
     return await ipcRenderer.invoke(Background.SHOW_OPEN_RECORD_DIALOG, formats);
   },
@@ -359,9 +359,9 @@ const api: Bridge = {
   updateLayoutProfileList(uri: string, profileList: string): void {
     ipcRenderer.send(Background.UPDATE_LAYOUT_PROFILE_LIST, uri, profileList);
   },
-  onUpdateLayoutProfileList(callback: (uri: string, json: string) => void): void {
-    ipcRenderer.on(Renderer.UPDATE_LAYOUT_PROFILE_LIST, (_, uri, json) => {
-      callback(uri, json);
+  onUpdateLayoutProfile(callback: (json: string | null) => void): void {
+    ipcRenderer.on(Renderer.UPDATE_LAYOUT_PROFILE, (_, json) => {
+      callback(json);
     });
   },
 

--- a/src/renderer/ipc/setup.ts
+++ b/src/renderer/ipc/setup.ts
@@ -308,8 +308,8 @@ export function setup(): void {
   bridge.onCSAClose(onCSAClose);
 
   // Layout
-  bridge.onUpdateLayoutProfileList((uri, json) => {
-    store.updateLayoutProfileList(uri, JSON.parse(json));
+  bridge.onUpdateLayoutProfile((json) => {
+    store.updateLayoutProfile(json && JSON.parse(json));
   });
 
   // MISC

--- a/src/renderer/ipc/web.ts
+++ b/src/renderer/ipc/web.ts
@@ -17,6 +17,7 @@ import { SessionStates } from "@/common/advanced/monitor.js";
 import { emptyLayoutProfileList } from "@/common/settings/layout.js";
 import * as uri from "@/common/uri.js";
 import { basename } from "@/renderer/helpers/path.js";
+import { ProcessArgs } from "@/common/ipc/process";
 
 enum STORAGE_KEY {
   APP_SETTINGS = "appSetting",
@@ -35,6 +36,9 @@ export const webAPI: Bridge = {
   // Core
   updateAppState(): void {
     // DO NOTHING
+  },
+  async fetchProcessArgs(): Promise<string> {
+    return JSON.stringify({} as ProcessArgs);
   },
   onClosable(): void {
     // Do Nothing
@@ -164,9 +168,6 @@ export const webAPI: Bridge = {
   },
 
   // Record File
-  async fetchInitialRecordFileRequest(): Promise<string> {
-    return "null";
-  },
   async showOpenRecordDialog(formats: string[]): Promise<string> {
     const input = document.createElement("input");
     input.setAttribute("type", "file");
@@ -425,7 +426,7 @@ export const webAPI: Bridge = {
   updateLayoutProfileList(): void {
     // Do Nothing
   },
-  onUpdateLayoutProfileList(): void {
+  onUpdateLayoutProfile(): void {
     // Do Nothing
   },
 

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -65,7 +65,7 @@ import { setOnStartSearchHandler, setOnUpdateUSIInfoHandler } from "@/renderer/p
 import { useErrorStore } from "./error.js";
 import { useBusyState } from "./busy.js";
 import { Confirmation, useConfirmationStore } from "./confirm.js";
-import { LayoutProfile, LayoutProfileList } from "@/common/settings/layout.js";
+import { LayoutProfile } from "@/common/settings/layout.js";
 import { clearURLParams, loadRecordForWebApp, saveRecordForWebApp } from "./webapp.js";
 import { CommentBehavior } from "@/common/settings/comment.js";
 import { Attachment, ListItem } from "@/common/message.js";
@@ -315,8 +315,8 @@ class Store {
     return this._customLayout;
   }
 
-  updateLayoutProfileList(uri: string, profileList: LayoutProfileList): void {
-    this._customLayout = profileList.profiles.find((p) => p.uri === uri) || null;
+  updateLayoutProfile(layout: LayoutProfile | null): void {
+    this._customLayout = layout;
   }
 
   get pvPreview(): PVPreview | undefined {

--- a/src/renderer/view/layout/LayoutManager.vue
+++ b/src/renderer/view/layout/LayoutManager.vue
@@ -29,12 +29,18 @@
         </div>
       </div>
       <div v-if="customProfile" class="custom-profile column grow scroll">
-        <div class="row">
+        <div>
           <input
             class="profile-name"
             :value="customProfile.name"
             @input="(e) => updateCustomProfileProp('name', inputEventToString(e))"
           />
+        </div>
+        <div class="uri row">
+          <span>{{ customProfile.uri }}</span>
+          <button @click="copyProfileURI">
+            <Icon :icon="IconType.COPY" />
+          </button>
         </div>
         <div class="row">
           <span class="key">{{ t.dialogPosition }}:</span>
@@ -361,6 +367,8 @@ import { useConfirmationStore } from "@/renderer/store/confirm";
 import InfoMessage from "@/renderer/view/dialog/InfoMessage.vue";
 import ErrorMessage from "@/renderer/view/dialog/ErrorMessage.vue";
 import ConfirmDialog from "@/renderer/view/dialog/ConfirmDialog.vue";
+import Icon from "@/renderer/view/primitive/Icon.vue";
+import { IconType } from "@/renderer/assets/icons.js";
 
 const appSettings = useAppSettings();
 const messageStore = useMessageStore();
@@ -419,6 +427,14 @@ const importProfile = async () => {
   } catch (e) {
     errorStore.add(new Error(t.failedToImportProfile));
   }
+};
+
+const copyProfileURI = () => {
+  const profile = getCurrentProfile();
+  if (!profile) {
+    return;
+  }
+  navigator.clipboard.writeText(profile.uri);
 };
 
 const updateCustomProfileProp = (key: string, value: unknown) => {
@@ -605,6 +621,15 @@ button {
 }
 .profile-name {
   width: 100%;
+}
+.uri {
+  font-size: 0.8em;
+}
+.uri .icon {
+  width: 16px;
+}
+.uri > *:not(:last-child) {
+  margin-right: 5px;
 }
 .component {
   border: 1px solid var(--dialog-border-color);


### PR DESCRIPTION
# 説明 / Description

#1267 

起動引数でカスタムレイアウトの指定を受け付け、起動後すぐにカスタムレイアウトを利用可能にする。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving and using process arguments at startup, including file path, ply number, and layout profile.
  * The layout profile editor now displays the profile URI with a convenient copy-to-clipboard button.

* **Improvements**
  * Unified and simplified handling of command-line arguments for both GUI and headless modes.
  * Enhanced layout profile update mechanism to send only the updated profile to the renderer.

* **Bug Fixes**
  * Improved error handling and validation for command-line arguments.

* **Refactor**
  * Streamlined IPC channels and method names for clarity and consistency.
  * Simplified and clarified layout profile management and related event handling.

* **Tests**
  * Updated and improved tests for process argument parsing and layout profile handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->