### PR TITLE
Fix default value of auto-save for portable app

### DIFF
--- a/src/background/settings.ts
+++ b/src/background/settings.ts
@@ -31,7 +31,7 @@ import {
   normalizeSecureCSAGameSettingsHistory,
 } from "@/common/settings/csa.js";
 import { DecryptString, EncryptString, isEncryptionAvailable } from "./helpers/encrypt.js";
-import { getPortableExeDir } from "./proc/env.js";
+import { getPortableExeDir, isPortable } from "./proc/env.js";
 import {
   MateSearchSettings as MateSearchSettings,
   defaultMateSearchSettings,
@@ -178,7 +178,7 @@ export async function saveGameSettings(settings: GameSettings): Promise<void> {
 export async function loadGameSettings(): Promise<GameSettings> {
   const opts = {
     // v1.26.0 で autoSaveDirectory がアプリ設定から移動したので値を引き継ぐ。
-    autoSaveDirectory: loadAppSettingsOnce().autoSaveDirectory || docDir,
+    autoSaveDirectory: isPortable() ? undefined : loadAppSettingsOnce().autoSaveDirectory || docDir,
   };
   if (!(await exists(gameSettingsPath))) {
     return defaultGameSettings(opts);
@@ -206,7 +206,7 @@ export async function saveCSAGameSettingsHistory(settings: CSAGameSettingsHistor
 export async function loadCSAGameSettingsHistory(): Promise<CSAGameSettingsHistory> {
   const opts = {
     // v1.26.0 で autoSaveDirectory がアプリ設定から移動したので値を引き継ぐ。
-    autoSaveDirectory: loadAppSettingsOnce().autoSaveDirectory || docDir,
+    autoSaveDirectory: isPortable() ? undefined : loadAppSettingsOnce().autoSaveDirectory || docDir,
   };
   if (!(await exists(csaGameSettingsHistoryPath))) {
     return defaultCSAGameSettingsHistory(opts);


### PR DESCRIPTION
# 説明 / Description

古い自動保存設定がアプリ設定に残っているとポータブル版がそれを初期値に引き継いでしまう問題を修正する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved auto-save directory handling for portable installations. When running in portable mode, auto-save settings now reset appropriately instead of inheriting from standard application settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->