### PR TITLE
Update add-engine command

### DIFF
--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -10,7 +10,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      USI_ENGINE_JSON: .config/electron-shogi/usi_engine.json
     steps:
+      # Setup
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
@@ -18,7 +21,23 @@ jobs:
           cache: "npm"
       - run: npm version
       - run: npm ci --no-audit --no-fund
+
+      # usi-csa-bridge
       - run: npm run usi-csa-bridge:build
-      - name: Scenario-1
+      - name: Test usi-csa-bridge (Scenario 1)
         timeout-minutes: 1
         run: ./src/tests/e2e/usi-csa-bridge/run 1
+
+      # Electron App
+      - run: npm run electron:build
+      - name: Test --add-engine command
+        timeout-minutes: 1
+        run: |
+          xvfb-run -a ./dist/linux-unpacked/electron-shogi \
+            --no-sandbox \
+            --add-engine \
+            ./scripts/dummy-usi-engine "Dummy Engine" \
+            10 \
+            H4sIAAAAAAAAE42Sa0+DMBSG/8v53IXLLjpiTCxx0W+axU/GmALd1ggtgWI2F/67KRY4u+FCApyXvs/bHs4eynjDMwYB8DJwnKoUIy7XQvKRyrVQshzFqcgjxYpklDDNgID9AMEelroQcv1gXiXLOASdQkDvciOUjWBsRcILCDzXJZDwFatSDQGslAIC3yytzOKEmQtqYjn0hEyHyF5Pipi5elJ4QgqHSD7e4x3Pcr27R/tslZrAQqTccHETeq2LWFkJh4wvN8LJmd44WjnGh2PomRg6HDNB9vCMPRy2T69uRbjh8RfugxU6fGxqzJ5hti4qjsBN2VLpMZUOUG/MX8+FPJjLpu7/eC4kttyijXgugUxICMyTbe3I2m15UwunR3B6GT7v3K45j8oiddClP6E/j6mR32vSixKCd1g0U0JZ0dx/gMBrtW3u1RY+cDcXB/Nk1rbZ9DibDmR712bXBGiltZKIboWOHrV1h/drAm/L588nVm6QsZMu9RSddOx3x5y485kFvijZrDxAWvHS5Pj/TmNNgEsWpfyRFemuzVixtOT1LzpIE4pLBQAA
+          test "$(cat $HOME/$USI_ENGINE_JSON | jq -r '.engines[].name')" = "Dummy Engine"
+          test "$(cat $HOME/$USI_ENGINE_JSON | jq -r '.engines[].options.FilenameA.value')" = "/path/to/file"

--- a/src/background/headless/command.ts
+++ b/src/background/headless/command.ts
@@ -3,4 +3,5 @@ export type HeadlessModeOperation = {
   path: string;
   name: string;
   timeout: number;
+  engineOptionsBase64?: string;
 };

--- a/src/background/headless/invoke.ts
+++ b/src/background/headless/invoke.ts
@@ -3,16 +3,22 @@ import { loadUSIEngines, saveUSIEngines } from "@/background/settings.js";
 import { getAppLogger } from "@/background/log.js";
 import { HeadlessModeOperation } from "./command.js";
 import { getUSIEngineInfo } from "@/background/usi/index.js";
+import { decompressUSIEngineOptionsClipboardData } from "@/common/settings/usi.js";
 
 export async function invoke(headless: HeadlessModeOperation) {
   switch (headless.operation) {
     case "addEngine":
-      await addEngine(headless.path, headless.name, headless.timeout);
+      await addEngine(headless.path, headless.name, headless.timeout, headless.engineOptionsBase64);
       break;
   }
 }
 
-export async function addEngine(enginePath: string, name: string, timeout: number) {
+export async function addEngine(
+  enginePath: string,
+  name: string,
+  timeout: number,
+  engineOptionsBase64?: string,
+) {
   const engineFullPath = path.resolve(process.cwd(), enginePath);
   getAppLogger().info(
     "Adding engine in headless mode: path=[%s] name=[%s] timeout=[%d]",
@@ -23,6 +29,18 @@ export async function addEngine(enginePath: string, name: string, timeout: numbe
   const engine = await getUSIEngineInfo(engineFullPath, timeout);
   engine.name = name;
   const engineSettings = await loadUSIEngines();
+
+  // overwrite options if provided
+  if (engineOptionsBase64) {
+    try {
+      const data = await decompressUSIEngineOptionsClipboardData(engineOptionsBase64);
+      engine.options = data.options;
+      engine.enableEarlyPonder = data.enableEarlyPonder;
+    } catch (e) {
+      throw new Error(`Failed to decode engine options: ${e}`);
+    }
+  }
+
   engineSettings.addEngine(engine);
   await saveUSIEngines(engineSettings);
   getAppLogger().info("Engine added successfully: %s", engine.name);

--- a/src/background/proc/args.ts
+++ b/src/background/proc/args.ts
@@ -21,7 +21,7 @@ export function parseProcessArgs(args: string[]): ProcessArgs | Error {
   //     layout profile
   //
   // Headless mode option:
-  //   --add-engine <path> <name> <timeout>
+  //   --add-engine <path> <name> <timeout> [<engine_options_base64>]
   //     add USI engine
   //
   let path;
@@ -50,7 +50,7 @@ export function parseProcessArgs(args: string[]): ProcessArgs | Error {
       i++;
     } else if (arg === "--add-engine") {
       // エンジン追加
-      const usage = "Usage: --add-engine <path> <name> <timeout>";
+      const usage = "Usage: --add-engine <path> <name> <timeout> [<engine_options_base64>]";
       if (args.length < i + 4) {
         return new Error(usage);
       }
@@ -66,12 +66,14 @@ export function parseProcessArgs(args: string[]): ProcessArgs | Error {
       if (isNaN(timeout) || timeout < 0) {
         return new Error("Invalid timeout value");
       }
+      const engineOptionsBase64 = args[++i] as string | undefined;
       return {
         type: "headless",
         operation: "addEngine",
         path,
         name,
         timeout,
+        engineOptionsBase64,
       };
     }
   }

--- a/src/tests/background/proc/args.spec.ts
+++ b/src/tests/background/proc/args.spec.ts
@@ -89,6 +89,25 @@ describe("args", () => {
     });
   });
 
+  it("headless/add-engine/with-options", () => {
+    const args = parseProcessArgs([
+      "node",
+      "--add-engine",
+      "/path/to/engine",
+      "EngineName",
+      "30",
+      "test-base64-options",
+    ]) as ProcessArgs;
+    expect(args).toEqual({
+      type: "headless",
+      operation: "addEngine",
+      path: "/path/to/engine",
+      name: "EngineName",
+      timeout: 30,
+      engineOptionsBase64: "test-base64-options",
+    });
+  });
+
   it("headless/add-engine/few-args", () => {
     const args = parseProcessArgs(["node", "--add-engine", "/path/to/engine"]);
     expect(args).toBeInstanceOf(Error);


### PR DESCRIPTION
# 説明 / Description

#1266

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Headless mode: optional base64-encoded engine options can be supplied when adding an engine to preload configuration (including early-ponder).
* **Command line**
  * The --add-engine command accepts an extra engine_options_base64 argument after the timeout to pass those options.
* **Tests**
  * Added CLI test verifying parsing accepts and returns the optional engine options argument.
* **Bug Fixes**
  * Decoding failures now surface a clearer error message.
* **Chores**
  * CI workflow added an automated add-engine validation step and test organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->