### PR TITLE
macOS の空きメモリを表示

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "archiver": "^7.0.1",
         "concurrently": "^9.0.1",
         "depcheck": "^1.4.7",
-        "electron": "^37.1.0",
+        "electron": "^38.0.0",
         "electron-builder": "^26.0.12",
         "electron-devtools-installer": "^4.0.0",
         "eslint": "^8.26.0",
@@ -2305,72 +2305,6 @@
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@electron/windows-sign": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz",
-      "integrity": "sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "cross-dirname": "^0.1.0",
-        "debug": "^4.3.4",
-        "fs-extra": "^11.1.1",
-        "minimist": "^1.2.8",
-        "postject": "^1.0.0-alpha.6"
-      },
-      "bin": {
-        "electron-windows-sign": "bin/electron-windows-sign.js"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/@electron/windows-sign/node_modules/fs-extra": {
-      "version": "11.3.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
-      "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/@electron/windows-sign/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@electron/windows-sign/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -7599,15 +7533,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/cross-dirname": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
-      "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -8384,9 +8309,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "37.4.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-37.4.0.tgz",
-      "integrity": "sha512-HhsSdWowE5ODOeWNc/323Ug2C52mq/TqNBG+4uMeOA3G2dMXNc/nfyi0RYu1rJEgiaJLEjtHveeZZaYRYFsFCQ==",
+      "version": "38.0.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-38.0.0.tgz",
+      "integrity": "sha512-egljptiPJqbL/oamFCEY+g3RNeONWTVxZSGeyLqzK8xq106JhzuxnhJZ3sxt4DzJFaofbGyGJA37Oe9d+gVzYw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -13687,36 +13612,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/postject": {
-      "version": "1.0.0-alpha.6",
-      "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
-      "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "commander": "^9.4.0"
-      },
-      "bin": {
-        "postject": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/postject/node_modules/commander": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "archiver": "^7.0.1",
     "concurrently": "^9.0.1",
     "depcheck": "^1.4.7",
-    "electron": "^37.1.0",
+    "electron": "^38.0.0",
     "electron-builder": "^26.0.12",
     "electron-devtools-installer": "^4.0.0",
     "eslint": "^8.26.0",

--- a/src/background/proc/state.ts
+++ b/src/background/proc/state.ts
@@ -36,9 +36,6 @@ export async function collectOSState(): Promise<OSState> {
     cpuTotalTime,
     cpuIdleTime,
     memoryTotal: mem.total,
-    // TODO:
-    //   macOS では Activity Monitor に近い値が出せないので非表示にしておく
-    //   Electron に追加予定の mem.purgeable を加えると Activity Monitor に近い値が出せるようになる
-    memoryFree: process.platform === "darwin" ? undefined : mem.free,
+    memoryFree: mem.free + mem.fileBacked,
   };
 }

--- a/src/background/proc/state.ts
+++ b/src/background/proc/state.ts
@@ -36,6 +36,6 @@ export async function collectOSState(): Promise<OSState> {
     cpuTotalTime,
     cpuIdleTime,
     memoryTotal: mem.total,
-    memoryFree: mem.free + mem.fileBacked,
+    memoryFree: mem.free + (process.platform === "darwin" ? mem.fileBacked : 0),
   };
 }

--- a/src/common/advanced/monitor.ts
+++ b/src/common/advanced/monitor.ts
@@ -7,7 +7,7 @@ export type OSState = {
   cpuTotalTime: number;
   cpuIdleTime: number;
   memoryTotal: number;
-  memoryFree?: number;
+  memoryFree: number;
 };
 
 export function blankOSState(): OSState {
@@ -17,6 +17,7 @@ export function blankOSState(): OSState {
     cpuTotalTime: 0,
     cpuIdleTime: 0,
     memoryTotal: 0,
+    memoryFree: 0,
   };
 }
 

--- a/src/renderer/view/monitor/MonitorView.vue
+++ b/src/renderer/view/monitor/MonitorView.vue
@@ -135,8 +135,9 @@
         <div class="footer">
           <span>{{ states.os.version }}/{{ states.os.arch }}</span>
           <span>CPU Usage: {{ cpuUsage.toFixed(1) }}%</span>
-          <span v-if="memoryFree !== null && memoryUsage !== null">
-            Memory Free: {{ memoryFree.toFixed(2) }}GiB ({{ memoryUsage.toFixed(1) }}%)
+          <span>
+            Memory Free: {{ memoryFree.toFixed(2) }}GiB
+            <span v-if="memoryUsage !== null">({{ memoryUsage.toFixed(1) }}%)</span>
           </span>
         </div>
       </div>
@@ -208,11 +209,9 @@ onBeforeUnmount(() => {
   }
 });
 
-const memoryFree = computed(() =>
-  states.value.os.memoryFree !== undefined ? states.value.os.memoryFree / 1024 ** 2 : null,
-);
+const memoryFree = computed(() => states.value.os.memoryFree / 1024 ** 2);
 const memoryUsage = computed(() =>
-  states.value.os.memoryFree !== undefined && states.value.os.memoryTotal
+  states.value.os.memoryTotal
     ? (states.value.os.memoryFree / states.value.os.memoryTotal) * 100
     : null,
 );


### PR DESCRIPTION
# 説明 / Description

#1321 

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Memory metrics display is now consistent across platforms; “Memory Free” always appears.
  * Free memory calculation improved to include additional available memory on macOS, increasing accuracy.
  * “Memory Usage” percentage now shows only when total memory is available, reducing empty or misleading displays.

* **Chores**
  * Upgraded Electron development dependency to v38.x for improved stability and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->