### PR TITLE
Normalize CONTRIBUTING link labels and URLs in README and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/不具合報告---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/不具合報告---bug-report.md
@@ -9,7 +9,7 @@ assignees: sunfish-shogi
 
 ## Checklist
 
-- [ ] understand [プロジェクトへの関わり方について](../../CONTRIBUTING.md)
+- [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/shogihome/blob/main/CONTRIBUTING.md)
 - [ ] do not remove following sections
 
 ## 説明 / Description

--- a/.github/ISSUE_TEMPLATE/提案---suggestion.md
+++ b/.github/ISSUE_TEMPLATE/提案---suggestion.md
@@ -9,7 +9,7 @@ assignees: sunfish-shogi
 
 ## Checklist
 
-- [ ] understand [プロジェクトへの関わり方について](../../CONTRIBUTING.md)
+- [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/shogihome/blob/main/CONTRIBUTING.md)
 - [ ] do not remove following sections
 
 ## 説明 /  Description

--- a/.github/ISSUE_TEMPLATE/質問---question.md
+++ b/.github/ISSUE_TEMPLATE/質問---question.md
@@ -9,6 +9,6 @@ assignees: sunfish-shogi
 
 ## Checklist
 
-- [ ] understand [プロジェクトへの関わり方について](../../CONTRIBUTING.md)
+- [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/shogihome/blob/main/CONTRIBUTING.md)
 
 ## 質問 / Question

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@
   - [ ] changes of `/docs/webapp` not included (except release branch)
   - [ ] `console.log` not included (except script file)
 - MUST for Outside Contributor
-  - [ ] understand [プロジェクトへの関わり方について](../CONTRIBUTING.md)
+  - [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/shogihome/blob/main/CONTRIBUTING.md)
 - RECOMMENDED (it depends on what you change)
   - [ ] unit test added/updated
   - [ ] i18n

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ USI や CSA プロトコルの通信ログの出力はデフォルトで無効�
 
 ## 不具合報告及びその他の開発協力
 
-[プロジェクトへの関わり方について](CONTRIBUTING.md) を必ずお読みください。
+[CONTRIBUTING.md](CONTRIBUTING.md) を必ずお読みください。
 
 GitHub のアカウントをお持ちの方は Issue/PullRequest を活用してください。
 大きな変更はいきなり着手せず Issue を作成してください。


### PR DESCRIPTION
### Motivation
- Make the CONTRIBUTING link label consistent across docs and templates.
- Ensure templates use a canonical, unambiguous full GitHub URL to the `CONTRIBUTING.md` file.
- Preserve the README's relative link target as requested so local navigation remains unchanged.
- Fix remaining occurrences where the Japanese label `プロジェクトへの関わり方について` was left in place.

### Description
- Replaced the Japanese link label with `CONTRIBUTING.md` in templates and the README.
- Updated templates in ` .github/ISSUE_TEMPLATE/*` and `.github/PULL_REQUEST_TEMPLATE.md` to point to `https://github.com/sunfish-shogi/shogihome/blob/main/CONTRIBUTING.md`.
- Restored the README link to the relative `CONTRIBUTING.md` path while using the label `CONTRIBUTING.md` in `README.md`.
- Modified files: `README.md`, `.github/ISSUE_TEMPLATE/提案---suggestion.md`, `.github/ISSUE_TEMPLATE/質問---question.md`, `.github/ISSUE_TEMPLATE/不具合報告---bug-report.md`, and `.github/PULL_REQUEST_TEMPLATE.md`.

### Testing
- No automated tests or CI jobs were run for these documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a7cf2c4f883218097317dad8763a9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guideline links across issue and pull request templates to use absolute GitHub URLs for improved accessibility.
  * Enhanced README with clearer contribution process guidance, template usage instructions, and alternative contact options for non-GitHub users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->