### PR TITLE
Windows/Linuxのフルスクリーン表示切り替え動作の変更

### DIFF
--- a/src/background/window/menu.ts
+++ b/src/background/window/menu.ts
@@ -81,6 +81,8 @@ function menuItem(
   };
 }
 
+let fullScreenNotiSent = false;
+
 function createMenuTemplate(window: BrowserWindow) {
   const menuTemplate: Array<MenuItemConstructorOptions | MenuItem> = [
     {
@@ -349,10 +351,23 @@ function createMenuTemplate(window: BrowserWindow) {
         {
           type: "separator",
         },
-        {
-          label: t.toggleFullScreen,
-          role: "togglefullscreen",
-        },
+        isMac
+          ? {
+              label: t.toggleFullScreen,
+              role: "togglefullscreen",
+            }
+          : {
+              label: t.toggleFullScreen,
+              click: () => {
+                const enable = !window.isFullScreen();
+                window.setFullScreen(enable);
+                if (enable && !fullScreenNotiSent) {
+                  sendMessage({ text: t.youCanExitFullScreenByPressing("F11") });
+                  fullScreenNotiSent = true;
+                }
+              },
+              accelerator: "F11",
+            },
         menuItem(t.flipBoard, MenuEvent.FLIP_BOARD, null, "CmdOrCtrl+T"),
         {
           label: t.defaultFontSize,

--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -764,4 +764,7 @@ export const en: Texts = {
   directoryNotFound(path: string) {
     return `Directory not found. [${path}]`;
   },
+  youCanExitFullScreenByPressing(key: string) {
+    return `You can exit full screen by pressing ${key} key.`;
+  },
 };

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -763,4 +763,7 @@ export const ja: Texts = {
   directoryNotFound(path: string) {
     return `フォルダが見つかりません。 [${path}]`;
   },
+  youCanExitFullScreenByPressing(key: string) {
+    return `全画面表示を終了するには ${key} キーを押してください。`;
+  },
 };

--- a/src/common/i18n/locales/vi.ts
+++ b/src/common/i18n/locales/vi.ts
@@ -760,4 +760,7 @@ export const vi: Texts = {
   directoryNotFound(path: string) {
     return `Không tìm thấy tập tin. [${path}]`;
   },
+  youCanExitFullScreenByPressing(key: string) {
+    return `全画面表示を終了するには ${key} キーを押してください。`; // TODO: Translate
+  },
 };

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -747,4 +747,7 @@ export const zh_tw: Texts = {
   directoryNotFound(path: string) {
     return `無法找到該目錄。 [${path}]`;
   },
+  youCanExitFullScreenByPressing(key: string) {
+    return `全画面表示を終了するには ${key} キーを押してください。`; // TODO: Translate
+  },
 };

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -711,4 +711,5 @@ export type Texts = {
   unexpectedRecordFileExtension: (path: string) => string;
   fileNotFound: (path: string) => string;
   directoryNotFound: (path: string) => string;
+  youCanExitFullScreenByPressing: (key: string) => string;
 };


### PR DESCRIPTION
# 説明 / Description

Windows/Linux のフルスクリーン表示に以下の変更を加える。

- 対象をメインウィンドウに限定
- アプリ起動後最初の切り替え時に F11 で元に戻る旨のメッセージを表示

#1286

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [x] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a notification on non-macOS platforms to inform users how to exit full screen mode the first time they enter it.
  * The "Toggle Full Screen" menu item now uses a custom shortcut and behavior on non-macOS platforms.

* **Localization**
  * Added new messages in English, Japanese, Vietnamese, and Traditional Chinese to instruct users on exiting full screen mode (some translations pending).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->