### PR TITLE
対局機能でAobaNNUEを使用できない問題の修正

### DIFF
--- a/src/common/settings/usi.ts
+++ b/src/common/settings/usi.ts
@@ -263,10 +263,18 @@ function isValidOptionValue(option: USIEngineOption): boolean {
       if (typeof option.value !== "number") {
         return false;
       }
-      if (option.min !== undefined && option.value < option.min) {
+      if (
+        option.min !== undefined &&
+        option.value < option.min &&
+        option.value !== option.default
+      ) {
         return false;
       }
-      if (option.max !== undefined && option.value > option.max) {
+      if (
+        option.max !== undefined &&
+        option.value > option.max &&
+        option.value !== option.default
+      ) {
         return false;
       }
       break;

--- a/src/tests/common/settings/usi.spec.ts
+++ b/src/tests/common/settings/usi.spec.ts
@@ -490,6 +490,25 @@ describe("settings/usi", () => {
       type: "button",
       order: 7,
     };
+    // AobaNNUE において default が min 未満の事例があったため default と等しいものは範囲外でも許容
+    const validSpinOption: USIEngineOption = {
+      name: "MySpin",
+      type: "spin",
+      order: 8,
+      default: 0,
+      min: 100,
+      max: 200,
+      value: 0,
+    };
+    const validSpinOption2: USIEngineOption = {
+      name: "MySpin2",
+      type: "spin",
+      order: 9,
+      default: 300,
+      min: 100,
+      max: 200,
+      value: 300,
+    };
 
     it("ok", () => {
       expect(
@@ -507,6 +526,8 @@ describe("settings/usi", () => {
             MyCombo2: validComboOption2,
             MyFilename: validFilenameOption,
             MyButton: validButtonOption,
+            MySpin: validSpinOption,
+            MySpin2: validSpinOption2,
           },
           enableEarlyPonder: false,
         }),
@@ -529,6 +550,8 @@ describe("settings/usi", () => {
             MyCombo2: validComboOption2,
             MyFilename: validFilenameOption,
             MyButton: validButtonOption,
+            MySpin: validSpinOption,
+            MySpin2: validSpinOption2,
           },
           enableEarlyPonder: false,
         }),
@@ -557,6 +580,8 @@ describe("settings/usi", () => {
             MyCombo2: validComboOption2,
             MyFilename: validFilenameOption,
             MyButton: validButtonOption,
+            MySpin: validSpinOption,
+            MySpin2: validSpinOption2,
           },
           enableEarlyPonder: false,
         } as unknown as USIEngine),
@@ -586,6 +611,8 @@ describe("settings/usi", () => {
             MyCombo2: validComboOption2,
             MyFilename: validFilenameOption,
             MyButton: validButtonOption,
+            MySpin: validSpinOption,
+            MySpin2: validSpinOption2,
           },
           enableEarlyPonder: false,
         } as unknown as USIEngine),
@@ -614,6 +641,8 @@ describe("settings/usi", () => {
             MyCombo2: validComboOption2,
             MyFilename: validFilenameOption,
             MyButton: validButtonOption,
+            MySpin: validSpinOption,
+            MySpin2: validSpinOption2,
           },
           enableEarlyPonder: false,
         } as unknown as USIEngine),


### PR DESCRIPTION
# 説明 / Description

[AobaNNUE v1](https://github.com/yssaya/AobaNNUE/releases/tag/v1) のオプション `ConstantThinkingTime` の初期値が min より小さいことを ShogiHome が異常と判定して対局を開始できない。
設定値が初期値と等しい場合は範囲外でも許可する回避策を適用する。

<img width="807" height="536" alt="スクリーンショット 2026-01-03 021806" src="https://github.com/user-attachments/assets/5099d377-da71-4e25-bbd5-6c0f33baa68b" />

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed validation behavior for configuration options with defined bounds. The system now correctly permits default values that fall outside minimum or maximum ranges, while maintaining strict validation for other values. This resolves issues where valid default configurations were incorrectly rejected.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->