### PR TITLE
Disable entry count for on-the-fly mode

### DIFF
--- a/src/background/book/index.ts
+++ b/src/background/book/index.ts
@@ -552,11 +552,18 @@ export async function importBookMoves(
     successFileCount++;
   }
 
+  if (bookRef.type === "in-memory") {
+    return {
+      successFileCount,
+      errorFileCount,
+      skippedFileCount,
+      entryCount,
+      duplicateCount,
+    };
+  }
   return {
     successFileCount,
     errorFileCount,
     skippedFileCount,
-    entryCount,
-    duplicateCount,
   };
 }

--- a/src/common/book.ts
+++ b/src/common/book.ts
@@ -17,8 +17,8 @@ export type BookImportSummary = {
   successFileCount: number; // 正常に読み込んだファイルの数
   errorFileCount: number; // 読み込みエラーが発生したファイルの数
   skippedFileCount: number; // 読み込みをスキップしたファイルの数
-  entryCount: number; // 新規に登録された定跡手の数
-  duplicateCount: number; // 重複した定跡手の数
+  entryCount?: number; // 新規に登録された定跡手の数
+  duplicateCount?: number; // 重複した定跡手の数
 };
 
 export type BookMoveEx = BookMove & {

--- a/src/renderer/store/book.ts
+++ b/src/renderer/store/book.ts
@@ -184,30 +184,28 @@ export class BookStore {
       .saveBookImportSettings(settings)
       .then(() => api.importBookMoves(settings))
       .then((summary) => {
+        const items = [
+          {
+            text: t.file,
+            children: [
+              `${t.success}: ${summary.successFileCount}`,
+              `${t.failed}: ${summary.errorFileCount}`,
+              `${t.skipped}: ${summary.skippedFileCount}`,
+            ],
+          },
+        ];
+        if (summary.entryCount !== undefined && summary.duplicateCount !== undefined) {
+          items.push({
+            text: t.moveEntry,
+            children: [
+              `${t.new}: ${summary.entryCount}`,
+              `${t.duplicated}: ${summary.duplicateCount}`,
+            ],
+          });
+        }
         useMessageStore().enqueue({
           text: t.bookMovesWereImported,
-          attachments: [
-            {
-              type: "list",
-              items: [
-                {
-                  text: t.file,
-                  children: [
-                    `${t.success}: ${summary.successFileCount}`,
-                    `${t.failed}: ${summary.errorFileCount}`,
-                    `${t.skipped}: ${summary.skippedFileCount}`,
-                  ],
-                },
-                {
-                  text: t.moveEntry,
-                  children: [
-                    `${t.new}: ${summary.entryCount}`,
-                    `${t.duplicated}: ${summary.duplicateCount}`,
-                  ],
-                },
-              ],
-            },
-          ],
+          attachments: [{ type: "list", items }],
           withCopyButton: true,
         });
         return this.reloadBookMoves();


### PR DESCRIPTION
# 説明 / Description

related to #1327 

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Importing in-memory books now shows detailed stats, including new and duplicated entries.
  * Import summaries display a clear list of file outcomes: successful, failed, and skipped.

* **Bug Fixes**
  * Entry and duplicate counts are no longer shown when unavailable, preventing misleading or empty stats in non-in-memory imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->