### PR TITLE
カスタムレイアウトのデスクトップショートカットを作成する機能

### DIFF
--- a/src/background/file/escape.ts
+++ b/src/background/file/escape.ts
@@ -1,0 +1,28 @@
+export function escapePosixArg(arg: string): string {
+  return `'${arg.replace(/'/g, `'\\''`)}'`;
+}
+
+export function escapeWinArg(arg: string): string {
+  if (arg.length === 0) {
+    return '""';
+  }
+  let result = '"';
+  let bs = 0;
+  for (const c of arg) {
+    if (c === "\\") {
+      bs++;
+    } else if (c === '"') {
+      result += "\\".repeat(bs * 2 + 1) + '"';
+      bs = 0;
+    } else {
+      result += "\\".repeat(bs) + c;
+      bs = 0;
+    }
+  }
+  result += "\\".repeat(bs * 2) + '"';
+  return result;
+}
+
+export function escapeLinuxDesktopToken(s: string): string {
+  return `"${s.replace(/%/g, "%%").replace(/"/g, '\\"')}"`;
+}

--- a/src/background/file/escape.ts
+++ b/src/background/file/escape.ts
@@ -24,5 +24,11 @@ export function escapeWinArg(arg: string): string {
 }
 
 export function escapeLinuxDesktopToken(s: string): string {
-  return `"${s.replace(/%/g, "%%").replace(/"/g, '\\"')}"`;
+  return `"${s
+    .replace(/\\/g, "\\\\")
+    .replace(/%/g, "%%")
+    .replace(/"/g, '\\"')
+    .replace(/`/g, "\\`")
+    .replace(/\$/g, "\\$")
+    .replace(/[\r\n\t]/g, " ")}"`;
 }

--- a/src/background/file/shortcuts.ts
+++ b/src/background/file/shortcuts.ts
@@ -39,11 +39,14 @@ async function createWindowsShortcut(dirname: string, name: string, args: string
 
 async function createAppleScript(dirname: string, name: string, args: string[]) {
   const scriptPath = path.join(dirname, `${name}.applescript`);
-  const safeArgs = args.map((arg) => arg.replace(/\\/g, "\\\\").replace(/ /g, "\\ ")).join(" ");
+  const execPath = process.execPath;
+  const safeArgs = [execPath, ...args]
+    .map((arg) => arg.replace(/\\/g, "\\\\").replace(/ /g, "\\ "))
+    .join(" ");
   if (safeArgs.lastIndexOf('"') !== -1) {
     throw new Error("AppleScript does not support double quotes in arguments.");
   }
-  const script = `do shell script "${process.execPath} ${safeArgs}"`;
+  const script = `do shell script "${safeArgs}"`;
   await fs.promises.writeFile(scriptPath, script, "utf8");
   const compiledPath = path.join(dirname, `${name}.app`);
   await new Promise<void>((resolve, reject) => {

--- a/src/background/file/shortcuts.ts
+++ b/src/background/file/shortcuts.ts
@@ -38,14 +38,14 @@ async function createWindowsShortcut(dirname: string, name: string, args: string
 }
 
 async function createAppleScript(dirname: string, name: string, args: string[]) {
+  if (args.some((arg) => arg.includes('"'))) {
+    throw new Error("AppleScript does not support double quotes in arguments.");
+  }
   const scriptPath = path.join(dirname, `${name}.applescript`);
   const execPath = process.execPath;
   const safeArgs = [execPath, ...args]
     .map((arg) => arg.replace(/\\/g, "\\\\").replace(/ /g, "\\ "))
     .join(" ");
-  if (safeArgs.lastIndexOf('"') !== -1) {
-    throw new Error("AppleScript does not support double quotes in arguments.");
-  }
   const script = `do shell script "${safeArgs}"`;
   await fs.promises.writeFile(scriptPath, script, "utf8");
   const compiledPath = path.join(dirname, `${name}.app`);

--- a/src/background/file/shortcuts.ts
+++ b/src/background/file/shortcuts.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import child_process from "node:child_process";
 import { getAppPath } from "@/background/proc/path-electron.js";
 import { shell } from "electron";
-import { escapePosixArg, escapeWinArg, escapeLinuxDesktopToken } from "./escape";
+import { escapePosixArg, escapeWinArg, escapeLinuxDesktopToken } from "./escape.js";
 
 export async function createDesktopShortcut(name: string, args: string[]) {
   const desktopPath = getAppPath("desktop");

--- a/src/background/file/shortcuts.ts
+++ b/src/background/file/shortcuts.ts
@@ -1,0 +1,75 @@
+import fs from "node:fs";
+import path from "node:path";
+import child_process from "node:child_process";
+import { getAppPath } from "@/background/proc/path-electron.js";
+import { shell } from "electron";
+
+export async function createDesktopShortcut(name: string, args: string[]) {
+  const desktopPath = getAppPath("desktop");
+
+  switch (process.platform) {
+    case "win32":
+      await createWindowsShortcut(desktopPath, name, args);
+      break;
+    case "darwin":
+      await createAppleScript(desktopPath, name, args);
+      break;
+    case "linux":
+      await createLinuxDesktop(desktopPath, name, args);
+      break;
+    default:
+      throw new Error("Unsupported platform");
+  }
+}
+
+async function createWindowsShortcut(dirname: string, name: string, args: string[]) {
+  const shortcutPath = path.join(dirname, `${name}.lnk`);
+  const safeArgs = args.map((arg) => `"${arg.replace(/"/g, '\\"')}"`).join(" ");
+  const ok = shell.writeShortcutLink(shortcutPath, {
+    target: process.execPath,
+    args: safeArgs,
+    cwd: process.cwd(),
+    description: "Start ShogiHome with custom options",
+  });
+  if (!ok) {
+    throw new Error("");
+  }
+}
+
+async function createAppleScript(dirname: string, name: string, args: string[]) {
+  const scriptPath = path.join(dirname, `${name}.applescript`);
+  const safeArgs = args.map((arg) => `${arg.replace(/ /g, "\\ ")}`).join(" ");
+  if (safeArgs.lastIndexOf('"') !== -1) {
+    throw new Error("AppleScript does not support double quotes in arguments.");
+  }
+  const script = `do shell script "${process.execPath} ${safeArgs}"`;
+  await fs.promises.writeFile(scriptPath, script, "utf8");
+  const compiledPath = path.join(dirname, `${name}.app`);
+  await new Promise<void>((resolve, reject) => {
+    child_process.exec(
+      `osacompile -o "${compiledPath.replace(/"/g, '\\"')}" "${scriptPath.replace(/"/g, '\\"')}"`,
+      (error) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      },
+    );
+  });
+  await fs.promises.unlink(scriptPath);
+}
+
+async function createLinuxDesktop(dirname: string, name: string, args: string[]) {
+  const execPath = process.env.APPIMAGE || process.execPath;
+  const desktopFilePath = path.join(dirname, `${name}.desktop`);
+  const safeArgs = args.map((arg) => `"${arg.replace(/"/g, '\\"')}"`).join(" ");
+  const content = `[Desktop Entry]
+Type=Application
+Name=${name}
+Exec=${execPath} ${safeArgs}
+Terminal=false
+`;
+  await fs.promises.writeFile(desktopFilePath, content, "utf8");
+  await fs.promises.chmod(desktopFilePath, 0o755);
+}

--- a/src/background/proc/path-cmd.ts
+++ b/src/background/proc/path-cmd.ts
@@ -1,6 +1,8 @@
 import path from "node:path";
 
-export function getAppPath(name: "userData" | "logs" | "exe" | "documents" | "pictures"): string {
+export function getAppPath(
+  name: "userData" | "desktop" | "logs" | "exe" | "documents" | "pictures",
+): string {
   switch (name) {
     case "logs":
       return path.join(process.cwd(), "logs");

--- a/src/background/proc/path-electron.ts
+++ b/src/background/proc/path-electron.ts
@@ -3,7 +3,9 @@ import fs from "node:fs";
 import { getTempPathForTesting, isTest } from "./env.js";
 import { app } from "electron";
 
-export function getAppPath(name: "userData" | "logs" | "exe" | "documents" | "pictures"): string {
+export function getAppPath(
+  name: "userData" | "desktop" | "logs" | "exe" | "documents" | "pictures",
+): string {
   if (isTest()) {
     const tempPath = path.join(getTempPathForTesting(), name);
     fs.mkdirSync(tempPath, { recursive: true });

--- a/src/background/window/ipc.ts
+++ b/src/background/window/ipc.ts
@@ -125,6 +125,7 @@ import { Message } from "@/common/message.js";
 import { RecordFileFormat } from "@/common/file/record.js";
 import { LayoutProfileList } from "@/common/settings/layout.js";
 import { ProcessArgs } from "@/common/ipc/process.js";
+import { createDesktopShortcut } from "@/background/file/shortcuts.js";
 
 const isWindows = process.platform === "win32";
 
@@ -665,6 +666,15 @@ ipcMain.on(Background.UPDATE_LAYOUT_PROFILE_LIST, (event, uri: string, json: str
     sendError(new Error(`failed to save layout config: ${e}`));
   });
 });
+
+ipcMain.handle(
+  Background.CREATE_DESKTOP_SHORTCUT_FOR_LAYOUT_PROFILE,
+  (event, uri: string, name: string) => {
+    validateIPCSender(event.senderFrame);
+    getAppLogger().debug("create desktop shortcut for layout profile: %s", uri);
+    createDesktopShortcut(`ShogiHome ${name}`, ["--layout-profile", uri]);
+  },
+);
 
 ipcMain.handle(Background.LOAD_USI_ENGINES, async (event): Promise<string> => {
   validateIPCSender(event.senderFrame);

--- a/src/background/window/ipc.ts
+++ b/src/background/window/ipc.ts
@@ -126,6 +126,7 @@ import { RecordFileFormat } from "@/common/file/record.js";
 import { LayoutProfileList } from "@/common/settings/layout.js";
 import { ProcessArgs } from "@/common/ipc/process.js";
 import { createDesktopShortcut } from "@/background/file/shortcuts.js";
+import { escapeFileName } from "@/common/file/path.js";
 
 const isWindows = process.platform === "win32";
 
@@ -669,10 +670,15 @@ ipcMain.on(Background.UPDATE_LAYOUT_PROFILE_LIST, (event, uri: string, json: str
 
 ipcMain.handle(
   Background.CREATE_DESKTOP_SHORTCUT_FOR_LAYOUT_PROFILE,
-  (event, uri: string, name: string) => {
+  async (event, uri: string, name: string) => {
     validateIPCSender(event.senderFrame);
-    getAppLogger().debug("create desktop shortcut for layout profile: %s", uri);
-    createDesktopShortcut(`ShogiHome ${name}`, ["--layout-profile", uri]);
+    const fileName = escapeFileName(`ShogiHome ${name}`);
+    getAppLogger().debug(
+      "create desktop shortcut for layout profile: uri=[%s] file=[%s]",
+      uri,
+      fileName,
+    );
+    await createDesktopShortcut(fileName, ["--layout-profile", uri]);
   },
 );
 

--- a/src/command/common/preload.ts
+++ b/src/command/common/preload.ts
@@ -338,6 +338,9 @@ const bridge: Bridge = {
   onUpdateLayoutProfile(): void {
     // Do Nothing
   },
+  createDesktopShortcutForLayoutProfile(): Promise<void> {
+    throw new Error("This feature is not available on command line tool");
+  },
 
   // Log
   openLogFile(): void {

--- a/src/common/file/path.ts
+++ b/src/common/file/path.ts
@@ -1,1 +1,5 @@
 export const defaultRecordFileNameTemplate = "{datetime}{_title}{_sente}{_gote}";
+
+export function escapeFileName(path: string): string {
+  return path.replaceAll(/[<>:"/\\|?*]/g, "_");
+}

--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -633,6 +633,8 @@ export const en: Texts = {
     "If it does not work, you should allow notification on OS setting.",
   translationHelpNeeded: "We'd like your help to translate.",
   restartRequiredAfterLocaleChange: "You should restart this app to change the language.",
+  createDesktopShortcut: "Create desktop shortcut",
+  desktopShortcutCreated: "Desktop shortcut created.",
   areYouSureWantToResign: "Are you sure you want to resign?",
   areYouSureWantToDoDeclaration: "Are you sure you want to do declaration?",
   areYouSureWantToQuitGames: "Are you sure you want to quit games?",

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -635,6 +635,8 @@ export const ja: Texts = {
     "表示されない場合はOSの設定で通知を許可してください。",
   translationHelpNeeded: "翻訳の改善にご協力ください。",
   restartRequiredAfterLocaleChange: "言語の変更には再起動が必要です。",
+  createDesktopShortcut: "デスクトップにショートカットを作成",
+  desktopShortcutCreated: "デスクトップにショートカットを作成しました。",
   areYouSureWantToResign: "投了しますか？",
   areYouSureWantToDoDeclaration: "宣言しますか？",
   areYouSureWantToQuitGames: "連続対局を中断しますか？",

--- a/src/common/i18n/locales/vi.ts
+++ b/src/common/i18n/locales/vi.ts
@@ -632,6 +632,8 @@ export const vi: Texts = {
     "Nếu nó không hoạt động, vui lòng cho phép thông báo trong tùy chọn hệ điều hành.",
   translationHelpNeeded: "Chúng tôi cần bạn giúp đỡ phiên dịch.",
   restartRequiredAfterLocaleChange: "Khởi động lại ứng dụng để áp dụng ngôn ngữ.",
+  createDesktopShortcut: "デスクトップにショートカットを作成", // TODO: Translate
+  desktopShortcutCreated: "デスクトップにショートカットを作成しました。", // TODO: Translate
   areYouSureWantToResign: "Bạn có thật sự muốn đầu hàng không?",
   areYouSureWantToDoDeclaration: "Bạn có thật sự muốn tuyên bố không?",
   areYouSureWantToQuitGames: "Bạn có thật sự muốn bỏ ván không?",

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -627,6 +627,8 @@ export const zh_tw: Texts = {
     "若無法顯示，請在使用的作業系統中許可本程式的通知。",
   translationHelpNeeded: "我們正在招募翻譯人員。",
   restartRequiredAfterLocaleChange: "更改語言後，請重新啟動本程式。",
+  createDesktopShortcut: "デスクトップにショートカットを作成", // TODO: Translate
+  desktopShortcutCreated: "デスクトップにショートカットを作成しました。", // TODO: Translate
   areYouSureWantToResign: "確定要投了嗎？",
   areYouSureWantToDoDeclaration: "確定要進行勝利宣言嗎？",
   areYouSureWantToQuitGames: "要中斷連續對局嗎？",

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -618,6 +618,8 @@ export type Texts = {
   ifNotWorkYouShouldAllowNotificationOnOSSetting: string;
   translationHelpNeeded: string;
   restartRequiredAfterLocaleChange: string;
+  createDesktopShortcut: string;
+  desktopShortcutCreated: string;
   areYouSureWantToResign: string;
   areYouSureWantToDoDeclaration: string;
   areYouSureWantToQuitGames: string;

--- a/src/common/ipc/channel.ts
+++ b/src/common/ipc/channel.ts
@@ -49,6 +49,7 @@ export enum Background {
   IMPORT_BOOK_MOVES = "importBookMoves",
   LOAD_LAYOUT_PROFILE_LIST = "loadLayoutProfileList",
   UPDATE_LAYOUT_PROFILE_LIST = "updateLayoutProfileList",
+  CREATE_DESKTOP_SHORTCUT_FOR_LAYOUT_PROFILE = "createDesktopShortcutForLayoutProfile",
   LOAD_USI_ENGINES = "loadUSIEngines",
   SAVE_USI_ENGINES = "saveUSIEngines",
   LOAD_BOOK_IMPORT_SETTINGS = "loadBookImportSettings",

--- a/src/renderer/helpers/path.ts
+++ b/src/renderer/helpers/path.ts
@@ -1,6 +1,6 @@
 import { getBlackPlayerName, getWhitePlayerName, ImmutableRecord, Move } from "tsshogi";
 import { getDateString } from "@/common/helpers/datetime.js";
-import { defaultRecordFileNameTemplate } from "@/common/file/path.js";
+import { defaultRecordFileNameTemplate, escapeFileName } from "@/common/file/path.js";
 import {
   getDateStringFromMetadata,
   getRecordTitleFromMetadata,
@@ -30,10 +30,6 @@ export function join(path: string, ...paths: string[]): string {
     result = trimEnd(result);
   }
   return result;
-}
-
-function escapePath(path: string): string {
-  return path.replaceAll(/[<>:"/\\|?*]/g, "_");
 }
 
 type RecordFileNameOptions = {
@@ -77,10 +73,10 @@ export function generateRecordFileName(
 
   // generate file name
   let ret = options.template || defaultRecordFileNameTemplate;
-  ret = escapePath(ret);
+  ret = escapeFileName(ret);
   for (const key in params) {
     const value = params[key];
-    ret = escapePath(ret.replaceAll("{" + key + "}", value));
+    ret = escapeFileName(ret.replaceAll("{" + key + "}", value));
   }
   ret = ret.trim();
   if (options.extension) {

--- a/src/renderer/ipc/api.ts
+++ b/src/renderer/ipc/api.ts
@@ -127,6 +127,7 @@ export interface API {
   // Layout
   loadLayoutProfileList(): Promise<[string, LayoutProfileList]>;
   updateLayoutProfileList(uri: string, profileList: LayoutProfileList): void;
+  createDesktopShortcutForLayoutProfile(uri: string, name: string): Promise<void>;
 
   // Log
   openLogFile(logType: LogType): void;

--- a/src/renderer/ipc/bridge.ts
+++ b/src/renderer/ipc/bridge.ts
@@ -131,6 +131,7 @@ export interface Bridge {
   loadLayoutProfileList(): Promise<[string, string]>;
   updateLayoutProfileList(uri: string, profileList: string): void;
   onUpdateLayoutProfile(callback: (json: string | null) => void): void;
+  createDesktopShortcutForLayoutProfile(uri: string, name: string): Promise<void>;
 
   // Log
   openLogFile(logType: LogType): void;

--- a/src/renderer/ipc/preload.ts
+++ b/src/renderer/ipc/preload.ts
@@ -364,6 +364,9 @@ const api: Bridge = {
       callback(json);
     });
   },
+  async createDesktopShortcutForLayoutProfile(uri: string, name: string) {
+    await ipcRenderer.invoke(Background.CREATE_DESKTOP_SHORTCUT_FOR_LAYOUT_PROFILE, uri, name);
+  },
 
   // Log
   openLogFile(logType: LogType): void {

--- a/src/renderer/ipc/web.ts
+++ b/src/renderer/ipc/web.ts
@@ -429,6 +429,9 @@ export const webAPI: Bridge = {
   onUpdateLayoutProfile(): void {
     // Do Nothing
   },
+  createDesktopShortcutForLayoutProfile(): Promise<void> {
+    throw new Error(t.thisFeatureNotAvailableOnWebApp);
+  },
 
   // Log
   openLogFile(): void {

--- a/src/renderer/view/layout/LayoutManager.vue
+++ b/src/renderer/view/layout/LayoutManager.vue
@@ -29,18 +29,22 @@
         </div>
       </div>
       <div v-if="customProfile" class="custom-profile column grow scroll">
-        <div>
+        <div class="column">
           <input
             class="profile-name"
             :value="customProfile.name"
             @input="(e) => updateCustomProfileProp('name', inputEventToString(e))"
           />
-        </div>
-        <div class="uri row">
-          <span>{{ customProfile.uri }}</span>
-          <button @click="copyProfileURI">
-            <Icon :icon="IconType.COPY" />
-          </button>
+          <div class="uri row">
+            <span>URI:</span>
+            <span>{{ customProfile.uri }}</span>
+            <button @click="copyProfileURI">
+              <Icon :icon="IconType.COPY" />
+            </button>
+          </div>
+          <div class="row">
+            <button @click="createDesktopShortcut">{{ t.createDesktopShortcut }}</button>
+          </div>
         </div>
         <div class="row">
           <span class="key">{{ t.dialogPosition }}:</span>
@@ -369,6 +373,7 @@ import ErrorMessage from "@/renderer/view/dialog/ErrorMessage.vue";
 import ConfirmDialog from "@/renderer/view/dialog/ConfirmDialog.vue";
 import Icon from "@/renderer/view/primitive/Icon.vue";
 import { IconType } from "@/renderer/assets/icons.js";
+import api from "@/renderer/ipc/api";
 
 const appSettings = useAppSettings();
 const messageStore = useMessageStore();
@@ -435,6 +440,19 @@ const copyProfileURI = () => {
     return;
   }
   navigator.clipboard.writeText(profile.uri);
+};
+
+const createDesktopShortcut = async () => {
+  const profile = getCurrentProfile();
+  if (!profile) {
+    return;
+  }
+  try {
+    await api.createDesktopShortcutForLayoutProfile(profile.uri, profile.name);
+    messageStore.enqueue({ text: t.desktopShortcutCreated });
+  } catch (e) {
+    errorStore.add(e);
+  }
 };
 
 const updateCustomProfileProp = (key: string, value: unknown) => {

--- a/src/tests/background/file/escape.spec.ts
+++ b/src/tests/background/file/escape.spec.ts
@@ -20,5 +20,6 @@ describe("escape", () => {
     expect(escapeLinuxDesktopToken("foo bar")).toBe('"foo bar"');
     expect(escapeLinuxDesktopToken("foo%bar")).toBe('"foo%%bar"');
     expect(escapeLinuxDesktopToken('foo"bar')).toBe('"foo\\"bar"');
+    expect(escapeLinuxDesktopToken("foo\\bar")).toBe('"foo\\\\bar"');
   });
 });

--- a/src/tests/background/file/escape.spec.ts
+++ b/src/tests/background/file/escape.spec.ts
@@ -1,0 +1,24 @@
+import { escapeLinuxDesktopToken, escapePosixArg, escapeWinArg } from "@/background/file/escape";
+
+describe("escape", () => {
+  it("posixArg", () => {
+    expect(escapePosixArg("foo")).toBe("'foo'");
+    expect(escapePosixArg("foo'bar")).toBe("'foo'\\''bar'");
+    expect(escapePosixArg("foo\\bar")).toBe("'foo\\bar'");
+  });
+
+  it("winArg", () => {
+    expect(escapeWinArg("foo")).toBe('"foo"');
+    expect(escapeWinArg('foo"bar')).toBe('"foo\\"bar"');
+    expect(escapeWinArg("foo\\bar")).toBe('"foo\\bar"');
+    expect(escapeWinArg('foo\\"bar')).toBe('"foo\\\\\\"bar"');
+    expect(escapeWinArg('foobar\\"')).toBe('"foobar\\\\\\""');
+  });
+
+  it("linuxDesktopToken", () => {
+    expect(escapeLinuxDesktopToken("foo")).toBe('"foo"');
+    expect(escapeLinuxDesktopToken("foo bar")).toBe('"foo bar"');
+    expect(escapeLinuxDesktopToken("foo%bar")).toBe('"foo%%bar"');
+    expect(escapeLinuxDesktopToken('foo"bar')).toBe('"foo\\"bar"');
+  });
+});


### PR DESCRIPTION
# 説明 / Description

#1301

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [x] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Create desktop shortcuts for layout profiles on Windows, macOS and Linux (not available on web or CLI); new IPC/API to request shortcut creation.

- **UI**
  - Layout Manager: “Create desktop shortcut” button in custom profile, URI labeled with copy action, success notification after creation.

- **Internationalization**
  - Added texts for English and Japanese; placeholder translations for Vietnamese and Traditional Chinese.

- **Reliability**
  - Filename sanitization and improved cross-platform argument escaping.

- **Tests**
  - Unit tests covering escaping behavior for shortcut creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->