### PR TITLE
棋譜ビューの最大幅を緩和

### DIFF
--- a/src/renderer/view/main/StandardLayout.vue
+++ b/src/renderer/view/main/StandardLayout.vue
@@ -243,9 +243,10 @@ const boardPaneStyle = computed(() => {
 const recordPaneStyle = computed(() => {
   const width =
     windowSize.width -
-    boardPaneSize.width -
-    margin * 3 -
-    (appSettings.boardLayoutType === BoardLayoutType.STANDARD ? 0 : boardPaneSize.height * 0.1);
+    (boardPaneSize.width +
+      margin * 3 +
+      // コンパクトとポータブルは左端に 1x10 のメニューボタンを配置するため高さの 1/10 を確保
+      (appSettings.boardLayoutType === BoardLayoutType.STANDARD ? 0 : boardPaneSize.height * 0.1));
   const height = boardPaneSize.height;
   return {
     margin: `${margin}px ${margin}px ${margin}px 0`,

--- a/src/renderer/view/primitive/RecordView.vue
+++ b/src/renderer/view/primitive/RecordView.vue
@@ -283,7 +283,7 @@ onUpdated(() => {
   user-select: none;
 }
 .record-view.limited {
-  max-width: 600px;
+  max-width: calc(max(100vh, 600px));
 }
 .control {
   width: 100%;


### PR DESCRIPTION
# 説明 / Description

#1265 

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the layout so that certain views now have a responsive maximum width based on the viewport size, improving adaptability across different screen sizes.

* **Documentation**
  * Added an explanatory comment to clarify margin behavior in specific board layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->