### PR TITLE
USI形式棋譜の拡張表現対応を強化

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "proper-lockfile": "^4.1.2",
         "semver": "^7.7.3",
         "splitpanes": "^4.0.3",
-        "tsshogi": "^2.3.0",
+        "tsshogi": "^2.3.1",
         "vue": "^3.5.25",
         "yaml": "^2.8.2"
       },
@@ -16558,9 +16558,9 @@
       "license": "0BSD"
     },
     "node_modules/tsshogi": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tsshogi/-/tsshogi-2.3.0.tgz",
-      "integrity": "sha512-iu9GKOJyiHf5p96TcGYpvb00ionKh59LH/t7EIJoGnNqKrQGKogTXXi0xf7fZlPCjMFiXnFirfCAreMBk+DQeg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tsshogi/-/tsshogi-2.3.1.tgz",
+      "integrity": "sha512-h+rP0VyKXh1MXovqkq3PtL8xvazp+GMdfybFf64mbUHFJy8DmFSiH3vQQmYbqWLB2fJAtt7zqOcMO9zJm4zFyg==",
       "license": "MIT"
     },
     "node_modules/tsx": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "proper-lockfile": "^4.1.2",
     "semver": "^7.7.3",
     "splitpanes": "^4.0.3",
-    "tsshogi": "^2.3.0",
+    "tsshogi": "^2.3.1",
     "vue": "^3.5.25",
     "yaml": "^2.8.2"
   },

--- a/src/background/file/conversion.ts
+++ b/src/background/file/conversion.ts
@@ -270,7 +270,7 @@ class SingleFileWriter {
       }
       if (p.move instanceof Move) {
         branches.push(moves + " " + p.move.usi);
-      } else if (this.appSettings.enableUSIFileResign && p.move.type === SpecialMoveType.RESIGN) {
+      } else if (this.settings.enableUSIResign && p.move.type === SpecialMoveType.RESIGN) {
         branches.push(moves + " resign");
       } else {
         branches.push(moves);

--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -265,6 +265,7 @@ export const en: Texts = {
   positionOfUSIOutput: "Position of USI Output",
   movesOfUSIOutput: "Moves of USI Output",
   onlySFEN: "Only SFEN",
+  minimal: "Minimal",
   pasteDialog: "Paste Dialog",
   liveDuplicatePositionDetection: "Live Duplicate Position Detection",
   onTheFlyThreshold: "On-the-fly Threshold",

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -265,6 +265,7 @@ export const ja: Texts = {
   positionOfUSIOutput: "USI の局面表記",
   movesOfUSIOutput: "USI の指し手表記",
   onlySFEN: "SFEN のみ",
+  minimal: "最小限",
   pasteDialog: "貼り付けダイアログ",
   liveDuplicatePositionDetection: "同一局面を常に検出",
   onTheFlyThreshold: "On-the-fly 閾値",

--- a/src/common/i18n/locales/vi.ts
+++ b/src/common/i18n/locales/vi.ts
@@ -265,6 +265,7 @@ export const vi: Texts = {
   positionOfUSIOutput: "Định dạng thế cờ USI",
   movesOfUSIOutput: "Định dạng kỳ phổ USI",
   onlySFEN: "Chỉ SFEN",
+  minimal: "最小限", // TODO: Translate
   pasteDialog: "Hộp thoại dán",
   liveDuplicatePositionDetection: "Tự động tìm thế cờ lặp lại",
   onTheFlyThreshold: "Giá trị On-the-fly",

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -262,6 +262,7 @@ export const zh_tw: Texts = {
   positionOfUSIOutput: "USI 局面紀錄格式",
   movesOfUSIOutput: "USI 棋譜紀錄格式",
   onlySFEN: "只有 SFEN",
+  minimal: "最小限", // TODO: Translate
   pasteDialog: "貼上視窗",
   liveDuplicatePositionDetection: "同一局面を常に検出", // TODO: Translate
   onTheFlyThreshold: "On-the-fly 閾値", // TODO: Translate

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -260,6 +260,7 @@ export type Texts = {
   positionOfUSIOutput: string;
   movesOfUSIOutput: string;
   onlySFEN: string;
+  minimal: string;
   pasteDialog: string;
   liveDuplicatePositionDetection: string;
   onTheFlyThreshold: string;

--- a/src/common/settings/app.ts
+++ b/src/common/settings/app.ts
@@ -207,7 +207,8 @@ export type AppSettings = {
   recordFileNameTemplate: string;
   useCSAV3: boolean;
   enableUSIFileStartpos: boolean;
-  enableUSIFileResign: boolean;
+  enableUSIFileResign: boolean; // Deprecated
+  enableUSIFileSpecialMoves: boolean;
   showPasteDialog: boolean;
   liveDuplicatePositionDetection: boolean;
 
@@ -362,6 +363,7 @@ export function defaultAppSettings(opt?: {
     useCSAV3: false,
     enableUSIFileStartpos: true,
     enableUSIFileResign: false,
+    enableUSIFileSpecialMoves: false,
     showPasteDialog: true,
     liveDuplicatePositionDetection: true,
     bookOnTheFlyThresholdMB: 64,
@@ -454,6 +456,10 @@ export function normalizeAppSettings(
   }
   // 旧バージョンでは On-the-fly の最大値が 4096 だったが 512 に変更した。
   result.bookOnTheFlyThresholdMB = Math.min(Math.max(result.bookOnTheFlyThresholdMB, 0), 512);
+  // 旧バージョンの USI 棋譜では resign のみに対応していた。
+  if (settings.enableUSIFileSpecialMoves === undefined) {
+    result.enableUSIFileSpecialMoves = result.enableUSIFileResign;
+  }
   return result;
 }
 

--- a/src/common/settings/conversion.ts
+++ b/src/common/settings/conversion.ts
@@ -29,6 +29,7 @@ export type BatchConversionSettings = {
   destinationFormat: RecordFileFormat;
   fileNameConflictAction: FileNameConflictAction;
   singleFileDestination: string;
+  enableUSIResign: boolean;
 };
 
 export function defaultBatchConversionSettings(): BatchConversionSettings {
@@ -51,6 +52,7 @@ export function defaultBatchConversionSettings(): BatchConversionSettings {
     destinationFormat: RecordFileFormat.KIF,
     fileNameConflictAction: FileNameConflictAction.NUMBER_SUFFIX,
     singleFileDestination: "",
+    enableUSIResign: true,
   };
 }
 

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -1194,7 +1194,12 @@ class Store {
       target === "after" ? this.recordManager.record.getSubtree() : this.recordManager.record;
     const str = record.getUSI({
       startpos: appSettings.enableUSIFileStartpos,
-      resign: appSettings.enableUSIFileResign,
+      resign: appSettings.enableUSIFileSpecialMoves,
+      repDraw: appSettings.enableUSIFileSpecialMoves,
+      draw: appSettings.enableUSIFileSpecialMoves,
+      timeout: appSettings.enableUSIFileSpecialMoves,
+      break: appSettings.enableUSIFileSpecialMoves,
+      win: appSettings.enableUSIFileSpecialMoves,
       allMoves: target !== "before",
     });
     navigator.clipboard.writeText(str);

--- a/src/renderer/store/settings.ts
+++ b/src/renderer/store/settings.ts
@@ -171,8 +171,12 @@ class AppSettingsStore {
   get enableUSIFileStartpos(): boolean {
     return this.merged.enableUSIFileStartpos;
   }
+  // Deprecated
   get enableUSIFileResign(): boolean {
     return this.merged.enableUSIFileResign;
+  }
+  get enableUSIFileSpecialMoves(): boolean {
+    return this.merged.enableUSIFileSpecialMoves;
   }
   get showPasteDialog(): boolean {
     return this.merged.showPasteDialog;

--- a/src/renderer/view/dialog/AppSettingsDialog.vue
+++ b/src/renderer/view/dialog/AppSettingsDialog.vue
@@ -476,14 +476,14 @@
           <div class="form-item-label-wide">{{ t.movesOfUSIOutput }}</div>
           <HorizontalSelector
             class="selector"
-            :value="String(update.enableUSIFileResign)"
+            :value="String(update.enableUSIFileSpecialMoves)"
             :items="[
-              { label: t.onlySFEN, value: 'false' },
-              { label: 'SFEN / resign', value: 'true' },
+              { label: t.minimal, value: 'false' },
+              { label: t.all, value: 'true' },
             ]"
             @update:value="
               (value: string) => {
-                update.enableUSIFileResign = value === 'true';
+                update.enableUSIFileSpecialMoves = value === 'true';
               }
             "
           />
@@ -813,7 +813,7 @@ const update = ref({
   recordFileNameTemplate: org.recordFileNameTemplate,
   useCSAV3: org.useCSAV3,
   enableUSIFileStartpos: org.enableUSIFileStartpos,
-  enableUSIFileResign: org.enableUSIFileResign,
+  enableUSIFileSpecialMoves: org.enableUSIFileSpecialMoves,
   showPasteDialog: org.showPasteDialog,
   liveDuplicatePositionDetection: org.liveDuplicatePositionDetection,
   bookOnTheFlyThresholdMB: org.bookOnTheFlyThresholdMB,

--- a/src/renderer/view/dialog/BatchConversionDialog.vue
+++ b/src/renderer/view/dialog/BatchConversionDialog.vue
@@ -138,6 +138,16 @@
           <Icon :icon="IconType.OPEN_FOLDER" />
         </button>
       </div>
+      <div
+        v-show="
+          settings.sourceType === SourceType.DIRECTORY &&
+          settings.destinationType === DestinationType.SINGLE_FILE
+        "
+        class="form-item row"
+      >
+        <div class="form-item-label-wide">resign</div>
+        <ToggleButton v-model:value="settings.enableUSIResign" class="toggle" />
+      </div>
     </div>
     <button class="wide" data-hotkey="Enter" @click="convert">
       {{ t.convert }}

--- a/src/tests/background/file/conversion.spec.ts
+++ b/src/tests/background/file/conversion.spec.ts
@@ -291,6 +291,7 @@ describe("conversion", () => {
       {
         appSettings: defaultAppSettings(),
         destination: "all.sfen",
+        enableUSIResign: false,
         expected: [
           "startpos moves 2g2f 3c3d 7g7f 5c5d 3i4h 8b5b 5i6h 5d5e 6h7h 3a4b 5g5f 4b3c 5f5e 3c4d 4h5g 4d5e P*5f 5e4d 4i5h",
           "startpos moves 2g2f 8c8d 2f2e 8d8e 6i7h 4a3b",
@@ -304,11 +305,9 @@ describe("conversion", () => {
         ],
       },
       {
-        appSettings: {
-          ...defaultAppSettings(),
-          enableUSIFileResign: true,
-        },
+        appSettings: defaultAppSettings(),
         destination: "all-noStartpos-resign.sfen",
+        enableUSIResign: true,
         expected: [
           "startpos moves 2g2f 3c3d 7g7f 5c5d 3i4h 8b5b 5i6h 5d5e 6h7h 3a4b 5g5f 4b3c 5f5e 3c4d 4h5g 4d5e P*5f 5e4d 4i5h",
           "startpos moves 2g2f 8c8d 2f2e 8d8e 6i7h 4a3b 3i3h 7a7b 2e2d 2c2d 2h2d P*2c 2d2f 6c6d 3g3f 3c3d 3h3g 5a4b 3g4f 2b4d 3f3e 3d3e 5i6i",
@@ -327,6 +326,7 @@ describe("conversion", () => {
           enableUSIFileStartpos: false,
         },
         destination: "all-noStartpos-resign.sfen",
+        enableUSIResign: false,
         expected: [
           "sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 2g2f 3c3d 7g7f 5c5d 3i4h 8b5b 5i6h 5d5e 6h7h 3a4b 5g5f 4b3c 5f5e 3c4d 4h5g 4d5e P*5f 5e4d 4i5h",
           "sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 2g2f 8c8d 2f2e 8d8e 6i7h 4a3b",
@@ -357,6 +357,7 @@ describe("conversion", () => {
         subdirectories: true,
         destinationType: DestinationType.SINGLE_FILE,
         singleFileDestination: destinationFullPath,
+        enableUSIResign: testCase.enableUSIResign,
       });
       expect(result).toStrictEqual({
         successTotal: 8,


### PR DESCRIPTION
# 説明 / Description

#1275

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated
  - [x] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "resign" option to batch conversion controls and a USI output choice shown as "Minimal" or "All" in app settings.

* **Chores**
  * Updated tsshogi dependency to v2.3.1.
  * Added localization entries for the new "Minimal" label (en, ja, vi, zh_tw).

* **Tests**
  * Adjusted conversion tests to cover the new resign/USI options and behaviors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->