### PR TITLE
盤レイアウトを切り替えるメニュー

### DIFF
--- a/src/background/window/ipc.ts
+++ b/src/background/window/ipc.ts
@@ -1006,7 +1006,6 @@ export function onMenuEvent(event: MenuEvent, ...args: any[]): void {
   mainWindow.webContents.send(Renderer.MENU_EVENT, event, ...args);
 }
 
-// FIXME: do not export
 export function updateAppSettings(settings: AppSettingsUpdate): void {
   mainWindow.webContents.send(Renderer.UPDATE_APP_SETTINGS, JSON.stringify(settings));
 }

--- a/src/background/window/menu.ts
+++ b/src/background/window/menu.ts
@@ -39,6 +39,7 @@ import { materialIconsGuideURL } from "@/common/links/google.js";
 import { openPath } from "@/background/helpers/electron.js";
 import { createMonitorWindow } from "./monitor.js";
 import { createListItems } from "@/common/message.js";
+import { BoardLayoutType } from "@/common/settings/layout.js";
 
 const isWin = process.platform === "win32";
 const isMac = process.platform === "darwin";
@@ -385,6 +386,35 @@ function createMenuTemplate(window: BrowserWindow) {
           click: () => {
             createMonitorWindow(window);
           },
+        },
+        {
+          type: "separator",
+        },
+        {
+          label: t.boardLayout,
+          submenu: [
+            {
+              label: t.standard,
+              click: () => {
+                updateAppSettings({ boardLayoutType: BoardLayoutType.STANDARD });
+              },
+              accelerator: "CmdOrCtrl+1",
+            },
+            {
+              label: t.compact,
+              click: () => {
+                updateAppSettings({ boardLayoutType: BoardLayoutType.COMPACT });
+              },
+              accelerator: "CmdOrCtrl+2",
+            },
+            {
+              label: t.portrait,
+              click: () => {
+                updateAppSettings({ boardLayoutType: BoardLayoutType.PORTRAIT });
+              },
+              accelerator: "CmdOrCtrl+3",
+            },
+          ],
         },
         {
           type: "separator",


### PR DESCRIPTION
# 説明 / Description

メニューバーやショートカットキーで盤レイアウトを素早く切り替えられるようにする。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Board Layout” submenu under View to switch between Standard, Compact, and Portrait layouts.
  * Introduced keyboard shortcuts for quick layout switching: Cmd/Ctrl+1 (Standard), Cmd/Ctrl+2 (Compact), Cmd/Ctrl+3 (Portrait).
* **Chores**
  * Cleaned up a deprecated comment with no impact on functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->