### PR TITLE
エンジンオプションのコピー・貼り付け機能

### DIFF
--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -650,6 +650,8 @@ export const en: Texts = {
   yamlFormatSettingsCopiedToClipboard: "YAML format settings copied to clipboard.",
   jsonFormatSettingsCopiedToClipboard: "JSON format settings copied to clipboard.",
   usiCsaBridgeCommandCopiedToClipboard: "usi-csa-bridge command copied to clipboard.",
+  copiedToClipboard: "Copied to clipboard.",
+  pastedFromClipboard: "Pasted from clipboard.",
   youCanNotCloseAppWhileCSAOnlineGame: "You cannot close app while CSA online game.",
   fileExtensionNotSupported: "File extension is not supported.",
   errorOccuredWhileDisconnectingFromCSAServer:

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -651,6 +651,8 @@ export const ja: Texts = {
   yamlFormatSettingsCopiedToClipboard: "YAML形式の設定をクリップボードにコピーしました。",
   jsonFormatSettingsCopiedToClipboard: "JSON形式の設定をクリップボードにコピーしました。",
   usiCsaBridgeCommandCopiedToClipboard: "usi-csa-bridge コマンドをクリップボードにコピーしました。",
+  copiedToClipboard: "クリップボードにコピーしました。",
+  pastedFromClipboard: "クリップボードから貼り付けました。",
   youCanNotCloseAppWhileCSAOnlineGame: "CSAプロトコル使用中はアプリを終了できません。",
   fileExtensionNotSupported: "取り扱いできないファイル拡張子です。",
   errorOccuredWhileDisconnectingFromCSAServer: "CSAサーバーからの切断中にエラーが発生しました。",

--- a/src/common/i18n/locales/vi.ts
+++ b/src/common/i18n/locales/vi.ts
@@ -648,6 +648,8 @@ export const vi: Texts = {
   yamlFormatSettingsCopiedToClipboard: "Cài đặt đã được sao chép dưới dạng YAML.",
   jsonFormatSettingsCopiedToClipboard: "Cài đặt đã được sao chép dưới dạng JSON.",
   usiCsaBridgeCommandCopiedToClipboard: "Lệnh usi-csa-bridge đã được sao chép.",
+  copiedToClipboard: "クリップボードにコピーしました。", // TODO: Translate
+  pastedFromClipboard: "クリップボードから貼り付けました。", // TODO: Translate
   youCanNotCloseAppWhileCSAOnlineGame: "Bạn không thể đóng ứng dụng trong khi đang có ván CSA.",
   fileExtensionNotSupported: "Không hỗ trợ định dạng này.",
   errorOccuredWhileDisconnectingFromCSAServer: "Đã có lỗi trong khi ngắt kết nối khỏi máy chủ CSA.",

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -643,6 +643,8 @@ export const zh_tw: Texts = {
   yamlFormatSettingsCopiedToClipboard: "已將 YAML 格式之設定複製到剪貼板。",
   jsonFormatSettingsCopiedToClipboard: "已將 JSON 格式之設定複製到剪貼板。",
   usiCsaBridgeCommandCopiedToClipboard: "已將 usi-csa-bridge 指令複製到剪貼板。",
+  copiedToClipboard: "クリップボードにコピーしました。", // TODO: Translate
+  pastedFromClipboard: "クリップボードから貼り付けました。", // TODO: Translate
   youCanNotCloseAppWhileCSAOnlineGame: "由於CSA協定正在使用中，本程式無法被關閉。",
   fileExtensionNotSupported: "無法使用該副檔名。",
   errorOccuredWhileDisconnectingFromCSAServer: "在與CSA伺服器中斷連線時發生錯誤。",

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -633,6 +633,8 @@ export type Texts = {
   yamlFormatSettingsCopiedToClipboard: string;
   jsonFormatSettingsCopiedToClipboard: string;
   usiCsaBridgeCommandCopiedToClipboard: string;
+  copiedToClipboard: string;
+  pastedFromClipboard: string;
   youCanNotCloseAppWhileCSAOnlineGame: string;
   fileExtensionNotSupported: string;
   errorOccuredWhileDisconnectingFromCSAServer: string;


### PR DESCRIPTION
# 説明 / Description

related to #1266

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [x] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Added Copy and Paste for USI engine options in the options dialog (preserves advanced settings), with success notifications.
* Style
  * Dialog layout refreshed with a new menu row and consistent button spacing; Copy/Paste icons added.
* Localization
  * Added "Copied to clipboard." and "Pasted from clipboard." messages for English and Japanese; provisional strings included for Vietnamese and Traditional Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->