### PR TITLE
Add electron fuse settings

### DIFF
--- a/.electron-builder.config.mjs
+++ b/.electron-builder.config.mjs
@@ -1,4 +1,7 @@
+import { execFile } from "node:child_process";
 import fs from "node:fs";
+import path from "node:path";
+import { promisify } from "node:util";
 
 /**
  * @type {import('electron-builder').Configuration}
@@ -26,20 +29,25 @@ const config = {
     "dist/packed",
     "!node_modules/**/*",
   ],
-  afterPack: function (context) {
+  afterPack: async function (context) {
     if (context.electronPlatformName === "darwin") {
-      return;
+      const appPath = path.join(
+        context.appOutDir,
+        `${context.packager.appInfo.productFilename}.app`,
+      );
+      await removeUnnecessaryFilesForMac(appPath);
+    } else {
+      await removeUnnecessaryFiles(context.appOutDir);
     }
-    const localeDir = context.appOutDir + "/locales/";
-    for (const file of fs.readdirSync(localeDir)) {
-      switch (file) {
-        case "en-US.pak":
-        case "ja.pak":
-          break;
-        default:
-          fs.unlinkSync(localeDir + file);
-          break;
-      }
+  },
+  afterSign: async function (context) {
+    // macOS では Fuses 適用後に署名をしないと起動できない
+    if (context.electronPlatformName === "darwin") {
+      const appPath = path.join(
+        context.appOutDir,
+        `${context.packager.appInfo.productFilename}.app`,
+      );
+      await signMacApp(appPath);
     }
   },
   win: {
@@ -81,6 +89,49 @@ const config = {
     ],
   },
   publish: null,
+
+  // https://www.electronjs.org/docs/latest/tutorial/fuses
+  electronFuses: {
+    runAsNode: false, // 任意の JavaScript コードの実行を防止 (Default: true)
+    //enableCookieEncryption: true, // Cookieの暗号化を有効化 (Default: false)
+    enableNodeOptionsEnvironmentVariable: false, // Node.js の特別な環境変数を無効化 (Default: true)
+    enableNodeCliInspectArguments: false, // --inspect などの引数を無効化 (Default: true)
+    enableEmbeddedAsarIntegrityValidation: true, // ASAR の整合性検証を有効化 (Default: false)
+    onlyLoadAppFromAsar: true, // ASAR 以外からのアプリケーションコードの読み込みを防止 (Default: false)
+    //loadBrowserProcessSpecificV8Snapshot: true, // ブラウザープロセスのスナップショットを分離 (Default: false)
+    grantFileProtocolExtraPrivileges: false, // 本番環境ではカスタムスキームを使用するため不要 (Default: true)
+  },
 };
 
 export default config;
+
+async function signMacApp(appPath) {
+  await promisify(execFile)("codesign", ["--force", "--sign", "-", "--deep", appPath]);
+  await promisify(execFile)("codesign", ["--verify", "--deep", "--strict", "--verbose=2", appPath]);
+}
+
+async function removeUnnecessaryFiles(appOutDir) {
+  const localeDir = path.join(appOutDir, "locales");
+  for (const file of await fs.promises.readdir(localeDir)) {
+    switch (file) {
+      case "en-US.pak":
+      case "ja.pak":
+        break;
+      default:
+        await fs.promises.unlink(path.join(localeDir, file));
+        break;
+    }
+  }
+}
+
+async function removeUnnecessaryFilesForMac(appPath) {
+  const resourceDir = path.join(
+    appPath,
+    "Contents/Frameworks/Electron Framework.framework/Versions/A/Resources",
+  );
+  for (const file of await fs.promises.readdir(resourceDir)) {
+    if (file.endsWith(".lproj") && file !== "en.lproj" && file !== "ja.lproj") {
+      await fs.promises.rm(path.join(resourceDir, file), { recursive: true, force: true });
+    }
+  }
+}


### PR DESCRIPTION
# 説明 / Description

#1349 

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Enabled additional Electron security hardening flags for safer runtime behavior.

- Chores
  - Improved macOS signing and verification for more reliable distribution.
  - Reduced app size by removing unused language resources; only English and Japanese are retained.
  - Streamlined post-pack processing with per-platform cleanup to remove unnecessary files after packaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->