### PR TITLE
Check platform when building portable app

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ npm run serve
 # Electron App (Installer)
 npm run electron:build
 
-# Electron App (Portable)
+# Electron App (Windows Portable App)
 npm run electron:portable
 
 # Web App

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -7,6 +7,9 @@ const target = process.argv[2];
 
 switch (target) {
   case "portable":
+    if (process.platform !== "win32") {
+      throw new Error("Portable build is only supported on Windows.");
+    }
     config.win.target = "portable";
     break;
 }


### PR DESCRIPTION
# 説明 / Description

portable 版を Windows 以外でビルドしようとしても無効なので、エラーメッセージを出すようにする。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to clarify that portable app builds are Windows-exclusive.
* **Bug Fixes**
  * Added platform validation to prevent portable app builds on non-Windows platforms, ensuring builds fail gracefully with an error message on unsupported systems.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->