### PR TITLE
Update resource usage messages

### DIFF
--- a/src/background/window/ipc.ts
+++ b/src/background/window/ipc.ts
@@ -733,14 +733,16 @@ ipcMain.handle(Background.SHOW_SELECT_USI_ENGINE_DIALOG, async (event): Promise<
 
 ipcMain.handle(
   Background.GET_USI_ENGINE_INFO,
-  async (event, path: string, timeoutSeconds: number): Promise<[string, string]> => {
+  async (event, path: string, timeoutSeconds: number): Promise<string> => {
     validateIPCSender(event.senderFrame);
-    return [
-      JSON.stringify(await usiGetUSIEngineInfo(path, timeoutSeconds)),
-      JSON.stringify(await loadUSIEngineMeta(path)),
-    ];
+    return JSON.stringify(await usiGetUSIEngineInfo(path, timeoutSeconds));
   },
 );
+
+ipcMain.handle(Background.GET_USI_ENGINE_METADATA, async (event, path: string): Promise<string> => {
+  validateIPCSender(event.senderFrame);
+  return JSON.stringify(await loadUSIEngineMeta(path));
+});
 
 ipcMain.handle(
   Background.SEND_USI_OPTION_BUTTON_SIGNAL,

--- a/src/command/common/preload.ts
+++ b/src/command/common/preload.ts
@@ -198,7 +198,10 @@ const bridge: Bridge = {
   async showSelectUSIEngineDialog(): Promise<string> {
     throw new Error("This feature is not available on command line tool");
   },
-  async getUSIEngineInfo(): Promise<[string, string]> {
+  async getUSIEngineInfo(): Promise<string> {
+    throw new Error("This feature is not available on command line tool");
+  },
+  async getUSIEngineMetadata(): Promise<string> {
     throw new Error("This feature is not available on command line tool");
   },
   async sendUSIOptionButtonSignal(): Promise<void> {

--- a/src/common/ipc/channel.ts
+++ b/src/common/ipc/channel.ts
@@ -56,6 +56,7 @@ export enum Background {
   SAVE_BOOK_IMPORT_SETTINGS = "saveBookImportSettings",
   SHOW_SELECT_USI_ENGINE_DIALOG = "showSelectUSIEngineDialog",
   GET_USI_ENGINE_INFO = "getUSIEngineInfo",
+  GET_USI_ENGINE_METADATA = "getUSIEngineMetadata",
   SEND_USI_OPTION_BUTTON_SIGNAL = "sendUSIOptionButtonSignal",
   LAUNCH_USI = "usiLaunch",
   USI_READY = "usiReady",

--- a/src/renderer/ipc/api.ts
+++ b/src/renderer/ipc/api.ts
@@ -85,7 +85,8 @@ export interface API {
 
   // USI
   showSelectUSIEngineDialog(): Promise<string>;
-  getUSIEngineInfo(path: string, timeoutSeconds: number): Promise<[USIEngine, USIEngineMetadata]>;
+  getUSIEngineInfo(path: string, timeoutSeconds: number): Promise<USIEngine>;
+  getUSIEngineMetadata(path: string): Promise<USIEngineMetadata>;
   sendUSIOptionButtonSignal(path: string, name: string, timeoutSeconds: number): Promise<void>;
   usiLaunch(engine: USIEngine, timeoutSeconds: number): Promise<number>;
   usiReady(sessionID: number): Promise<void>;
@@ -246,12 +247,13 @@ const api: API = {
   },
 
   // USI
-  async getUSIEngineInfo(
-    path: string,
-    timeoutSeconds: number,
-  ): Promise<[USIEngine, USIEngineMetadata]> {
-    const [engine, metadata] = await bridge.getUSIEngineInfo(path, timeoutSeconds);
-    return [JSON.parse(engine), JSON.parse(metadata)];
+  async getUSIEngineInfo(path: string, timeoutSeconds: number): Promise<USIEngine> {
+    const engine = await bridge.getUSIEngineInfo(path, timeoutSeconds);
+    return JSON.parse(engine);
+  },
+  async getUSIEngineMetadata(path: string): Promise<USIEngineMetadata> {
+    const metadata = await bridge.getUSIEngineMetadata(path);
+    return JSON.parse(metadata);
   },
   usiLaunch(engine: USIEngine, timeoutSeconds: number): Promise<number> {
     return bridge.usiLaunch(JSON.stringify(engine), timeoutSeconds);

--- a/src/renderer/ipc/bridge.ts
+++ b/src/renderer/ipc/bridge.ts
@@ -69,7 +69,8 @@ export interface Bridge {
 
   // USI
   showSelectUSIEngineDialog(): Promise<string>;
-  getUSIEngineInfo(path: string, timeoutSeconds: number): Promise<[string, string]>;
+  getUSIEngineInfo(path: string, timeoutSeconds: number): Promise<string>;
+  getUSIEngineMetadata(path: string): Promise<string>;
   sendUSIOptionButtonSignal(path: string, name: string, timeoutSeconds: number): Promise<void>;
   usiLaunch(json: string, timeoutSeconds: number): Promise<number>;
   usiReady(sessionID: number): Promise<void>;

--- a/src/renderer/ipc/preload.ts
+++ b/src/renderer/ipc/preload.ts
@@ -182,8 +182,11 @@ const api: Bridge = {
   async showSelectUSIEngineDialog(): Promise<string> {
     return await ipcRenderer.invoke(Background.SHOW_SELECT_USI_ENGINE_DIALOG);
   },
-  async getUSIEngineInfo(path: string, timeoutSeconds: number): Promise<[string, string]> {
+  async getUSIEngineInfo(path: string, timeoutSeconds: number): Promise<string> {
     return await ipcRenderer.invoke(Background.GET_USI_ENGINE_INFO, path, timeoutSeconds);
+  },
+  async getUSIEngineMetadata(path: string): Promise<string> {
+    return await ipcRenderer.invoke(Background.GET_USI_ENGINE_METADATA, path);
   },
   async sendUSIOptionButtonSignal(
     path: string,

--- a/src/renderer/ipc/web.ts
+++ b/src/renderer/ipc/web.ts
@@ -285,7 +285,10 @@ export const webAPI: Bridge = {
   async showSelectUSIEngineDialog(): Promise<string> {
     throw new Error(t.thisFeatureNotAvailableOnWebApp);
   },
-  async getUSIEngineInfo(): Promise<[string, string]> {
+  async getUSIEngineInfo(): Promise<string> {
+    throw new Error(t.thisFeatureNotAvailableOnWebApp);
+  },
+  async getUSIEngineMetadata(): Promise<string> {
     throw new Error(t.thisFeatureNotAvailableOnWebApp);
   },
   async sendUSIOptionButtonSignal(): Promise<void> {

--- a/src/renderer/view/dialog/USIEngineManagementDialog.vue
+++ b/src/renderer/view/dialog/USIEngineManagementDialog.vue
@@ -204,7 +204,7 @@ const add = async () => {
     }
     const appSettings = useAppSettings();
     const timeoutSeconds = appSettings.engineTimeoutSeconds;
-    const [engine] = await api.getUSIEngineInfo(path, timeoutSeconds);
+    const engine = await api.getUSIEngineInfo(path, timeoutSeconds);
     usiEngines.value.addEngine(engine);
     lastAdded.value = scrollTo = engine.uri;
   } catch (e) {

--- a/src/renderer/view/dialog/USIEngineOptionsDialog.vue
+++ b/src/renderer/view/dialog/USIEngineOptionsDialog.vue
@@ -338,7 +338,8 @@ busyState.retain();
 onMounted(async () => {
   try {
     const timeoutSeconds = appSettings.engineTimeoutSeconds;
-    [engine.value, metadata.value] = await api.getUSIEngineInfo(props.latest.path, timeoutSeconds);
+    engine.value = await api.getUSIEngineInfo(props.latest.path, timeoutSeconds);
+    metadata.value = await api.getUSIEngineMetadata(props.latest.path);
     mergeUSIEngine(engine.value, props.latest);
     options.value = Object.values(engine.value.options)
       .sort((a, b): number => (a.order < b.order ? -1 : 1))
@@ -372,7 +373,7 @@ const replaceEnginePath = async () => {
       message: t.incompatibleOptionsWillBeDiscardedDoYouReallyWantToReplaceTheEnginePath,
       onOk: async () => {
         try {
-          const [newEngine] = await api.getUSIEngineInfo(path, timeoutSeconds);
+          const newEngine = await api.getUSIEngineInfo(path, timeoutSeconds);
           mergeUSIEngine(newEngine, engine.value); // もとの設定を引き継ぐ
           engine.value = newEngine;
         } catch (e) {


### PR DESCRIPTION
# 説明 / Description



# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [ ] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Engine info retrieval reworked: engine data and metadata are fetched via separate calls rather than a combined response.
  * Dialogs updated to load metadata asynchronously and cache per-engine metadata, and computations now respect metadata (e.g., excluding shell-script engines).

* **New Features**
  * Added a distinct API to fetch USI engine metadata independently.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->