### PR TITLE
一部のエンジンオプションを先頭に表示

### DIFF
--- a/src/renderer/view/dialog/USIEngineOptionsDialog.vue
+++ b/src/renderer/view/dialog/USIEngineOptionsDialog.vue
@@ -336,6 +336,20 @@ const optionVisibility = computed(() =>
 const machineSpec = ref<MachineSpec>({ cpuCores: 0, memory: 0 });
 const metadata = ref<USIEngineMetadata>({ isShellScript: false });
 
+function optionOrder(option: USIEngineOption): number {
+  switch (option.name) {
+    case Threads:
+    case NumberOfThreads:
+      return -100;
+    case USIHash:
+      return -99;
+    case FVScale:
+      return -98;
+    default:
+      return option.order;
+  }
+}
+
 busyState.retain();
 onMounted(async () => {
   try {
@@ -344,7 +358,7 @@ onMounted(async () => {
     metadata.value = await api.getUSIEngineMetadata(props.latest.path);
     mergeUSIEngine(engine.value, props.latest);
     options.value = Object.values(engine.value.options)
-      .sort((a, b): number => (a.order < b.order ? -1 : 1))
+      .sort((a, b): number => (optionOrder(a) < optionOrder(b) ? -1 : 1))
       .map((option) => ({
         displayName: appSettings.translateEngineOptionName ? usiOptionNameMap[option.name] : "",
         ...option,


### PR DESCRIPTION
# 説明 / Description

多くの人が触る NumberOfThreads(Threads), USI_Hash, FV_SCALE を先頭に表示するように並び替える。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the ordering of USI engine options in the dialog to prioritize key settings. Threads, Number of Threads, USI Hash, and FV Scale now appear first for improved accessibility, while other options maintain their relative order.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->