### PR TITLE
macOS のメモリ使用率表示を一時廃止

### DIFF
--- a/src/background/proc/state.ts
+++ b/src/background/proc/state.ts
@@ -36,6 +36,9 @@ export async function collectOSState(): Promise<OSState> {
     cpuTotalTime,
     cpuIdleTime,
     memoryTotal: mem.total,
-    memoryFree: mem.free,
+    // TODO:
+    //   macOS では Activity Monitor に近い値が出せないので非表示にしておく
+    //   Electron に追加予定の mem.purgeable を加えると Activity Monitor に近い値が出せるようになる
+    memoryFree: process.platform === "darwin" ? undefined : mem.free,
   };
 }

--- a/src/common/advanced/monitor.ts
+++ b/src/common/advanced/monitor.ts
@@ -7,7 +7,7 @@ export type OSState = {
   cpuTotalTime: number;
   cpuIdleTime: number;
   memoryTotal: number;
-  memoryFree: number;
+  memoryFree?: number;
 };
 
 export function blankOSState(): OSState {
@@ -17,7 +17,6 @@ export function blankOSState(): OSState {
     cpuTotalTime: 0,
     cpuIdleTime: 0,
     memoryTotal: 0,
-    memoryFree: 0,
   };
 }
 

--- a/src/renderer/view/monitor/MonitorView.vue
+++ b/src/renderer/view/monitor/MonitorView.vue
@@ -135,7 +135,9 @@
         <div class="footer">
           <span>{{ states.os.version }}/{{ states.os.arch }}</span>
           <span>CPU Usage: {{ cpuUsage.toFixed(1) }}%</span>
-          <span>Memory Free: {{ memoryFree.toFixed(2) }}GiB ({{ memoryUsage.toFixed(1) }}%)</span>
+          <span v-if="memoryFree !== null && memoryUsage !== null">
+            Memory Free: {{ memoryFree.toFixed(2) }}GiB ({{ memoryUsage.toFixed(1) }}%)
+          </span>
         </div>
       </div>
     </div>
@@ -206,9 +208,13 @@ onBeforeUnmount(() => {
   }
 });
 
-const memoryFree = computed(() => states.value.os.memoryFree / 1024 ** 2);
-const memoryUsage = computed(
-  () => (states.value.os.memoryFree / states.value.os.memoryTotal) * 100,
+const memoryFree = computed(() =>
+  states.value.os.memoryFree !== undefined ? states.value.os.memoryFree / 1024 ** 2 : null,
+);
+const memoryUsage = computed(() =>
+  states.value.os.memoryFree !== undefined && states.value.os.memoryTotal
+    ? (states.value.os.memoryFree / states.value.os.memoryTotal) * 100
+    : null,
 );
 const cpuUsage = computed(() => {
   const totalTime = states.value.os.cpuTotalTime - prevOSState.value.cpuTotalTime;


### PR DESCRIPTION
# 説明 / Description

#1321 

Electron で purgeable が取れるようになるまで、 Activity Monitor に近い値を表示できないので、それが可能になるまで表示を取り下げる。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected memory reporting on macOS by hiding “Memory Free” when unavailable, preventing misleading values and erroneous percentages.
  - Improved robustness when memory data is missing to avoid formatting errors.

- UI
  - Monitor footer now conditionally displays “Memory Free” only when data is available.
  - Memory usage percentage is shown only when both free and total memory are known, avoiding blank or incorrect displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->