### PR TITLE
Disable session remove delay on cli

### DIFF
--- a/src/background/csa/index.ts
+++ b/src/background/csa/index.ts
@@ -38,7 +38,11 @@ function issueSessionID(): number {
 }
 
 const clients = new Map<number, Client>();
-const sessionRemoveDelay = 20e3;
+let sessionRemoveDelay = 20e3;
+
+export function setSessionRemoveDelay(delay: number): void {
+  sessionRemoveDelay = delay;
+}
 
 function registerClient(client: Client): void {
   clients.set(client.sessionID, client);

--- a/src/background/usi/index.ts
+++ b/src/background/usi/index.ts
@@ -122,7 +122,11 @@ function issueSessionID(): number {
 }
 
 const sessions = new Map<number, Session>();
-const engineRemoveDelay = 20e3;
+let sessionRemoveDelay = 20e3;
+
+export function setSessionRemoveDelay(delay: number): void {
+  sessionRemoveDelay = delay;
+}
 
 function isSessionExists(sessionID: number): boolean {
   return sessions.has(sessionID);
@@ -153,7 +157,7 @@ export function setupPlayer(engine: USIEngine, timeoutSeconds: number): Promise<
       .on("close", () => {
         setTimeout(() => {
           sessions.delete(sessionID);
-        }, engineRemoveDelay);
+        }, sessionRemoveDelay);
       })
       .on("error", (err) => {
         const lastReceived = process.lastReceived?.command;

--- a/src/command/common/preload.ts
+++ b/src/command/common/preload.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 import { LogDestination, getAppLogger, setLogDestinations } from "@/background/log.js";
 import {
+  setSessionRemoveDelay as setCSASessionRemoveDelay,
   login as csaLogin,
   logout as csaLogout,
   agree as csaAgree,
@@ -11,6 +12,7 @@ import {
   setHandlers as setCSAHandlers,
 } from "@/background/csa/index.js";
 import {
+  setSessionRemoveDelay as setUSISessionRemoveDelay,
   ready as usiReady,
   setOption as usiSetOption,
   go as usiGo,
@@ -416,6 +418,9 @@ export function preload(config: Config) {
   setLogDestinations(LogType.APP, appDestinations, config.logLevel);
   setLogDestinations(LogType.USI, usiDestinations, config.logLevel);
   setLogDestinations(LogType.CSA, csaDestinations, config.logLevel);
+
+  setUSISessionRemoveDelay(0);
+  setCSASessionRemoveDelay(0);
 
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const usi = require("@/renderer/players/usi.js");


### PR DESCRIPTION
# 説明 / Description

#1335 

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a setting to adjust how quickly inactive sessions are removed, configurable at runtime.
* **Improvements**
  * Sessions for CSA and USI now default to immediate removal after closing, reducing delays and keeping the interface cleaner.
  * Faster cleanup may improve responsiveness and lower resource usage during session-heavy workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->