### PR TITLE
一部のメッセージボックスにコピーボタンを設置

### DIFF
--- a/src/background/window/menu.ts
+++ b/src/background/window/menu.ts
@@ -594,6 +594,7 @@ function createMenuTemplate(window: BrowserWindow) {
             sendMessage({
               text: "GPU Feature Status",
               attachments: [{ type: "list", items: createListItems(status) }],
+              withCopyButton: true,
             });
           },
         },
@@ -608,6 +609,7 @@ function createMenuTemplate(window: BrowserWindow) {
               sendMessage({
                 text: "GPU Information",
                 attachments: [{ type: "list", items: createListItems(gpuInfo) }],
+                withCopyButton: true,
               });
             });
           },

--- a/src/common/message.ts
+++ b/src/common/message.ts
@@ -19,7 +19,32 @@ export type Attachment = List | Link;
 export type Message = {
   text: string;
   attachments?: Attachment[];
+  withCopyButton?: boolean;
 };
+
+export function toMarkdown(message: Message): string {
+  const lines = [message.text];
+  for (const attachment of message.attachments ?? []) {
+    switch (attachment.type) {
+      case "list":
+        lines.push("");
+        for (const item of attachment.items) {
+          lines.push(`- ${item.text}`);
+          if (item.children) {
+            for (const child of item.children) {
+              lines.push(`  - ${child}`);
+            }
+          }
+        }
+        break;
+      case "link":
+        lines.push("");
+        lines.push(`[${attachment.text}](${attachment.url})`);
+        break;
+    }
+  }
+  return lines.join("\n");
+}
 
 export function createListItems(object: unknown[] | object): ListItem[] {
   if (object instanceof Array) {

--- a/src/renderer/store/book.ts
+++ b/src/renderer/store/book.ts
@@ -208,6 +208,7 @@ export class BookStore {
               ],
             },
           ],
+          withCopyButton: true,
         });
         return this.reloadBookMoves();
       })

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -718,6 +718,7 @@ class Store {
     useMessageStore().enqueue({
       text: t.gameProgress,
       attachments: getMessageAttachmentsByGameResults(results),
+      withCopyButton: true,
     });
   }
 
@@ -730,6 +731,7 @@ class Store {
       useMessageStore().enqueue({
         text: t.allGamesCompleted,
         attachments: getMessageAttachmentsByGameResults(results),
+        withCopyButton: true,
       });
     } else if (specialMoveType) {
       useMessageStore().enqueue({
@@ -1460,6 +1462,7 @@ class Store {
           ],
         },
       ],
+      withCopyButton: true,
     });
   }
 

--- a/src/renderer/view/dialog/BatchConversionDialog.vue
+++ b/src/renderer/view/dialog/BatchConversionDialog.vue
@@ -276,6 +276,7 @@ const convert = async () => {
           ],
         },
       ],
+      withCopyButton: true,
     });
   } catch (e) {
     useErrorStore().add(e);

--- a/src/renderer/view/dialog/ErrorMessage.vue
+++ b/src/renderer/view/dialog/ErrorMessage.vue
@@ -15,6 +15,9 @@
         </div>
       </div>
     </div>
+    <div>
+      <button @click="copyMessage"><Icon :icon="IconType.COPY" />{{ t.copy }}</button>
+    </div>
     <div class="main-buttons">
       <button autofocus data-hotkey="Escape" @click="onClose()">
         {{ t.close }}
@@ -42,6 +45,12 @@ onMounted(() => {
 onBeforeUnmount(() => {
   uninstallHotKeyForDialog(dialog.value);
 });
+
+const copyMessage = () => {
+  navigator.clipboard.writeText(
+    store.errors.map((e) => (e.count === 1 ? e.message : `${e.message} (${e.count})`)).join("\n"),
+  );
+};
 
 const onClose = () => {
   store.clear();
@@ -76,5 +85,8 @@ dialog button {
 }
 dialog button:hover {
   background: linear-gradient(to top, var(--hovered-error-dialog-button-bg-color) 80%, white 140%);
+}
+dialog button .icon {
+  margin-right: 0.5em;
 }
 </style>

--- a/src/renderer/view/dialog/InfoMessage.vue
+++ b/src/renderer/view/dialog/InfoMessage.vue
@@ -23,6 +23,9 @@
         {{ attachment.text }}
       </button>
     </div>
+    <div v-if="store.message.withCopyButton">
+      <button @click="copyMessage"><Icon :icon="IconType.COPY" />{{ t.copy }}</button>
+    </div>
     <div class="main-buttons">
       <button autofocus data-hotkey="Escape" @click="onClose()">
         {{ t.close }}
@@ -40,6 +43,7 @@ import { IconType } from "@/renderer/assets/icons";
 import { installHotKeyForDialog, uninstallHotKeyForDialog } from "@/renderer/devices/hotkey";
 import { useMessageStore } from "@/renderer/store/message";
 import api from "@/renderer/ipc/api";
+import { toMarkdown } from "@/common/message";
 
 const store = useMessageStore();
 const dialog = ref();
@@ -52,6 +56,10 @@ onMounted(() => {
 onBeforeUnmount(() => {
   uninstallHotKeyForDialog(dialog.value);
 });
+
+const copyMessage = () => {
+  navigator.clipboard.writeText(toMarkdown(store.message));
+};
 
 const onClose = () => {
   store.dequeue();
@@ -67,5 +75,8 @@ const onClose = () => {
 }
 .list {
   text-align: left;
+}
+dialog button .icon {
+  margin-right: 0.5em;
 }
 </style>

--- a/src/tests/common/message.spec.ts
+++ b/src/tests/common/message.spec.ts
@@ -1,0 +1,19 @@
+import { toMarkdown } from "@/common/message";
+
+describe("message", () => {
+  it("toMarkdown", () => {
+    expect(toMarkdown({ text: "Hello world!" })).toBe("Hello world!");
+    expect(
+      toMarkdown({
+        text: "Hello world!",
+        attachments: [{ type: "list", items: [{ text: "Item 1" }, { text: "Item 2" }] }],
+      }),
+    ).toBe("Hello world!\n\n- Item 1\n- Item 2");
+    expect(
+      toMarkdown({
+        text: "Hello world!",
+        attachments: [{ type: "link", text: "My Link", url: "https://example.com" }],
+      }),
+    ).toBe("Hello world!\n\n[My Link](https://example.com)");
+  });
+});

--- a/src/tests/renderer/store/index.spec.ts
+++ b/src/tests/renderer/store/index.spec.ts
@@ -1054,6 +1054,7 @@ describe("store/index", () => {
           ],
         },
       ],
+      withCopyButton: true,
     });
   });
 });


### PR DESCRIPTION
# 説明 / Description

#1310 

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated
  - [x] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Copy button to more messages: GPU status/info, import summary, game results, jishogi points, and batch conversion success.
  * Added Copy button to error dialogs to quickly copy aggregated errors.
* **Improvements**
  * Copied info content is now formatted as Markdown, preserving lists and links; spacing tweak for button icons.
* **Tests**
  * Added unit tests for message-to-Markdown and updated renderer tests to reflect copy-button availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->