### PR TITLE
Add windows portable build to github releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,16 @@ jobs:
         include:
           - os: windows
             os_short: win
+            variant: installer
+          - os: windows
+            os_short: win
+            variant: portable
           - os: macos
             os_short: mac
+            variant: installer
           - os: ubuntu
             os_short: linux
+            variant: installer
     runs-on: ${{ matrix.os }}-latest
     steps:
       - run: git config --global core.autocrlf false
@@ -31,10 +37,13 @@ jobs:
       - run: npm version
       - run: npm ci --no-audit --no-fund --prefer-online
       - run: npm run electron:build
-      - run: node scripts/archive.mjs ${{ matrix.os_short }} ${{ github.ref_name }}
+        if: matrix.variant != 'portable'
+      - run: npm run electron:portable
+        if: matrix.variant == 'portable'
+      - run: node scripts/archive.mjs ${{ matrix.os_short }} ${{ github.ref_name }} ${{ matrix.variant }}
       - uses: actions/upload-artifact@v6
         with:
-          name: ${{ matrix.os}}-release
+          name: ${{ matrix.os }}${{ matrix.variant == 'portable' && '-portable' || '' }}-release
           path: dist/release-*.zip
   release:
     needs: build

--- a/scripts/archive.mjs
+++ b/scripts/archive.mjs
@@ -4,7 +4,11 @@ import fs from "node:fs";
 
 const platform = process.argv[2];
 const version = process.argv[3];
-const outputPath = `dist/release-${version}-${platform}.zip`;
+const variant = process.argv[4] || "installer";
+const outputPath =
+  variant === "portable"
+    ? `dist/release-${version}-portable.zip`
+    : `dist/release-${version}-${platform}.zip`;
 
 const packageJson = JSON.parse(fs.readFileSync("./package.json"));
 if (`v${packageJson.version}` !== version) {


### PR DESCRIPTION
# 説明 / Description

Windows のポータブル版をリリースに加える。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow to support per-OS release variants (installer and portable versions).
  * Improved release artifact naming and organization to differentiate between variant types.
  * Optimized build process to conditionally execute steps based on the selected release variant.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->