### PR TITLE
Update shortcut file name

### DIFF
--- a/src/background/file/conversion.ts
+++ b/src/background/file/conversion.ts
@@ -23,22 +23,7 @@ import {
   Move,
   SpecialMoveType,
 } from "tsshogi";
-
-async function getAlternativeFilePathWithNumberSuffix(
-  filePath: string,
-  maxNumber: number,
-): Promise<string> {
-  const parsed = path.parse(filePath);
-  let suffix = 2;
-  while (await exists(filePath)) {
-    if (suffix > maxNumber) {
-      throw new Error("Too many files with the same name");
-    }
-    filePath = path.join(parsed.dir, parsed.name + "-" + suffix + parsed.ext);
-    suffix++;
-  }
-  return filePath;
-}
+import { resolveConflictFilePath } from "./filename.js";
 
 export async function convertRecordFiles(
   settings: BatchConversionSettings,
@@ -124,7 +109,7 @@ class DirectoryWriter {
         case FileNameConflictAction.OVERWRITE:
           break;
         case FileNameConflictAction.NUMBER_SUFFIX:
-          destination = await getAlternativeFilePathWithNumberSuffix(destination, 1000);
+          destination = await resolveConflictFilePath(destination);
           break;
         case FileNameConflictAction.SKIP:
           getAppLogger().debug(`batch conversion: skipped: ${source}`);

--- a/src/background/file/filename.ts
+++ b/src/background/file/filename.ts
@@ -1,0 +1,12 @@
+import path from "node:path";
+import { exists } from "@/background/helpers/file.js";
+
+export async function resolveConflictFilePath(filePath: string): Promise<string> {
+  const parsed = path.parse(filePath);
+  let suffix = 2;
+  while (await exists(filePath)) {
+    filePath = path.join(parsed.dir, parsed.name + "-" + suffix + parsed.ext);
+    suffix++;
+  }
+  return filePath;
+}

--- a/src/background/file/filename.ts
+++ b/src/background/file/filename.ts
@@ -5,6 +5,9 @@ export async function resolveConflictFilePath(filePath: string): Promise<string>
   const parsed = path.parse(filePath);
   let suffix = 2;
   while (await exists(filePath)) {
+    if (suffix > 1000) {
+      throw new Error("Too many files with the same name");
+    }
     filePath = path.join(parsed.dir, parsed.name + "-" + suffix + parsed.ext);
     suffix++;
   }

--- a/src/tests/background/file/filename.spec.ts
+++ b/src/tests/background/file/filename.spec.ts
@@ -1,0 +1,21 @@
+import path from "node:path";
+import fs from "node:fs";
+import { resolveConflictFilePath } from "@/background/file/filename";
+import { getTempPathForTesting } from "@/background/proc/env";
+
+describe("filename", () => {
+  it("should resolve conflict file paths", async () => {
+    const tempDir = getTempPathForTesting();
+    const filePath = path.join(tempDir, "test.txt");
+
+    for (const expected of [
+      path.join(tempDir, "test.txt"),
+      path.join(tempDir, "test-2.txt"),
+      path.join(tempDir, "test-3.txt"),
+      path.join(tempDir, "test-4.txt"),
+    ]) {
+      expect(await resolveConflictFilePath(filePath)).toBe(expected);
+      fs.writeFileSync(expected, "data");
+    }
+  });
+});


### PR DESCRIPTION
# 説明 / Description

同名のレウアウトプロファイルに対してショートカットを複数回作成しようとしたときに同名による作成を回避する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automatically avoids filename collisions when generating shortcuts and other artifacts on Windows, macOS, and Linux by appending numeric suffixes (e.g., "-2") while preserving extensions.

- **Bug Fixes**
  - Prevents accidental overwriting of existing files during shortcut/script/app creation.

- **Tests**
  - Added unit tests validating conflict-free filename generation when files already exist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->