### PR TITLE
カスタムレイアウトに書籍風局面図を追加

### DIFF
--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -463,6 +463,7 @@ export const en: Texts = {
   filterByOptionName: "Filter by Option Name",
   filterByEngineName: "Filter by Engine Name",
   bookStyle: "Book Style",
+  bookStyleDiagram: "Book Style Diagram",
   gameStyle: "Game Style",
   thin: "Thin",
   bold: "Bold",

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -463,6 +463,7 @@ export const ja: Texts = {
   filterByOptionName: "オプション名で検索",
   filterByEngineName: "エンジン名で検索",
   bookStyle: "書籍風",
+  bookStyleDiagram: "書籍風局面図",
   gameStyle: "対局画面風",
   thin: "細",
   bold: "太",

--- a/src/common/i18n/locales/vi.ts
+++ b/src/common/i18n/locales/vi.ts
@@ -463,6 +463,7 @@ export const vi: Texts = {
   filterByOptionName: "Lọc theo tên tùy chọn",
   filterByEngineName: "Lọc theo tên phần mềm",
   bookStyle: "Kiểu sách",
+  bookStyleDiagram: "書籍風局面図", // TODO: Translate
   gameStyle: "Kiểu bàn cờ",
   thin: "Mảnh",
   bold: "Đậm",

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -460,6 +460,7 @@ export const zh_tw: Texts = {
   filterByOptionName: "搜尋設定名稱",
   filterByEngineName: "搜尋引擎名稱",
   bookStyle: "書籍風",
+  bookStyleDiagram: "書籍風局面図", // TODO: Translate
   gameStyle: "對局畫面風",
   thin: "細",
   bold: "粗",

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -458,6 +458,7 @@ export type Texts = {
   filterByOptionName: string;
   filterByEngineName: string;
   bookStyle: string;
+  bookStyleDiagram: string;
   gameStyle: string;
   thin: string;
   bold: string;

--- a/src/common/settings/app.ts
+++ b/src/common/settings/app.ts
@@ -2,7 +2,7 @@ import { Language, t } from "@/common/i18n/index.js";
 import { LogLevel, LogType } from "@/common/log.js";
 import { RecordFileFormat } from "@/common/file/record.js";
 import { defaultRecordFileNameTemplate } from "@/common/file/path.js";
-import { BoardLayoutType } from "./layout.js";
+import { BoardLayoutType, PositionImageFontWeight } from "./layout.js";
 import { SearchCommentFormat } from "./comment.js";
 
 export enum Thema {
@@ -146,12 +146,6 @@ export enum PositionImageHandLabelType {
   MOCHIGOMA = "mochigoma",
   TSUME_SHOGI = "tsumeShogi",
   NONE = "none",
-}
-
-export enum PositionImageFontWeight {
-  W400 = "400",
-  W400X = "400+",
-  W700X = "700+",
 }
 
 export type AppSettings = {

--- a/src/common/settings/layout.ts
+++ b/src/common/settings/layout.ts
@@ -14,6 +14,12 @@ export enum BoardLayoutType {
   PORTRAIT = "portrait",
 }
 
+export enum PositionImageFontWeight {
+  W400 = "400",
+  W400X = "400+",
+  W700X = "700+",
+}
+
 type Board = {
   type: "Board";
   rightControlBox?: boolean;
@@ -74,6 +80,14 @@ type ControlGroup2 = {
   type: "ControlGroup2";
 };
 
+type SimpleBoard = {
+  type: "SimpleBoard";
+  fontWeight?: PositionImageFontWeight;
+  fontScale?: number;
+  characterY?: number;
+  bookmark?: boolean;
+};
+
 export type UIComponent = UIComponentCommon &
   (
     | Board
@@ -85,6 +99,7 @@ export type UIComponent = UIComponentCommon &
     | RecordInfo
     | ControlGroup1
     | ControlGroup2
+    | SimpleBoard
   );
 
 export enum DialogPosition {

--- a/src/renderer/store/settings.ts
+++ b/src/renderer/store/settings.ts
@@ -11,7 +11,6 @@ import {
   NodeCountFormat,
   PieceImageType,
   PieceStandImageType,
-  PositionImageFontWeight,
   PositionImageHandLabelType,
   PositionImageStyle,
   PositionImageTypeface,
@@ -31,7 +30,7 @@ import api from "@/renderer/ipc/api.js";
 import { LogLevel } from "@/common/log.js";
 import { Language } from "@/common/i18n/index.js";
 import { RecordFileFormat } from "@/common/file/record.js";
-import { BoardLayoutType } from "@/common/settings/layout.js";
+import { BoardLayoutType, PositionImageFontWeight } from "@/common/settings/layout.js";
 import { SearchCommentFormat } from "@/common/settings/comment.js";
 
 class AppSettingsStore {

--- a/src/renderer/view/dialog/PositionImageExportDialog.vue
+++ b/src/renderer/view/dialog/PositionImageExportDialog.vue
@@ -186,7 +186,6 @@ import {
   PositionImageHandLabelType,
   PositionImageStyle,
   PositionImageTypeface,
-  PositionImageFontWeight,
   getPieceImageURLTemplate,
 } from "@/common/settings/app";
 import HorizontalSelector from "@/renderer/view/primitive/HorizontalSelector.vue";
@@ -194,6 +193,7 @@ import ToggleButton from "@/renderer/view/primitive/ToggleButton.vue";
 import { readInputAsNumber } from "@/renderer/helpers/form";
 import { useErrorStore } from "@/renderer/store/error";
 import DialogFrame from "./DialogFrame.vue";
+import { PositionImageFontWeight } from "@/common/settings/layout";
 
 const lazyUpdateDelay = 100;
 const windowMarginHor = 150;

--- a/src/renderer/view/layout/LayoutManager.vue
+++ b/src/renderer/view/layout/LayoutManager.vue
@@ -92,6 +92,7 @@
             <option value="RecordInfo">{{ t.recordProperties }}</option>
             <option value="ControlGroup1">{{ t.controlGroup }}1</option>
             <option value="ControlGroup2">{{ t.controlGroup }}2</option>
+            <option value="SimpleBoard">{{ t.bookStyleDiagram }}</option>
           </select>
           <button class="thin" @click="insertCustomProfileComponent">{{ t.insert }}</button>
         </div>
@@ -106,6 +107,7 @@
             <span v-if="component.type === 'RecordInfo'">{{ t.recordProperties }}</span>
             <span v-if="component.type === 'ControlGroup1'">{{ t.controlGroup }}1</span>
             <span v-if="component.type === 'ControlGroup2'">{{ t.controlGroup }}2</span>
+            <span v-if="component.type === 'SimpleBoard'">{{ t.bookStyleDiagram }}</span>
           </div>
           <div>
             <span class="property">
@@ -321,6 +323,54 @@
               />
             </span>
           </div>
+          <div v-if="component.type === 'SimpleBoard'">
+            <span class="property">
+              <span class="key">{{ t.weight }}:</span>
+              <HorizontalSelector
+                :value="component.fontWeight || '400'"
+                :items="[
+                  { label: t.thin, value: PositionImageFontWeight.W400 },
+                  { label: t.bold, value: PositionImageFontWeight.W400X },
+                  { label: t.extraBold, value: PositionImageFontWeight.W700X },
+                ]"
+                @update:value="(value) => updateCustomProfileComponent(index, 'fontWeight', value)"
+              />
+            </span>
+            <span class="property">
+              <span class="key">{{ t.size }}:</span>
+              <input
+                class="value"
+                type="number"
+                min="0"
+                max="200"
+                :value="component.fontScale || 100"
+                @input="
+                  (e) => updateCustomProfileComponent(index, 'fontScale', inputEventToNumber(e))
+                "
+              />
+              <span>%</span>
+            </span>
+            <span class="property">
+              <span class="key">{{ t.vertical }}:</span>
+              <input
+                class="value"
+                type="number"
+                min="-100"
+                max="100"
+                :value="component.characterY || 0"
+                @input="
+                  (e) => updateCustomProfileComponent(index, 'characterY', inputEventToNumber(e))
+                "
+              />
+            </span>
+            <span class="property">
+              <ToggleButton
+                :value="!!component.bookmark"
+                :label="t.bookmark"
+                @update:value="(value) => updateCustomProfileComponent(index, 'bookmark', value)"
+              />
+            </span>
+          </div>
           <div>
             <button
               v-if="index !== 0"
@@ -363,6 +413,7 @@ import {
   EvaluationChartType,
   serializeLayoutProfile,
   DialogPosition,
+  PositionImageFontWeight,
 } from "@/common/settings/layout";
 import { t } from "@/common/i18n";
 import { useMessageStore } from "@/renderer/store/message";
@@ -594,6 +645,15 @@ const insertCustomProfileComponent = () => {
         top: 0,
         width: 150,
         height: 200,
+      });
+      break;
+    case "SimpleBoard":
+      components.unshift({
+        type,
+        left: 0,
+        top: 0,
+        width: 400,
+        height: 300,
       });
       break;
   }

--- a/src/renderer/view/main/CustomLayout.vue
+++ b/src/renderer/view/main/CustomLayout.vue
@@ -4,11 +4,11 @@
       v-for="c in components"
       :key="`${c.type}.${c.index}`"
       class="component"
-      :style="{ ...c.rect.style, ...c.style, zIndex: 1e5 - c.index }"
+      :style="{ ...c.style, zIndex: 1e5 - c.index }"
     >
       <BoardPane
         v-if="c.type === 'Board'"
-        :max-size="c.rect.size"
+        :max-size="c.size"
         :left-control-type="
           c.leftControlBox ? LeftSideControlType.STANDARD : LeftSideControlType.NONE
         "
@@ -29,7 +29,7 @@
       <BookPanel v-else-if="c.type === 'Book'" class="full" />
       <div v-else-if="c.type === 'Analytics'" class="full tab-content">
         <EngineAnalytics
-          :size="c.rect.size"
+          :size="c.size"
           :history-mode="!!c.historyMode"
           :show-header="!!c.showHeader"
           :show-time-column="!!c.showTimeColumn"
@@ -43,7 +43,7 @@
       </div>
       <EvaluationChart
         v-else-if="c.type === 'Chart'"
-        :size="c.rect.size"
+        :size="c.size"
         :type="c.chartType"
         :thema="appSettings.thema"
         :coefficient-in-sigmoid="appSettings.coefficientInSigmoid"
@@ -54,7 +54,7 @@
         class="full"
         :show-bookmark="!!c.showBookmark"
       />
-      <RecordInfo v-else-if="c.type === 'RecordInfo'" class="full" :size="c.rect.size" />
+      <RecordInfo v-else-if="c.type === 'RecordInfo'" class="full" :size="c.size" />
       <ControlPane
         v-else-if="c.type === 'ControlGroup1'"
         class="full"
@@ -65,14 +65,36 @@
         class="full"
         :group="ControlGroup.Group2"
       />
+      <SimpleBoardView
+        v-else-if="c.type === 'SimpleBoard'"
+        :max-size="c.size"
+        :position="store.record.position"
+        :black-name="getBlackPlayerNamePreferShort(store.record.metadata)"
+        :white-name="getWhitePlayerNamePreferShort(store.record.metadata)"
+        :header="c.bookmark ? store.record.current.bookmark : ''"
+        :footer="store.record.current.comment"
+        :last-move="
+          store.record.current.move instanceof Move ? store.record.current.move : undefined
+        "
+        typeface="mincho"
+        :font-weight="c.fontWeight === PositionImageFontWeight.W700X ? 700 : 400"
+        :text-shadow="c.fontWeight !== PositionImageFontWeight.W400"
+        :character-y="c.characterY || 0"
+        :font-scale="(c.fontScale || 100) / 100"
+      />
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { LayoutProfile, BoardLayoutType, UIComponent } from "@/common/settings/layout";
+import {
+  LayoutProfile,
+  BoardLayoutType,
+  UIComponent,
+  PositionImageFontWeight,
+} from "@/common/settings/layout";
 import { computed } from "vue";
-import { Rect } from "@/common/assets/geometry";
+import { Rect, RectSize } from "@/common/assets/geometry";
 import { LeftSideControlType, RightSideControlType } from "@/common/settings/app";
 import BoardPane from "./BoardPane.vue";
 import RecordPane from "./RecordPane.vue";
@@ -83,20 +105,35 @@ import { useAppSettings } from "@/renderer/store/settings";
 import RecordComment from "@/renderer/view/tab/RecordComment.vue";
 import RecordInfo from "@/renderer/view/tab/RecordInfo.vue";
 import BookPanel from "./BookPanel.vue";
+import SimpleBoardView from "@/renderer/view/primitive/SimpleBoardView.vue";
+import { useStore } from "@/renderer/store";
+import { getBlackPlayerNamePreferShort, getWhitePlayerNamePreferShort, Move } from "tsshogi";
 
 const props = defineProps<{ profile: LayoutProfile }>();
 
 const appSettings = useAppSettings();
+const store = useStore();
 
 function componentStyle(c: UIComponent) {
+  const rect = new Rect(c.left, c.top, c.width, c.height);
   switch (c.type) {
+    case "Board":
+    case "SimpleBoard":
+      // アスペクト比が決まっているものは左上座標のみを指定
+      return {
+        left: `${rect.x}px`,
+        top: `${rect.y}px`,
+      };
     case "ControlGroup1":
     case "ControlGroup2":
       return {
+        ...rect.style,
         fontSize: `${Math.min((c.width - c.height * 0.2) * 0.2, c.height * 0.08)}px`,
       };
     default:
-      return {};
+      return {
+        ...rect.style,
+      };
   }
 }
 
@@ -105,7 +142,7 @@ const components = computed(() => {
     return {
       ...c,
       index: i,
-      rect: new Rect(c.left, c.top, c.width, c.height),
+      size: new RectSize(c.width, c.height),
       style: componentStyle(c),
     };
   });


### PR DESCRIPTION
# 説明 / Description

#1307 

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [x] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a new “Book Style Diagram” (SimpleBoard) component for custom layouts.
  - Added editor controls for SimpleBoard: font weight, font scale, character Y offset, and bookmark toggle.
  - Enabled insertion, display, and configuration of SimpleBoard within layout manager and main view.

- Localization
  - Added “Book Style Diagram” label to English and Japanese; entries added for other locales.

- Refactor
  - Streamlined layout component sizing and style handling (no behavior change).
  - Consolidated font-weight setting under layout settings (no user-facing change).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->