### PR TITLE
On-the-fly モードでの定跡手登録の高速化

### DIFF
--- a/src/tests/background/book/apery.bench.ts
+++ b/src/tests/background/book/apery.bench.ts
@@ -16,7 +16,7 @@ describe("background/book/apery", async () => {
     const file = fs.createReadStream(book10mPath);
     try {
       const book = await loadAperyBook(file);
-      expect(book.aperyEntries.get(BigInt(0))).not.toBeUndefined();
+      expect(book.entries.get(BigInt(0))).not.toBeUndefined();
     } finally {
       file.close();
     }

--- a/src/tests/background/book/yaneuraou.spec.ts
+++ b/src/tests/background/book/yaneuraou.spec.ts
@@ -16,8 +16,9 @@ describe("background/book/yaneuraou", () => {
         "9f9e 8g7g 0 32 1\n",
       ]);
       const book = await loadYaneuraOuBook(input);
-      expect(book.yaneEntries).toEqual({
+      expect(Object.fromEntries(book.entries.entries())).toEqual({
         "+P1kg3nl/1ps2b3/+P3p3p/2pgsr1p1/s2p1pP2/2P1P1pR1/1SNG1P2P/1KG6/7NL w N2LPb2p 1": {
+          type: "normal",
           comment: "",
           moves: [
             ["4e4f", "9c9d", 120, 40, 2, ""],
@@ -26,6 +27,7 @@ describe("background/book/yaneuraou", () => {
           minPly: 78,
         },
         "lnB4nl/4k1g2/p3pps2/1G5rp/1pPPsb3/3p2P1P/PPS1PP3/2G1KSGP1/LN5NL w R2Pp 1": {
+          type: "normal",
           comment: "",
           moves: [
             ["4e7h+", undefined, 540, 38, 1, ""],
@@ -34,6 +36,7 @@ describe("background/book/yaneuraou", () => {
           minPly: 64,
         },
         "+B3g3l/5rgk1/pB+P1ppn1p/n4spp1/1G1SP3P/K2P5/1+pS3P2/P2+l+r4/LNP6 b SNL2Pg2p 1": {
+          type: "normal",
           comment: "",
           moves: [["9f9e", "8g7g", 0, 32, 1, ""]],
           minPly: 0,


### PR DESCRIPTION
# 説明 / Description

棋譜ファイルから定跡手を登録する際に、定跡ファイルのバイナリサーチの実行をなくすことで高速化する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Aggregated moves per position for more accurate opening-book results and simpler on-the-fly search entries.
  - Public merge helper added to reliably combine base and edits.

- Bug Fixes
  - Improved error handling during merges to avoid partial outputs and ensure cleanup.

- Refactor
  - Unified Map-based in-memory storage for book entries; consistent read/write/merge flow.
  - Entry objects now include a type discriminator and normalized shape.

- Tests
  - Updated tests to match the new entry structure and behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->