### PR TITLE
平手初形で初期化するメニューを追加

### DIFF
--- a/src/background/window/menu.ts
+++ b/src/background/window/menu.ts
@@ -89,6 +89,12 @@ function createMenuTemplate(window: BrowserWindow) {
       label: t.file,
       submenu: [
         menuItem(t.newRecord, MenuEvent.NEW_RECORD, [AppState.NORMAL], "CmdOrCtrl+N"),
+        menuItem(
+          t.newRecordHirateSetup,
+          MenuEvent.NEW_RECORD_HIRATE_SETUP,
+          [AppState.NORMAL],
+          "CmdOrCtrl+Shift+N",
+        ),
         menuItem(t.openRecord, MenuEvent.OPEN_RECORD, [AppState.NORMAL], "CmdOrCtrl+O"),
         menuItem(t.saveRecord, MenuEvent.SAVE_RECORD, [AppState.NORMAL], "CmdOrCtrl+S"),
         menuItem(t.saveRecordAs, MenuEvent.SAVE_RECORD_AS, [AppState.NORMAL], "CmdOrCtrl+Shift+S"),

--- a/src/common/control/menu.ts
+++ b/src/common/control/menu.ts
@@ -1,5 +1,6 @@
 export enum MenuEvent {
   NEW_RECORD = "newRecord",
+  NEW_RECORD_HIRATE_SETUP = "newRecordHirateSetup",
   OPEN_RECORD = "openRecord",
   SAVE_RECORD = "saveRecord",
   SAVE_RECORD_AS = "saveRecordAs",

--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -8,6 +8,7 @@ export const en: Texts = {
   openNewInstance: "Open New ShogiHome Instance",
   saveOverwrite: "Overwrite",
   newRecord: "New Record",
+  newRecordHirateSetup: "New Record (Hirate Setup)",
   openRecord: "Open Record",
   saveRecord: "Save Record",
   saveRecordAs: "Save Record As",

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -7,6 +7,7 @@ export const ja: Texts = {
   openNewInstance: "新しい ShogiHome ウィンドウを開く",
   saveOverwrite: "上書き保存",
   newRecord: "新規棋譜",
+  newRecordHirateSetup: "新規棋譜（平手初形）",
   openRecord: "棋譜を開く",
   saveRecord: "棋譜を上書き保存",
   saveRecordAs: "棋譜を名前を付けて保存",

--- a/src/common/i18n/locales/vi.ts
+++ b/src/common/i18n/locales/vi.ts
@@ -7,6 +7,7 @@ export const vi: Texts = {
   openNewInstance: "Mở một cửa sổ ShogiHome mới",
   saveOverwrite: "Ghi đè",
   newRecord: "Kỳ phổ mới",
+  newRecordHirateSetup: "新規棋譜（平手初形）", // TODO: Translate
   openRecord: "Mở kỳ phổ",
   saveRecord: "Lưu kỳ phổ",
   saveRecordAs: "Lưu kỳ phổ như",

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -7,6 +7,7 @@ export const zh_tw: Texts = {
   openNewInstance: "開啟新的 ShogiHome 視窗",
   saveOverwrite: "覆蓋檔案",
   newRecord: "新棋譜",
+  newRecordHirateSetup: "新規棋譜（平手初形）", // TODO: Translate
   openRecord: "打開棋譜",
   saveRecord: "保存棋譜",
   saveRecordAs: "另存棋譜",

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -5,6 +5,7 @@ export type Texts = {
   openNewInstance: string;
   saveOverwrite: string;
   newRecord: string;
+  newRecordHirateSetup: string;
   openRecord: string;
   saveRecord: string;
   saveRecordAs: string;

--- a/src/renderer/ipc/setup.ts
+++ b/src/renderer/ipc/setup.ts
@@ -80,6 +80,9 @@ export function setup(): void {
       case MenuEvent.NEW_RECORD:
         store.resetRecord();
         break;
+      case MenuEvent.NEW_RECORD_HIRATE_SETUP:
+        store.resetRecord("hirateSetup");
+        break;
       case MenuEvent.OPEN_RECORD:
         store.openRecord();
         break;

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -20,6 +20,7 @@ import {
   countJishogiPoint,
   Position,
   exportBOD,
+  InitialPositionType,
 } from "tsshogi";
 import { reactive, UnwrapNestedRefs } from "vue";
 import { GameSettings } from "@/common/settings/game.js";
@@ -977,14 +978,21 @@ class Store {
     this.researchManager?.updatePosition(this.recordManager.record);
   }
 
-  resetRecord(): void {
+  resetRecord(mode: "keepRootPosition" | "hirateSetup" = "keepRootPosition"): void {
     if (this.appState != AppState.NORMAL) {
       return;
     }
     this.showConfirmation({
       message: t.areYouSureWantToClearRecord,
       onOk: () => {
-        this.recordManager.reset();
+        switch (mode) {
+          case "keepRootPosition":
+            this.recordManager.reset();
+            break;
+          case "hirateSetup":
+            this.recordManager.resetByInitialPositionType(InitialPositionType.STANDARD);
+            break;
+        }
       },
     });
   }


### PR DESCRIPTION
# 説明 / Description

#1289 

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated
  - [x] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new menu item for creating a new record with the standard (Hirate) setup, accessible via "CmdOrCtrl+Shift+N".
  * The new menu item is available only in the normal application state.
  * Added support for this feature in English, Japanese, Vietnamese, and Traditional Chinese localizations.

* **Bug Fixes**
  * Improved handling of record resets, allowing users to choose between keeping the root position or resetting to the standard setup.

* **Tests**
  * Updated and expanded tests to cover new record reset scenarios, including the Hirate setup option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->