### PR TITLE
監視ビューに CPU とメモリの使用率を表示

### DIFF
--- a/src/background/proc/state.ts
+++ b/src/background/proc/state.ts
@@ -1,0 +1,42 @@
+import os from "node:os";
+import { OSState } from "@/common/advanced/monitor";
+import { getSystemMemoryInfo, getSystemVersion } from "node:process";
+
+function getOSVersion() {
+  const osVersion = getSystemVersion();
+  switch (process.platform) {
+    case "darwin":
+      return `macOS ${osVersion}`;
+    case "win32":
+      return `Windows ${osVersion}`;
+    case "linux":
+      return `Linux ${osVersion}`;
+    default:
+      return `${process.platform} ${osVersion}`;
+  }
+}
+
+let osVersion = "";
+
+export async function collectOSState(): Promise<OSState> {
+  if (!osVersion) {
+    osVersion = getOSVersion();
+  }
+  const cpus = os.cpus();
+  const cpuIdleTime = cpus.reduce((prev, cpu) => prev + cpu.times.idle, 0);
+  const cpuTotalTime =
+    cpuIdleTime +
+    cpus.reduce(
+      (prev, cpu) => prev + cpu.times.user + cpu.times.nice + cpu.times.sys + cpu.times.irq,
+      0,
+    );
+  const mem = getSystemMemoryInfo();
+  return {
+    version: osVersion,
+    arch: process.arch,
+    cpuTotalTime,
+    cpuIdleTime,
+    memoryTotal: mem.total,
+    memoryFree: mem.free,
+  };
+}

--- a/src/background/proc/state.ts
+++ b/src/background/proc/state.ts
@@ -1,9 +1,8 @@
 import os from "node:os";
 import { OSState } from "@/common/advanced/monitor";
-import { getSystemMemoryInfo, getSystemVersion } from "node:process";
 
 function getOSVersion() {
-  const osVersion = getSystemVersion();
+  const osVersion = process.getSystemVersion();
   switch (process.platform) {
     case "darwin":
       return `macOS ${osVersion}`;
@@ -30,7 +29,7 @@ export async function collectOSState(): Promise<OSState> {
       (prev, cpu) => prev + cpu.times.user + cpu.times.nice + cpu.times.sys + cpu.times.irq,
       0,
     );
-  const mem = getSystemMemoryInfo();
+  const mem = process.getSystemMemoryInfo();
   return {
     version: osVersion,
     arch: process.arch,

--- a/src/background/window/ipc.ts
+++ b/src/background/window/ipc.ts
@@ -127,6 +127,7 @@ import { LayoutProfileList } from "@/common/settings/layout.js";
 import { ProcessArgs } from "@/common/ipc/process.js";
 import { createDesktopShortcut } from "@/background/file/shortcuts.js";
 import { escapeFileName } from "@/common/file/path.js";
+import { collectOSState } from "@/background/proc/state.js";
 
 const isWindows = process.platform === "win32";
 
@@ -842,9 +843,10 @@ ipcMain.handle(Background.CSA_STOP, (event, sessionID: number): void => {
   csaStop(sessionID);
 });
 
-ipcMain.handle(Background.COLLECT_SESSION_STATES, (event): string => {
+ipcMain.handle(Background.COLLECT_SESSION_STATES, async (event): Promise<string> => {
   validateIPCSender(event.senderFrame);
   const sessionStates: SessionStates = {
+    os: await collectOSState(),
     usiSessions: collectUSISessionStates(),
     csaSessions: collectCSASessionStates(),
   };

--- a/src/background/window/menu.ts
+++ b/src/background/window/menu.ts
@@ -494,6 +494,7 @@ function createMenuTemplate(window: BrowserWindow) {
           click: () => {
             createMonitorWindow(window);
           },
+          accelerator: "CmdOrCtrl+Shift+M",
         },
         {
           label: t.logFile,

--- a/src/common/advanced/monitor.ts
+++ b/src/common/advanced/monitor.ts
@@ -1,6 +1,26 @@
 import { CSAProtocolVersion } from "@/common/settings/csa.js";
 import { Command } from "./command.js";
 
+export type OSState = {
+  version: string;
+  arch: string;
+  cpuTotalTime: number;
+  cpuIdleTime: number;
+  memoryTotal: number;
+  memoryFree: number;
+};
+
+export function blankOSState(): OSState {
+  return {
+    version: "-",
+    arch: "-",
+    cpuTotalTime: 0,
+    cpuIdleTime: 0,
+    memoryTotal: 0,
+    memoryFree: 0,
+  };
+}
+
 export type USISessionState = {
   sessionID: number;
   uri: string;
@@ -31,6 +51,7 @@ export type CSASessionState = {
 };
 
 export type SessionStates = {
+  os: OSState;
   usiSessions: USISessionState[];
   csaSessions: CSASessionState[];
 };

--- a/src/renderer/ipc/web.ts
+++ b/src/renderer/ipc/web.ts
@@ -13,7 +13,7 @@ import { defaultBatchConversionSettings } from "@/common/settings/conversion.js"
 import { getEmptyHistory } from "@/common/file/history.js";
 import { BookLoadingMode } from "@/common/book.js";
 import { VersionStatus } from "@/common/version.js";
-import { SessionStates } from "@/common/advanced/monitor.js";
+import { blankOSState, SessionStates } from "@/common/advanced/monitor.js";
 import { emptyLayoutProfileList } from "@/common/settings/layout.js";
 import * as uri from "@/common/uri.js";
 import { basename } from "@/renderer/helpers/path.js";
@@ -388,6 +388,7 @@ export const webAPI: Bridge = {
   // Sessions
   async collectSessionStates(): Promise<string> {
     return JSON.stringify({
+      os: blankOSState(),
       usiSessions: [],
       csaSessions: [],
     } as SessionStates);


### PR DESCRIPTION
# 説明 / Description

監視タブや監視ウィンドウのフッターに CPU やメモリの使用率を表示する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Monitor now shows OS details (version, architecture) and real-time resource metrics.
  * Added CPU usage and memory stats (free GiB and usage %) with a footer in the Monitor window.
  * More accurate CPU usage sampling between polls.

* **Style**
  * Adjusted Monitor layout to accommodate the new footer.

* **New Shortcuts**
  * Added Cmd/Ctrl+Shift+M to quickly open the Monitor window.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->