### PR TITLE
エンジンの代わりに定跡を検索して着手する機能

### DIFF
--- a/src/background/book/index.ts
+++ b/src/background/book/index.ts
@@ -214,7 +214,7 @@ export async function openBook(
   const size = stat.size;
   if (
     options?.forceOnTheFly ||
-    (options?.onTheFlyThresholdMB && size > options.onTheFlyThresholdMB * 1024 * 1024)
+    (options?.onTheFlyThresholdMB !== undefined && size > options.onTheFlyThresholdMB * 1024 * 1024)
   ) {
     await openBookOnTheFly(session, path, size);
     return "on-the-fly";

--- a/src/background/book/index.ts
+++ b/src/background/book/index.ts
@@ -131,7 +131,7 @@ function getBook(session: number): BookHandle {
 
 export function isBookUnsaved(session: number): boolean {
   const book = getBook(session);
-  return book.type === "in-memory" && !book.saved;
+  return !book.saved;
 }
 
 export function getBookFormat(session: number): BookFormat {

--- a/src/background/book/index.ts
+++ b/src/background/book/index.ts
@@ -1,5 +1,10 @@
 import fs, { ReadStream } from "node:fs";
-import { BookImportSummary, BookLoadingMode, BookLoadingOptions, BookMove } from "@/common/book.js";
+import {
+  BookImportSummary,
+  BookLoadingOptions,
+  BookMove,
+  defaultBookSession,
+} from "@/common/book.js";
 import { getAppLogger } from "@/background/log.js";
 import {
   arrayMoveToCommonBookMove,
@@ -91,7 +96,7 @@ function retrieveEntry(book: BookHandle, sfen: string): BookEntry | undefined {
   }
 }
 
-function storeEntry(sfen: string, entry: BookEntry): void {
+function storeEntry(book: BookHandle, sfen: string, entry: BookEntry): void {
   switch (book.format) {
     case "yane2016":
       book.entries.set(sfen, entry);
@@ -112,13 +117,25 @@ function emptyBook(): BookHandle {
   };
 }
 
-let book: BookHandle = emptyBook();
+const bookFiles = new Map<number, BookHandle>();
+bookFiles.set(defaultBookSession, emptyBook());
+let nextBookSession = defaultBookSession + 1;
 
-export function isBookUnsaved(): boolean {
+function getBook(session: number): BookHandle {
+  const book = bookFiles.get(session);
+  if (!book) {
+    throw new Error("Book session not found: " + session);
+  }
+  return book;
+}
+
+export function isBookUnsaved(session: number): boolean {
+  const book = getBook(session);
   return book.type === "in-memory" && !book.saved;
 }
 
-export function getBookFormat(): BookFormat {
+export function getBookFormat(session: number): BookFormat {
+  const book = getBook(session);
   return book.format;
 }
 
@@ -126,7 +143,7 @@ function getFormatByPath(path: string): "yane2016" | "apery" {
   return path.endsWith(".db") ? "yane2016" : "apery";
 }
 
-async function openBookOnTheFly(path: string, size: number): Promise<void> {
+async function openBookOnTheFly(session: number, path: string, size: number): Promise<void> {
   getAppLogger().info("Loading book on-the-fly: path=%s size=%d", path, size);
   const format = getFormatByPath(path);
   const file = await fs.promises.open(path, "r");
@@ -143,14 +160,14 @@ async function openBookOnTheFly(path: string, size: number): Promise<void> {
   }
   const common = { path, file, size, saved: true };
   if (format === "yane2016") {
-    replaceBook({
+    replaceBook(session, {
       ...common,
       type: "on-the-fly",
       format: "yane2016",
       entries: new Map<string, BookEntry>(),
     });
   } else {
-    replaceBook({
+    replaceBook(session, {
       ...common,
       type: "on-the-fly",
       format: "apery",
@@ -159,7 +176,7 @@ async function openBookOnTheFly(path: string, size: number): Promise<void> {
   }
 }
 
-async function openBookInMemory(path: string, size: number): Promise<void> {
+async function openBookInMemory(session: number, path: string, size: number): Promise<void> {
   getAppLogger().info("Loading book in-memory: path=%s size=%d", path, size);
   let file: ReadStream | undefined;
   try {
@@ -174,7 +191,7 @@ async function openBookInMemory(path: string, size: number): Promise<void> {
         book = await loadAperyBook(file);
         break;
     }
-    replaceBook({
+    replaceBook(session, {
       type: "in-memory",
       saved: true,
       ...book,
@@ -185,9 +202,10 @@ async function openBookInMemory(path: string, size: number): Promise<void> {
 }
 
 export async function openBook(
+  session: number,
   path: string,
   options?: BookLoadingOptions,
-): Promise<BookLoadingMode> {
+): Promise<"in-memory" | "on-the-fly"> {
   const stat = await fs.promises.lstat(path);
   if (!stat.isFile()) {
     throw new Error("Not a file: " + path);
@@ -195,23 +213,38 @@ export async function openBook(
 
   const size = stat.size;
   if (
-    options?.onTheFlyThresholdMB !== undefined &&
-    size > options.onTheFlyThresholdMB * 1024 * 1024
+    options?.forceOnTheFly ||
+    (options?.onTheFlyThresholdMB && size > options.onTheFlyThresholdMB * 1024 * 1024)
   ) {
-    await openBookOnTheFly(path, size);
+    await openBookOnTheFly(session, path, size);
     return "on-the-fly";
   } else {
-    await openBookInMemory(path, size);
+    await openBookInMemory(session, path, size);
     return "in-memory";
   }
 }
 
-function replaceBook(newBook: BookHandle) {
-  clearBook();
-  book = newBook;
+export async function openBookAsNewSession(
+  path: string,
+  options?: BookLoadingOptions,
+): Promise<{ session: number; mode: "in-memory" | "on-the-fly" }> {
+  const session = nextBookSession++;
+  const mode = await openBook(session, path, options);
+  return { session, mode };
 }
 
-export async function saveBook(path: string) {
+export function closeBookSession(session: number): void {
+  clearBook(session);
+  bookFiles.delete(session);
+}
+
+function replaceBook(session: number, newBook: BookHandle) {
+  clearBook(session);
+  bookFiles.set(session, newBook);
+}
+
+export async function saveBook(session: number, path: string) {
+  const book = getBook(session);
   // on-the-fly の場合は上書きを禁止
   if (book.type === "on-the-fly" && (await exists(path))) {
     const inputRealPath = await fs.promises.realpath(book.path);
@@ -261,14 +294,19 @@ export async function saveBook(path: string) {
   }
 }
 
-export function clearBook(): void {
+export function clearBook(session: number): void {
+  const book = bookFiles.get(session);
+  if (!book) {
+    return;
+  }
   if (book.type === "on-the-fly") {
     book.file.close();
   }
-  book = emptyBook();
+  bookFiles.set(session, emptyBook());
 }
 
-export async function searchBookMoves(sfen: string): Promise<BookMove[]> {
+export async function searchBookMoves(session: number, sfen: string): Promise<BookMove[]> {
+  const book = getBook(session);
   const entry = await retrieveMergedEntry(book, sfen);
   return entry ? entry.moves.map(arrayMoveToCommonBookMove) : [];
 }
@@ -283,7 +321,8 @@ function updateBookEntry(entry: BookEntry, move: BookMove): void {
   entry.moves.push(commonBookMoveToArray(move));
 }
 
-export async function updateBookMove(sfen: string, move: BookMove) {
+export async function updateBookMove(session: number, sfen: string, move: BookMove) {
+  const book = getBook(session);
   const entry = await retrieveMergedEntry(book, sfen);
   if (book.format === "yane2016") {
     if (entry) {
@@ -322,16 +361,23 @@ export async function updateBookMove(sfen: string, move: BookMove) {
   book.saved = false;
 }
 
-export async function removeBookMove(sfen: string, usi: string) {
+export async function removeBookMove(session: number, sfen: string, usi: string) {
+  const book = getBook(session);
   const entry = await retrieveMergedEntry(book, sfen);
   if (!entry) {
     return;
   }
   entry.moves = entry.moves.filter((move) => move[IDX_USI] !== usi);
-  storeEntry(sfen, entry);
+  storeEntry(book, sfen, entry);
 }
 
-export async function updateBookMoveOrder(sfen: string, usi: string, order: number) {
+export async function updateBookMoveOrder(
+  session: number,
+  sfen: string,
+  usi: string,
+  order: number,
+) {
+  const book = getBook(session);
   const entry = await retrieveMergedEntry(book, sfen);
   if (!entry) {
     return;
@@ -342,10 +388,10 @@ export async function updateBookMoveOrder(sfen: string, usi: string, order: numb
   }
   entry.moves = entry.moves.filter((move) => move[IDX_USI] !== usi);
   entry.moves.splice(order, 0, move);
-  storeEntry(sfen, entry);
+  storeEntry(book, sfen, entry);
 }
 
-function updateBookMovePatch(sfen: string, move: BookMove) {
+function updateBookMovePatch(book: BookHandle, sfen: string, move: BookMove) {
   let entry = retrieveEntry(book, sfen);
   if (book.format === "yane2016") {
     if (entry) {
@@ -386,13 +432,13 @@ function updateBookMovePatch(sfen: string, move: BookMove) {
 }
 
 export async function importBookMoves(
+  session: number,
   settings: BookImportSettings,
   onProgress?: (progress: number) => void,
 ): Promise<BookImportSummary> {
   getAppLogger().info("Importing book moves: %s", JSON.stringify(settings));
 
-  // 非同期処理のために参照を複製する
-  const bookRef = book;
+  const book = getBook(session);
 
   const appSettings = await loadAppSettings();
 
@@ -441,7 +487,7 @@ export async function importBookMoves(
     }
 
     const usi = node.move.usi;
-    const entry = retrieveEntry(bookRef, sfen);
+    const entry = retrieveEntry(book, sfen);
     const bookMoves = entry?.moves || [];
     const moves = bookMoves.map(arrayMoveToCommonBookMove);
     const existing = moves.find((move) => move.usi === usi);
@@ -452,7 +498,7 @@ export async function importBookMoves(
     }
     const bookMove = existing || { usi, comment: "" };
     bookMove.count = (bookMove.count || 0) + 1;
-    updateBookMovePatch(sfen, bookMove);
+    updateBookMovePatch(book, sfen, bookMove);
   }
 
   for (const path of paths) {
@@ -552,7 +598,7 @@ export async function importBookMoves(
     successFileCount++;
   }
 
-  if (bookRef.type === "in-memory") {
+  if (book.type === "in-memory") {
     return {
       successFileCount,
       errorFileCount,

--- a/src/background/book/index.ts
+++ b/src/background/book/index.ts
@@ -234,6 +234,9 @@ export async function openBookAsNewSession(
 }
 
 export function closeBookSession(session: number): void {
+  if (session === defaultBookSession) {
+    throw new Error("Cannot close default book session");
+  }
   clearBook(session);
   bookFiles.delete(session);
 }

--- a/src/command/common/preload.ts
+++ b/src/command/common/preload.ts
@@ -175,6 +175,12 @@ const bridge: Bridge = {
   async openBook(): Promise<void> {
     throw new Error("This feature is not available on command line tool");
   },
+  async openBookAsNewSession(): Promise<number> {
+    throw new Error("This feature is not available on command line tool");
+  },
+  async closeBookSession(): Promise<void> {
+    throw new Error("This feature is not available on command line tool");
+  },
   async saveBook(): Promise<void> {
     throw new Error("This feature is not available on command line tool");
   },

--- a/src/common/book.ts
+++ b/src/common/book.ts
@@ -1,5 +1,3 @@
-export type BookLoadingMode = "in-memory" | "on-the-fly";
-
 export type BookMove = {
   usi: string; // 定跡手
   usi2?: string; // 相手の応手
@@ -11,6 +9,7 @@ export type BookMove = {
 
 export type BookLoadingOptions = {
   onTheFlyThresholdMB?: number; // On-the-fly に切り替える閾値(MebiBytes)
+  forceOnTheFly?: boolean; // 強制的に On-the-fly モードにする
 };
 
 export type BookImportSummary = {
@@ -24,3 +23,5 @@ export type BookImportSummary = {
 export type BookMoveEx = BookMove & {
   repetition?: number; // 千日手
 };
+
+export const defaultBookSession = 1;

--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -395,6 +395,7 @@ export const en: Texts = {
   openDirectory: "Open Directory",
   replaceEnginePath: "Replace Engine Path",
   displayName: "Display Name",
+  frontendBook: "Frontend Book",
   showAllOptions: "Show All Options",
   invoke: "Invoke",
   resetToEngineDefaultValues: "Reset to default values",

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -395,6 +395,7 @@ export const ja: Texts = {
   openDirectory: "フォルダを開く",
   replaceEnginePath: "エンジン再選択",
   displayName: "表示名",
+  frontendBook: "定跡 (GUI拡張)",
   showAllOptions: "全てのオプションを表示",
   invoke: "実行",
   resetToEngineDefaultValues: "エンジンの既定値に戻す",

--- a/src/common/i18n/locales/vi.ts
+++ b/src/common/i18n/locales/vi.ts
@@ -395,6 +395,7 @@ export const vi: Texts = {
   openDirectory: "Mở đường dẫn",
   replaceEnginePath: "Chọn lại đường dẫn phần mềm",
   displayName: "Tên hiển thị",
+  frontendBook: "定跡 (GUI拡張)", // TODO: Translate
   showAllOptions: "全てのオプションを表示", // TODO: Translate
   invoke: "Thực hiện",
   resetToEngineDefaultValues: "Đặt lại về giá trị ban đầu",

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -392,6 +392,7 @@ export const zh_tw: Texts = {
   openDirectory: "開啟資料夾",
   replaceEnginePath: "重新選擇引擎",
   displayName: "表示名稱",
+  frontendBook: "定跡 (GUI拡張)", // TODO: Translate
   showAllOptions: "全てのオプションを表示", // TODO: Translate
   invoke: "執行",
   resetToEngineDefaultValues: "回復至引擎預設設定",

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -390,6 +390,7 @@ export type Texts = {
   openDirectory: string;
   replaceEnginePath: string;
   displayName: string;
+  frontendBook: string;
   showAllOptions: string;
   invoke: string;
   resetToEngineDefaultValues: string;

--- a/src/common/ipc/channel.ts
+++ b/src/common/ipc/channel.ts
@@ -41,6 +41,8 @@ export enum Background {
   SHOW_SAVE_BOOK_DIALOG = "showSaveBookDialog",
   CLEAR_BOOK = "clearBook",
   OPEN_BOOK = "openBook",
+  OPEN_BOOK_AS_NEW_SESSION = "openBookAsNewSession",
+  CLOSE_BOOK_SESSION = "closeBookSession",
   SAVE_BOOK = "saveBook",
   SEARCH_BOOK_MOVES = "searchBookMoves",
   UPDATE_BOOK_MOVE = "updateBookMove",

--- a/src/common/settings/usi.ts
+++ b/src/common/settings/usi.ts
@@ -126,6 +126,20 @@ export function getPredefinedUSIEngineTag(type: "game" | "research" | "mate"): s
   }
 }
 
+export type USIEngineExtraBookConfig = {
+  enabled: boolean;
+  filePath: string;
+  onTheFly: boolean;
+};
+
+export function emptyUSIEngineExtraBookConfig(): USIEngineExtraBookConfig {
+  return {
+    enabled: false,
+    filePath: "",
+    onTheFly: false,
+  };
+}
+
 export type USIEngine = {
   uri: string;
   name: string;
@@ -136,6 +150,7 @@ export type USIEngine = {
   labels?: USIEngineLabels; // deprecated: use tags instead
   tags?: string[];
   enableEarlyPonder: boolean;
+  extraBook?: USIEngineExtraBookConfig;
 };
 
 export function emptyUSIEngine(): USIEngine {
@@ -157,6 +172,11 @@ export function emptyUSIEngine(): USIEngine {
       getPredefinedUSIEngineTag("mate"),
     ],
     enableEarlyPonder: false,
+    extraBook: {
+      enabled: false,
+      filePath: "",
+      onTheFly: false,
+    },
   };
 }
 
@@ -223,6 +243,7 @@ export function mergeUSIEngine(engine: USIEngine, local: USIEngine): void {
   engine.labels = local.labels;
   engine.tags = local.tags || labelsToTags(local.labels || {});
   engine.enableEarlyPonder = local.enableEarlyPonder;
+  engine.extraBook = local.extraBook;
 }
 
 export function validateUSIEngine(engine: USIEngine): Error | undefined {
@@ -538,6 +559,7 @@ export type USIEngineForCLI = {
   path: string;
   options: { [name: string]: USIEngineOptionForCLI };
   enableEarlyPonder: boolean;
+  extraBook?: USIEngineExtraBookConfig;
 };
 
 export function exportUSIEnginesForCLI(engine: USIEngine): USIEngineForCLI {
@@ -567,6 +589,7 @@ export function exportUSIEnginesForCLI(engine: USIEngine): USIEngineForCLI {
     path: engine.path,
     options: options,
     enableEarlyPonder: engine.enableEarlyPonder,
+    extraBook: engine.extraBook,
   };
 }
 
@@ -603,6 +626,7 @@ export function importUSIEnginesForCLI(engine: USIEngineForCLI, uri?: string): U
     path: engine.path,
     options,
     enableEarlyPonder: engine.enableEarlyPonder,
+    extraBook: engine.extraBook,
     labels: {},
   };
 }
@@ -611,6 +635,7 @@ export type USIEngineOptionsClipboardData = {
   schema: "es://usi-engine-options-clipboard-data";
   options: { [name: string]: USIEngineOption };
   enableEarlyPonder: boolean;
+  extraBook?: USIEngineExtraBookConfig;
 };
 
 export async function compressUSIEngineOptionsClipboardData(

--- a/src/renderer/ipc/api.ts
+++ b/src/renderer/ipc/api.ts
@@ -73,15 +73,17 @@ export interface API {
 
   // Book
   showOpenBookDialog(): Promise<string>;
-  showSaveBookDialog(): Promise<string>;
-  openBook(path: string, options: BookLoadingOptions): Promise<void>;
-  saveBook(path: string): Promise<void>;
-  clearBook(): Promise<void>;
-  searchBookMoves(sfen: string): Promise<BookMove[]>;
-  updateBookMove(sfen: string, move: BookMove): Promise<void>;
-  removeBookMove(sfen: string, usi: string): Promise<void>;
-  updateBookMoveOrder(sfen: string, usi: string, order: number): Promise<void>;
-  importBookMoves(settings: BookImportSettings): Promise<BookImportSummary>;
+  showSaveBookDialog(session: number): Promise<string>;
+  openBook(session: number, path: string, options: BookLoadingOptions): Promise<void>;
+  openBookAsNewSession(path: string, options: BookLoadingOptions): Promise<number>;
+  closeBookSession(session: number): Promise<void>;
+  saveBook(session: number, path: string): Promise<void>;
+  clearBook(session: number): Promise<void>;
+  searchBookMoves(session: number, sfen: string): Promise<BookMove[]>;
+  updateBookMove(session: number, sfen: string, move: BookMove): Promise<void>;
+  removeBookMove(session: number, sfen: string, usi: string): Promise<void>;
+  updateBookMoveOrder(session: number, sfen: string, usi: string, order: number): Promise<void>;
+  importBookMoves(session: number, settings: BookImportSettings): Promise<BookImportSummary>;
 
   // USI
   showSelectUSIEngineDialog(): Promise<string>;
@@ -233,17 +235,20 @@ const api: API = {
   },
 
   // Book
-  openBook(path: string, options: BookLoadingOptions): Promise<void> {
-    return bridge.openBook(path, JSON.stringify(options));
+  openBook(session: number, path: string, options: BookLoadingOptions): Promise<void> {
+    return bridge.openBook(session, path, JSON.stringify(options));
   },
-  async searchBookMoves(sfen: string): Promise<BookMove[]> {
-    return JSON.parse(await bridge.searchBookMoves(sfen));
+  async openBookAsNewSession(path: string, options: BookLoadingOptions): Promise<number> {
+    return await bridge.openBookAsNewSession(path, JSON.stringify(options));
   },
-  updateBookMove(sfen: string, move: BookMove): Promise<void> {
-    return bridge.updateBookMove(sfen, JSON.stringify(move));
+  async searchBookMoves(session: number, sfen: string): Promise<BookMove[]> {
+    return JSON.parse(await bridge.searchBookMoves(session, sfen));
   },
-  async importBookMoves(settings: BookImportSettings): Promise<BookImportSummary> {
-    return JSON.parse(await bridge.importBookMoves(JSON.stringify(settings)));
+  updateBookMove(session: number, sfen: string, move: BookMove): Promise<void> {
+    return bridge.updateBookMove(session, sfen, JSON.stringify(move));
+  },
+  async importBookMoves(session: number, settings: BookImportSettings): Promise<BookImportSummary> {
+    return JSON.parse(await bridge.importBookMoves(session, JSON.stringify(settings)));
   },
 
   // USI

--- a/src/renderer/ipc/bridge.ts
+++ b/src/renderer/ipc/bridge.ts
@@ -57,15 +57,17 @@ export interface Bridge {
 
   // Book
   showOpenBookDialog(): Promise<string>;
-  showSaveBookDialog(): Promise<string>;
-  openBook(path: string, json: string): Promise<void>;
-  saveBook(path: string): Promise<void>;
-  clearBook(): Promise<void>;
-  searchBookMoves(sfen: string): Promise<string>;
-  updateBookMove(sfen: string, move: string): Promise<void>;
-  removeBookMove(sfen: string, usi: string): Promise<void>;
-  updateBookMoveOrder(sfen: string, usi: string, order: number): Promise<void>;
-  importBookMoves(json: string): Promise<string>;
+  showSaveBookDialog(session: number): Promise<string>;
+  openBook(session: number, path: string, json: string): Promise<void>;
+  openBookAsNewSession(path: string, json: string): Promise<number>;
+  closeBookSession(session: number): Promise<void>;
+  saveBook(session: number, path: string): Promise<void>;
+  clearBook(session: number): Promise<void>;
+  searchBookMoves(session: number, sfen: string): Promise<string>;
+  updateBookMove(session: number, sfen: string, move: string): Promise<void>;
+  removeBookMove(session: number, sfen: string, usi: string): Promise<void>;
+  updateBookMoveOrder(session: number, sfen: string, usi: string, order: number): Promise<void>;
+  importBookMoves(session: number, json: string): Promise<string>;
 
   // USI
   showSelectUSIEngineDialog(): Promise<string>;

--- a/src/renderer/ipc/preload.ts
+++ b/src/renderer/ipc/preload.ts
@@ -150,32 +150,43 @@ const api: Bridge = {
   async showOpenBookDialog(): Promise<string> {
     return await ipcRenderer.invoke(Background.SHOW_OPEN_BOOK_DIALOG);
   },
-  async showSaveBookDialog(): Promise<string> {
-    return await ipcRenderer.invoke(Background.SHOW_SAVE_BOOK_DIALOG);
+  async showSaveBookDialog(session: number): Promise<string> {
+    return await ipcRenderer.invoke(Background.SHOW_SAVE_BOOK_DIALOG, session);
   },
-  async clearBook(): Promise<void> {
-    return await ipcRenderer.invoke(Background.CLEAR_BOOK);
+  async clearBook(session: number): Promise<void> {
+    return await ipcRenderer.invoke(Background.CLEAR_BOOK, session);
   },
-  async openBook(path: string, json: string): Promise<void> {
-    await ipcRenderer.invoke(Background.OPEN_BOOK, path, json);
+  async openBook(session: number, path: string, json: string): Promise<void> {
+    await ipcRenderer.invoke(Background.OPEN_BOOK, session, path, json);
   },
-  async saveBook(path: string): Promise<void> {
-    return await ipcRenderer.invoke(Background.SAVE_BOOK, path);
+  async openBookAsNewSession(path: string, json: string): Promise<number> {
+    return await ipcRenderer.invoke(Background.OPEN_BOOK_AS_NEW_SESSION, path, json);
   },
-  async searchBookMoves(sfen: string): Promise<string> {
-    return await ipcRenderer.invoke(Background.SEARCH_BOOK_MOVES, sfen);
+  async closeBookSession(session: number): Promise<void> {
+    return await ipcRenderer.invoke(Background.CLOSE_BOOK_SESSION, session);
   },
-  async updateBookMove(sfen: string, json: string): Promise<void> {
-    return await ipcRenderer.invoke(Background.UPDATE_BOOK_MOVE, sfen, json);
+  async saveBook(session: number, path: string): Promise<void> {
+    return await ipcRenderer.invoke(Background.SAVE_BOOK, session, path);
   },
-  async removeBookMove(sfen: string, usi: string): Promise<void> {
-    return await ipcRenderer.invoke(Background.REMOVE_BOOK_MOVE, sfen, usi);
+  async searchBookMoves(session: number, sfen: string): Promise<string> {
+    return await ipcRenderer.invoke(Background.SEARCH_BOOK_MOVES, session, sfen);
   },
-  async updateBookMoveOrder(sfen: string, usi: string, order: number): Promise<void> {
-    return await ipcRenderer.invoke(Background.UPDATE_BOOK_MOVE_ORDER, sfen, usi, order);
+  async updateBookMove(session: number, sfen: string, json: string): Promise<void> {
+    return await ipcRenderer.invoke(Background.UPDATE_BOOK_MOVE, session, sfen, json);
   },
-  async importBookMoves(json: string): Promise<string> {
-    return await ipcRenderer.invoke(Background.IMPORT_BOOK_MOVES, json);
+  async removeBookMove(session: number, sfen: string, usi: string): Promise<void> {
+    return await ipcRenderer.invoke(Background.REMOVE_BOOK_MOVE, session, sfen, usi);
+  },
+  async updateBookMoveOrder(
+    session: number,
+    sfen: string,
+    usi: string,
+    order: number,
+  ): Promise<void> {
+    return await ipcRenderer.invoke(Background.UPDATE_BOOK_MOVE_ORDER, session, sfen, usi, order);
+  },
+  async importBookMoves(session: number, json: string): Promise<string> {
+    return await ipcRenderer.invoke(Background.IMPORT_BOOK_MOVES, session, json);
   },
 
   // USI

--- a/src/renderer/ipc/web.ts
+++ b/src/renderer/ipc/web.ts
@@ -262,6 +262,12 @@ export const webAPI: Bridge = {
   async openBook(): Promise<void> {
     throw new Error(t.thisFeatureNotAvailableOnWebApp);
   },
+  async openBookAsNewSession(): Promise<number> {
+    throw new Error("This feature is not available on command line tool");
+  },
+  async closeBookSession(): Promise<void> {
+    throw new Error("This feature is not available on command line tool");
+  },
   async saveBook(): Promise<void> {
     throw new Error(t.thisFeatureNotAvailableOnWebApp);
   },

--- a/src/renderer/ipc/web.ts
+++ b/src/renderer/ipc/web.ts
@@ -263,10 +263,10 @@ export const webAPI: Bridge = {
     throw new Error(t.thisFeatureNotAvailableOnWebApp);
   },
   async openBookAsNewSession(): Promise<number> {
-    throw new Error("This feature is not available on command line tool");
+    throw new Error(t.thisFeatureNotAvailableOnWebApp);
   },
   async closeBookSession(): Promise<void> {
-    throw new Error("This feature is not available on command line tool");
+    throw new Error(t.thisFeatureNotAvailableOnWebApp);
   },
   async saveBook(): Promise<void> {
     throw new Error(t.thisFeatureNotAvailableOnWebApp);

--- a/src/renderer/players/usi.ts
+++ b/src/renderer/players/usi.ts
@@ -12,6 +12,7 @@ import { Color, ImmutablePosition, Move, Position } from "tsshogi";
 import { Player, SearchInfo, SearchHandler, MateHandler } from "./player.js";
 import { GameResult } from "@/common/game/result.js";
 import { TimeStates } from "@/common/game/time.js";
+import { LogLevel } from "@/common/log.js";
 
 type onStartSearchHandler = (sessionID: number, position: ImmutablePosition) => void;
 
@@ -45,6 +46,7 @@ export class USIPlayer implements Player {
   private info?: SearchInfo;
   private usiInfoTimeout?: number;
   private customMultiPV?: number;
+  private bookSessionID?: number;
 
   constructor(
     private engine: USIEngine,
@@ -61,8 +63,20 @@ export class USIPlayer implements Player {
   }
 
   async launch(): Promise<void> {
-    this._sessionID = await api.usiLaunch(this.engine, this.timeoutSeconds);
-    usiPlayers[this.sessionID] = this;
+    try {
+      if (this.engine.extraBook?.enabled && this.engine.extraBook.filePath) {
+        this.bookSessionID = await api.openBookAsNewSession(this.engine.extraBook.filePath, {
+          forceOnTheFly: this.engine.extraBook.onTheFly,
+        });
+      }
+      this._sessionID = await api.usiLaunch(this.engine, this.timeoutSeconds);
+      usiPlayers[this.sessionID] = this;
+    } catch (e) {
+      if (this.bookSessionID) {
+        await api.closeBookSession(this.bookSessionID);
+      }
+      throw e;
+    }
   }
 
   isEngine(): boolean {
@@ -83,6 +97,9 @@ export class USIPlayer implements Player {
     this.searchHandler = handler;
     this.usi = usi;
     this.position = position.clone();
+    if (await this.searchBook()) {
+      return;
+    }
     if (this.ponderMove && this.ponder === this.usi) {
       api.usiPonderHit(this.sessionID, timeStates);
     } else {
@@ -152,8 +169,69 @@ export class USIPlayer implements Player {
     this.usi = usi;
     this.info = undefined;
     this.position = position.clone();
+    if (await this.searchBook()) {
+      return;
+    }
     await api.usiGoInfinite(this.sessionID, usi);
     onStartSearch(this.sessionID, this.position);
+  }
+
+  private async searchBook(): Promise<boolean> {
+    if (!this.bookSessionID || !this.position) {
+      return false;
+    }
+    try {
+      // 定跡を検索
+      const bookMoves = await api.searchBookMoves(this.bookSessionID, this.position.sfen);
+      if (bookMoves.length === 0) {
+        return false;
+      }
+      // Ponder 中の場合は停止
+      if (this.ponderMove) {
+        await api.usiStop(this.sessionID);
+        this.ponderMove = undefined;
+        this.ponder = undefined;
+      }
+      // 読み筋表示を初期化
+      onStartSearch(this.sessionID, this.position);
+      // 定跡に登録されている手の一覧を表示
+      if (onUpdateUSIInfo && this.usi) {
+        for (let i = 0; i < bookMoves.length; i++) {
+          const bookMove = bookMoves[i];
+          const move = this.position.createMoveByUSI(bookMove.usi);
+          if (move) {
+            const info: USIInfoCommand = {
+              multipv: i + 1,
+              depth: bookMove.depth,
+              scoreCP: bookMove.score,
+              nodes: bookMove.count,
+              currmove: bookMove.usi,
+              pv: bookMove.usi2 ? [bookMove.usi, bookMove.usi2] : [bookMove.usi],
+            };
+            onUpdateUSIInfo(this.sessionID, this.position, this.name, info);
+          }
+        }
+      }
+      // 最善手を返却
+      const searchHandler = this.searchHandler;
+      this.clearHandlers();
+      if (searchHandler) {
+        const bestMove = bookMoves[0];
+        const move = this.position.createMoveByUSI(bestMove.usi);
+        if (!move) {
+          api.log(
+            LogLevel.ERROR,
+            `Failed to search book moves: invalid move from book: ${bestMove.usi}`,
+          );
+          return false;
+        }
+        searchHandler.onMove(move);
+      }
+      return true;
+    } catch (e) {
+      api.log(LogLevel.ERROR, `Failed to search book moves: ${e}`);
+      return false;
+    }
   }
 
   async stop(): Promise<void> {
@@ -168,6 +246,9 @@ export class USIPlayer implements Player {
     this.clearHandlers();
     await api.usiQuit(this.sessionID);
     delete usiPlayers[this.sessionID];
+    if (this.bookSessionID) {
+      await api.closeBookSession(this.bookSessionID);
+    }
   }
 
   private clearHandlers(): void {

--- a/src/tests/common/settings/usi.spec.ts
+++ b/src/tests/common/settings/usi.spec.ts
@@ -354,7 +354,7 @@ describe("settings/usi", () => {
     expect(out.defaultName).toBe("Test Engine");
     expect(out.author).toBe("Author");
     expect(out.path).toBe("/foo/bar/baz");
-    expect(out.options).toStrictEqual({
+    expect(out.options).toEqual({
       foo: {
         name: "foo",
         type: "spin",
@@ -413,7 +413,7 @@ describe("settings/usi", () => {
       enableEarlyPonder: false,
     };
     mergeUSIEngine(lhs, rhs);
-    expect(lhs).toStrictEqual({
+    expect(lhs).toEqual({
       uri: "uri-b",
       name: "name-b",
       defaultName: "default-name-a",

--- a/src/tests/mock/usi.ts
+++ b/src/tests/mock/usi.ts
@@ -14,6 +14,11 @@ export const testUSIEngine: USIEngine = {
   },
   tags: ["対局"],
   enableEarlyPonder: false,
+  extraBook: {
+    enabled: false,
+    filePath: "",
+    onTheFly: false,
+  },
 };
 
 export const testUSIEngineWithPonder: USIEngine = {

--- a/src/tests/renderer/players/usi.spec.ts
+++ b/src/tests/renderer/players/usi.spec.ts
@@ -39,6 +39,7 @@ describe("usi", () => {
     mockAPI.usiGo.mockResolvedValueOnce();
     mockAPI.usiGoPonder.mockResolvedValueOnce();
     mockAPI.usiPonderHit.mockResolvedValueOnce();
+    mockAPI.usiQuit.mockResolvedValueOnce();
     const usi1 = "position startpos moves 7g7f 3c3d";
     const usi2 = "position startpos moves 7g7f 3c3d 2g2f";
     const usi3 = "position startpos moves 7g7f 3c3d 2g2f 8c8d";
@@ -46,86 +47,195 @@ describe("usi", () => {
     const record2 = Record.newByUSI(usi2) as Record;
     const record3 = Record.newByUSI(usi3) as Record;
     const player = new USIPlayer(testUSIEngineWithPonder, 10);
-    try {
-      await player.launch();
-      const searchHandler = {
-        onMove: vi.fn(),
-        onResign: vi.fn(),
-        onWin: vi.fn(),
-        onError: vi.fn(),
-      };
+    await player.launch();
+    expect(mockAPI.usiLaunch).toBeCalledTimes(1);
+    const searchHandler = {
+      onMove: vi.fn(),
+      onResign: vi.fn(),
+      onWin: vi.fn(),
+      onError: vi.fn(),
+    };
 
-      // search
-      await player.startSearch(record1.position, usi1, timeStates, searchHandler);
-      expect(mockAPI.usiGo).toBeCalledWith(100, usi1, timeStates);
-      onUSIInfo(100, usi1, {
-        depth: 32,
-        nodes: 12345678,
-        scoreCP: 138,
-        pv: ["2g2f", "8c8d", "2f2e"],
-      });
-      onUSIBestMove(100, usi1, "2g2f", "8c8d");
-      expect(searchHandler.onMove.mock.calls[0][0].usi).toBe("2g2f");
-      expect(searchHandler.onMove.mock.calls[0][1].depth).toBe(32);
-      expect(searchHandler.onMove.mock.calls[0][1].nodes).toBe(12345678);
-      expect(searchHandler.onMove.mock.calls[0][1].score).toBe(138);
-      expect(searchHandler.onMove.mock.calls[0][1].pv.map((m: Move) => m.usi)).toEqual([
-        "8c8d",
-        "2f2e",
-      ]);
+    // search
+    await player.startSearch(record1.position, usi1, timeStates, searchHandler);
+    expect(mockAPI.usiGo).toBeCalledWith(100, usi1, timeStates);
+    onUSIInfo(100, usi1, {
+      depth: 32,
+      nodes: 12345678,
+      scoreCP: 138,
+      pv: ["2g2f", "8c8d", "2f2e"],
+    });
+    onUSIBestMove(100, usi1, "2g2f", "8c8d");
+    expect(searchHandler.onMove.mock.calls[0][0].usi).toBe("2g2f");
+    expect(searchHandler.onMove.mock.calls[0][1].depth).toBe(32);
+    expect(searchHandler.onMove.mock.calls[0][1].nodes).toBe(12345678);
+    expect(searchHandler.onMove.mock.calls[0][1].score).toBe(138);
+    expect(searchHandler.onMove.mock.calls[0][1].pv.map((m: Move) => m.usi)).toEqual([
+      "8c8d",
+      "2f2e",
+    ]);
 
-      // ponder
-      await player.startPonder(record2.position, usi2, timeStates);
-      expect(mockAPI.usiGoPonder).toBeCalled();
-      onUSIInfo(100, usi3, {
-        pv: ["2f2e", "8d8e", "6i7h", "4a3b"],
-      });
+    // ponder
+    await player.startPonder(record2.position, usi2, timeStates);
+    expect(mockAPI.usiGoPonder).toBeCalled();
+    onUSIInfo(100, usi3, {
+      pv: ["2f2e", "8d8e", "6i7h", "4a3b"],
+    });
 
-      // startPonder を連続して呼び出すと無視される。
-      await player.startPonder(record2.position, usi2, timeStates);
-      expect(mockAPI.usiGoPonder).toBeCalledTimes(1);
+    // startPonder を連続して呼び出すと無視される。
+    await player.startPonder(record2.position, usi2, timeStates);
+    expect(mockAPI.usiGoPonder).toBeCalledTimes(1);
 
-      // search (ponderHit)
-      await player.startSearch(record3.position, usi3, timeStates, searchHandler);
-      expect(mockAPI.usiPonderHit).toBeCalledWith(100, timeStates);
-      onUSIBestMove(100, usi3, "2f2e");
-      expect(searchHandler.onMove.mock.calls[1][0].usi).toBe("2f2e");
-      expect(searchHandler.onMove.mock.calls[1][1].pv.map((m: Move) => m.usi)).toEqual([
-        "8d8e",
-        "6i7h",
-        "4a3b",
-      ]);
-    } finally {
-      await player.close();
-    }
+    // search (ponderHit)
+    await player.startSearch(record3.position, usi3, timeStates, searchHandler);
+    expect(mockAPI.usiPonderHit).toBeCalledWith(100, timeStates);
+    onUSIBestMove(100, usi3, "2f2e");
+    expect(searchHandler.onMove.mock.calls[1][0].usi).toBe("2f2e");
+    expect(searchHandler.onMove.mock.calls[1][1].pv.map((m: Move) => m.usi)).toEqual([
+      "8d8e",
+      "6i7h",
+      "4a3b",
+    ]);
+    await player.close();
+    expect(mockAPI.usiQuit).toBeCalledWith(100);
+  });
+
+  it("bookHit", async () => {
+    mockAPI.usiLaunch.mockResolvedValueOnce(100);
+    mockAPI.usiQuit.mockResolvedValueOnce();
+    mockAPI.openBookAsNewSession.mockResolvedValueOnce(123);
+    mockAPI.searchBookMoves.mockResolvedValueOnce([{ usi: "2g2f", comment: "" }]);
+    mockAPI.closeBookSession.mockResolvedValueOnce();
+    const usi = "position startpos moves 7g7f 3c3d";
+    const record = Record.newByUSI(usi) as Record;
+    const player = new USIPlayer(
+      {
+        ...testUSIEngine,
+        extraBook: { enabled: true, filePath: "/path/to/book", onTheFly: false },
+      },
+      10,
+    );
+    await player.launch();
+    expect(mockAPI.openBookAsNewSession).toBeCalledWith("/path/to/book", { forceOnTheFly: false });
+    expect(mockAPI.usiLaunch).toBeCalledTimes(1);
+    const searchHandler = {
+      onMove: vi.fn(),
+      onResign: vi.fn(),
+      onWin: vi.fn(),
+      onError: vi.fn(),
+    };
+    await player.startSearch(record.position, usi, timeStates, searchHandler);
+    expect(mockAPI.searchBookMoves).toBeCalledWith(123, record.position.sfen);
+    expect(searchHandler.onMove.mock.calls[0][0].usi).toBe("2g2f");
+    await player.close();
+    expect(mockAPI.usiQuit).toBeCalledWith(100);
+    expect(mockAPI.closeBookSession).toBeCalledTimes(1);
+  });
+
+  it("bookMiss", async () => {
+    mockAPI.usiLaunch.mockResolvedValueOnce(100);
+    mockAPI.usiGo.mockResolvedValueOnce();
+    mockAPI.usiQuit.mockResolvedValueOnce();
+    mockAPI.openBookAsNewSession.mockResolvedValueOnce(123);
+    mockAPI.searchBookMoves.mockResolvedValueOnce([]);
+    mockAPI.closeBookSession.mockResolvedValueOnce();
+    const usi = "position startpos moves 7g7f 3c3d";
+    const record = Record.newByUSI(usi) as Record;
+    const player = new USIPlayer(
+      {
+        ...testUSIEngine,
+        extraBook: { enabled: true, filePath: "/path/to/book", onTheFly: false },
+      },
+      10,
+    );
+    await player.launch();
+    expect(mockAPI.openBookAsNewSession).toBeCalledWith("/path/to/book", { forceOnTheFly: false });
+    expect(mockAPI.usiLaunch).toBeCalledTimes(1);
+    const searchHandler = {
+      onMove: vi.fn(),
+      onResign: vi.fn(),
+      onWin: vi.fn(),
+      onError: vi.fn(),
+    };
+    await player.startSearch(record.position, usi, timeStates, searchHandler);
+    expect(mockAPI.searchBookMoves).toBeCalledWith(123, record.position.sfen);
+    expect(mockAPI.usiGo).toBeCalledWith(100, usi, timeStates);
+    expect(searchHandler.onMove).not.toBeCalled();
+    await player.close();
+    expect(mockAPI.usiQuit).toBeCalledWith(100);
+    expect(mockAPI.closeBookSession).toBeCalledTimes(1);
+  });
+
+  it("bookHit/ponder", async () => {
+    mockAPI.usiLaunch.mockResolvedValueOnce(100);
+    mockAPI.usiGo.mockResolvedValueOnce();
+    mockAPI.usiGoPonder.mockResolvedValueOnce();
+    mockAPI.usiQuit.mockResolvedValueOnce();
+    mockAPI.openBookAsNewSession.mockResolvedValueOnce(123);
+    mockAPI.searchBookMoves.mockResolvedValueOnce([]);
+    mockAPI.searchBookMoves.mockResolvedValueOnce([{ usi: "2f2e", comment: "" }]);
+    mockAPI.closeBookSession.mockResolvedValueOnce();
+    const usi1 = "position startpos moves 7g7f 3c3d";
+    const usi2 = "position startpos moves 7g7f 3c3d 2g2f";
+    const usi3 = "position startpos moves 7g7f 3c3d 2g2f 8c8d";
+    const record1 = Record.newByUSI(usi1) as Record;
+    const record2 = Record.newByUSI(usi2) as Record;
+    const record3 = Record.newByUSI(usi3) as Record;
+    const player = new USIPlayer(
+      {
+        ...testUSIEngineWithPonder,
+        extraBook: { enabled: true, filePath: "/path/to/book", onTheFly: false },
+      },
+      10,
+    );
+    await player.launch();
+    expect(mockAPI.openBookAsNewSession).toBeCalledWith("/path/to/book", { forceOnTheFly: false });
+    expect(mockAPI.usiLaunch).toBeCalledTimes(1);
+    const searchHandler = {
+      onMove: vi.fn(),
+      onResign: vi.fn(),
+      onWin: vi.fn(),
+      onError: vi.fn(),
+    };
+    await player.startSearch(record1.position, usi1, timeStates, searchHandler);
+    expect(mockAPI.searchBookMoves).toBeCalledWith(123, record1.position.sfen);
+    expect(mockAPI.usiGo).toBeCalledWith(100, usi1, timeStates);
+    onUSIBestMove(100, usi1, "2g2f", "8c8d");
+    await player.startPonder(record2.position, usi2, timeStates);
+    expect(mockAPI.usiGoPonder).toBeCalled();
+    await player.startSearch(record3.position, usi3, timeStates, searchHandler);
+    expect(mockAPI.searchBookMoves).toBeCalledWith(123, record3.position.sfen);
+    expect(searchHandler.onMove.mock.calls[1][0].usi).toBe("2f2e");
+    await player.close();
+    expect(mockAPI.usiQuit).toBeCalledWith(100);
+    expect(mockAPI.closeBookSession).toBeCalledTimes(1);
   });
 
   it("illegalPonderMove", async () => {
     mockAPI.usiLaunch.mockResolvedValueOnce(100);
     mockAPI.usiGo.mockResolvedValueOnce();
     mockAPI.usiGoPonder.mockResolvedValueOnce();
+    mockAPI.usiQuit.mockResolvedValueOnce();
     const usi1 = "position startpos moves 7g7f 3c3d";
     const usi2 = "position startpos moves 7g7f 3c3d 2g2f";
     const record1 = Record.newByUSI(usi1) as Record;
     const record2 = Record.newByUSI(usi2) as Record;
     const player = new USIPlayer(testUSIEngineWithPonder, 10);
-    try {
-      await player.launch();
-      const searchHandler = {
-        onMove: vi.fn(),
-        onResign: vi.fn(),
-        onWin: vi.fn(),
-        onError: vi.fn(),
-      };
-      await player.startSearch(record1.position, usi1, timeStates, searchHandler);
-      expect(mockAPI.usiGo).toBeCalledWith(100, usi1, timeStates);
-      onUSIBestMove(100, usi1, "2g2f", "4a3a");
-      expect(searchHandler.onMove.mock.calls[0][0].usi).toBe("2g2f");
-      await player.startPonder(record2.position, usi2, timeStates);
-      expect(mockAPI.usiGoPonder).not.toBeCalled();
-    } finally {
-      await player.close();
-    }
+    await player.launch();
+    const searchHandler = {
+      onMove: vi.fn(),
+      onResign: vi.fn(),
+      onWin: vi.fn(),
+      onError: vi.fn(),
+    };
+    await player.startSearch(record1.position, usi1, timeStates, searchHandler);
+    expect(mockAPI.usiGo).toBeCalledWith(100, usi1, timeStates);
+    onUSIBestMove(100, usi1, "2g2f", "4a3a");
+    expect(searchHandler.onMove.mock.calls[0][0].usi).toBe("2g2f");
+    await player.startPonder(record2.position, usi2, timeStates);
+    expect(mockAPI.usiGoPonder).not.toBeCalled();
+    await player.close();
+    expect(mockAPI.usiQuit).toBeCalledWith(100);
   });
 
   it("checkmate", async () => {
@@ -134,29 +244,27 @@ describe("usi", () => {
     const usi = "position sfen 3sks3/9/4+P4/9/7+B1/9/9/9/9 b S2rb4gs4n4l17p 1";
     const record = Record.newByUSI(usi) as Record;
     const player = new USIPlayer(testUSIEngine, 10);
-    try {
-      await player.launch();
-      const handler = {
-        onCheckmate: vi.fn(),
-        onNotImplemented: vi.fn(),
-        onTimeout: vi.fn(),
-        onNoMate: vi.fn(),
-        onError: vi.fn(),
-      };
-      await player.startMateSearch(record.position, usi, 10, handler);
-      expect(mockAPI.usiGoMate).toBeCalledWith(100, usi, 10);
-      onUSICheckmate(100, usi, ["2e5b", "4a5b", "S*4b"]);
-      expect(handler.onCheckmate).toBeCalledTimes(1);
-      expect(handler.onCheckmate.mock.calls[0][0][0].usi).toBe("2e5b");
-      expect(handler.onCheckmate.mock.calls[0][0][1].usi).toBe("4a5b");
-      expect(handler.onCheckmate.mock.calls[0][0][2].usi).toBe("S*4b");
-      expect(handler.onNotImplemented).not.toBeCalled();
-      expect(handler.onTimeout).not.toBeCalled();
-      expect(handler.onNoMate).not.toBeCalled();
-      expect(handler.onError).not.toBeCalled();
-    } finally {
-      await player.close();
-    }
+    await player.launch();
+    const handler = {
+      onCheckmate: vi.fn(),
+      onNotImplemented: vi.fn(),
+      onTimeout: vi.fn(),
+      onNoMate: vi.fn(),
+      onError: vi.fn(),
+    };
+    await player.startMateSearch(record.position, usi, 10, handler);
+    expect(mockAPI.usiGoMate).toBeCalledWith(100, usi, 10);
+    onUSICheckmate(100, usi, ["2e5b", "4a5b", "S*4b"]);
+    expect(handler.onCheckmate).toBeCalledTimes(1);
+    expect(handler.onCheckmate.mock.calls[0][0][0].usi).toBe("2e5b");
+    expect(handler.onCheckmate.mock.calls[0][0][1].usi).toBe("4a5b");
+    expect(handler.onCheckmate.mock.calls[0][0][2].usi).toBe("S*4b");
+    expect(handler.onNotImplemented).not.toBeCalled();
+    expect(handler.onTimeout).not.toBeCalled();
+    expect(handler.onNoMate).not.toBeCalled();
+    expect(handler.onError).not.toBeCalled();
+    await player.close();
+    expect(mockAPI.usiQuit).toBeCalledWith(100);
   });
 
   it("checkmate/notImplemented", async () => {
@@ -165,26 +273,24 @@ describe("usi", () => {
     const usi = "position sfen 3sks3/9/4+P4/9/7+B1/9/9/9/9 b S2rb4gs4n4l17p 1";
     const record = Record.newByUSI(usi) as Record;
     const player = new USIPlayer(testUSIEngine, 10);
-    try {
-      await player.launch();
-      const handler = {
-        onCheckmate: vi.fn(),
-        onNotImplemented: vi.fn(),
-        onTimeout: vi.fn(),
-        onNoMate: vi.fn(),
-        onError: vi.fn(),
-      };
-      await player.startMateSearch(record.position, usi, undefined, handler);
-      expect(mockAPI.usiGoMate).toBeCalledWith(100, usi, undefined);
-      onUSICheckmateNotImplemented(100);
-      expect(handler.onCheckmate).not.toBeCalled();
-      expect(handler.onNotImplemented).toBeCalledTimes(1);
-      expect(handler.onTimeout).not.toBeCalled();
-      expect(handler.onNoMate).not.toBeCalled();
-      expect(handler.onError).not.toBeCalled();
-    } finally {
-      await player.close();
-    }
+    await player.launch();
+    const handler = {
+      onCheckmate: vi.fn(),
+      onNotImplemented: vi.fn(),
+      onTimeout: vi.fn(),
+      onNoMate: vi.fn(),
+      onError: vi.fn(),
+    };
+    await player.startMateSearch(record.position, usi, undefined, handler);
+    expect(mockAPI.usiGoMate).toBeCalledWith(100, usi, undefined);
+    onUSICheckmateNotImplemented(100);
+    expect(handler.onCheckmate).not.toBeCalled();
+    expect(handler.onNotImplemented).toBeCalledTimes(1);
+    expect(handler.onTimeout).not.toBeCalled();
+    expect(handler.onNoMate).not.toBeCalled();
+    expect(handler.onError).not.toBeCalled();
+    await player.close();
+    expect(mockAPI.usiQuit).toBeCalledWith(100);
   });
 
   it("checkmate/noMate", async () => {
@@ -193,26 +299,24 @@ describe("usi", () => {
     const usi = "position sfen 3sks3/9/4+P4/9/7+B1/9/9/9/9 b S2rb4gs4n4l17p 1";
     const record = Record.newByUSI(usi) as Record;
     const player = new USIPlayer(testUSIEngine, 10);
-    try {
-      await player.launch();
-      const handler = {
-        onCheckmate: vi.fn(),
-        onNotImplemented: vi.fn(),
-        onTimeout: vi.fn(),
-        onNoMate: vi.fn(),
-        onError: vi.fn(),
-      };
-      await player.startMateSearch(record.position, usi, undefined, handler);
-      expect(mockAPI.usiGoMate).toBeCalledWith(100, usi, undefined);
-      onUSINoMate(100, usi);
-      expect(handler.onCheckmate).not.toBeCalled();
-      expect(handler.onNotImplemented).not.toBeCalled();
-      expect(handler.onTimeout).not.toBeCalled();
-      expect(handler.onNoMate).toBeCalledTimes(1);
-      expect(handler.onError).not.toBeCalled();
-    } finally {
-      await player.close();
-    }
+    await player.launch();
+    const handler = {
+      onCheckmate: vi.fn(),
+      onNotImplemented: vi.fn(),
+      onTimeout: vi.fn(),
+      onNoMate: vi.fn(),
+      onError: vi.fn(),
+    };
+    await player.startMateSearch(record.position, usi, undefined, handler);
+    expect(mockAPI.usiGoMate).toBeCalledWith(100, usi, undefined);
+    onUSINoMate(100, usi);
+    expect(handler.onCheckmate).not.toBeCalled();
+    expect(handler.onNotImplemented).not.toBeCalled();
+    expect(handler.onTimeout).not.toBeCalled();
+    expect(handler.onNoMate).toBeCalledTimes(1);
+    expect(handler.onError).not.toBeCalled();
+    await player.close();
+    expect(mockAPI.usiQuit).toBeCalledWith(100);
   });
 
   it("onUSIInfo", async () => {
@@ -223,88 +327,86 @@ describe("usi", () => {
     const record = Record.newByUSI(usi) as Record;
     const onSearchInfo = vi.fn();
     const player = new USIPlayer(testUSIEngine, 10, onSearchInfo);
-    try {
-      await player.launch();
-      const searchHandler = {
-        onMove: vi.fn(),
-        onResign: vi.fn(),
-        onWin: vi.fn(),
-        onError: vi.fn(),
-      };
-      await player.startSearch(record.position, usi, timeStates, searchHandler);
+    await player.launch();
+    const searchHandler = {
+      onMove: vi.fn(),
+      onResign: vi.fn(),
+      onWin: vi.fn(),
+      onError: vi.fn(),
+    };
+    await player.startSearch(record.position, usi, timeStates, searchHandler);
 
-      // 深さ 15 の評価値と最善種
-      onUSIInfo(100, usi, {
-        multipv: 1,
-        depth: 15,
-        scoreCP: 81,
-        currmove: "2g2f",
-      });
-      expect(onSearchInfo).not.toBeCalled();
-      vi.runOnlyPendingTimers();
-      expect(onSearchInfo).toBeCalledTimes(1);
-      expect(onSearchInfo).lastCalledWith({
-        usi,
-        depth: 15,
-        pv: parsePV(record.position, "▲２六歩"),
-        score: 81,
-      });
+    // 深さ 15 の評価値と最善種
+    onUSIInfo(100, usi, {
+      multipv: 1,
+      depth: 15,
+      scoreCP: 81,
+      currmove: "2g2f",
+    });
+    expect(onSearchInfo).not.toBeCalled();
+    vi.runOnlyPendingTimers();
+    expect(onSearchInfo).toBeCalledTimes(1);
+    expect(onSearchInfo).lastCalledWith({
+      usi,
+      depth: 15,
+      pv: parsePV(record.position, "▲２六歩"),
+      score: 81,
+    });
 
-      // 深さ 16
-      onUSIInfo(100, usi, {
-        multipv: 1,
-        depth: 16,
-        scoreCP: 32,
-        currmove: "5g5f",
-        pv: ["5g5f", "8c8d", "5f5e"],
-      });
-      expect(onSearchInfo).toBeCalledTimes(1);
-      // タイマーが作動する前に深さ 17 が来た場合はその情報で上書きされる。
+    // 深さ 16
+    onUSIInfo(100, usi, {
+      multipv: 1,
+      depth: 16,
+      scoreCP: 32,
+      currmove: "5g5f",
+      pv: ["5g5f", "8c8d", "5f5e"],
+    });
+    expect(onSearchInfo).toBeCalledTimes(1);
+    // タイマーが作動する前に深さ 17 が来た場合はその情報で上書きされる。
 
-      // 深さ 17 の評価値と PV
-      onUSIInfo(100, usi, {
-        multipv: 1,
-        depth: 17,
-        scoreCP: 123,
-        currmove: "2g2f",
-        pv: ["2g2f", "8c8d", "2f2e"],
-      });
-      vi.runOnlyPendingTimers();
-      expect(onSearchInfo).toBeCalledTimes(2);
-      expect(onSearchInfo).lastCalledWith({
-        usi,
-        depth: 17,
-        pv: parsePV(record.position, "▲２六歩△８四歩▲２五歩"),
-        score: 123,
-      });
+    // 深さ 17 の評価値と PV
+    onUSIInfo(100, usi, {
+      multipv: 1,
+      depth: 17,
+      scoreCP: 123,
+      currmove: "2g2f",
+      pv: ["2g2f", "8c8d", "2f2e"],
+    });
+    vi.runOnlyPendingTimers();
+    expect(onSearchInfo).toBeCalledTimes(2);
+    expect(onSearchInfo).lastCalledWith({
+      usi,
+      depth: 17,
+      pv: parsePV(record.position, "▲２六歩△８四歩▲２五歩"),
+      score: 123,
+    });
 
-      // 評価値とメッセージ
-      onUSIInfo(100, usi, {
-        multipv: 1,
-        scoreCP: -75,
-        string: "free format message",
-      });
-      vi.runOnlyPendingTimers();
-      expect(onSearchInfo).toBeCalledTimes(3);
-      expect(onSearchInfo).lastCalledWith({
-        usi,
-        depth: 17,
-        pv: parsePV(record.position, "▲２六歩△８四歩▲２五歩"),
-        score: -75,
-      });
+    // 評価値とメッセージ
+    onUSIInfo(100, usi, {
+      multipv: 1,
+      scoreCP: -75,
+      string: "free format message",
+    });
+    vi.runOnlyPendingTimers();
+    expect(onSearchInfo).toBeCalledTimes(3);
+    expect(onSearchInfo).lastCalledWith({
+      usi,
+      depth: 17,
+      pv: parsePV(record.position, "▲２六歩△８四歩▲２五歩"),
+      score: -75,
+    });
 
-      // Multi PV 第 2 位
-      onUSIInfo(100, usi, {
-        multipv: 2,
-        depth: 17,
-        scoreCP: -98,
-        currmove: "5g5f",
-        pv: ["5g5f", "8c8d", "5f5e"],
-      });
-      vi.runOnlyPendingTimers();
-      expect(onSearchInfo).toBeCalledTimes(3);
-    } finally {
-      await player.close();
-    }
+    // Multi PV 第 2 位
+    onUSIInfo(100, usi, {
+      multipv: 2,
+      depth: 17,
+      scoreCP: -98,
+      currmove: "5g5f",
+      pv: ["5g5f", "8c8d", "5f5e"],
+    });
+    vi.runOnlyPendingTimers();
+    expect(onSearchInfo).toBeCalledTimes(3);
+    await player.close();
+    expect(mockAPI.usiQuit).toBeCalledWith(100);
   });
 });

--- a/src/tests/renderer/store/book.spec.ts
+++ b/src/tests/renderer/store/book.spec.ts
@@ -4,6 +4,7 @@ import { BookStore } from "@/renderer/store/book.js";
 import { useAppSettings } from "@/renderer/store/settings.js";
 import { Record } from "tsshogi";
 import { Mocked } from "vitest";
+import { defaultBookSession } from "@/common/book";
 
 vi.mock("@/renderer/ipc/api.js");
 
@@ -35,7 +36,7 @@ describe("store/book", () => {
         { usi: "4d4e", comment: "bar" },
       ]);
       expect(mockAPI.searchBookMoves).toHaveBeenCalledTimes(1);
-      expect(mockAPI.searchBookMoves).toHaveBeenNthCalledWith(1, sfen);
+      expect(mockAPI.searchBookMoves).toHaveBeenNthCalledWith(1, defaultBookSession, sfen);
     });
 
     it("match/flipped", async () => {
@@ -55,8 +56,8 @@ describe("store/book", () => {
         { usi: "6f6e", comment: "bar" },
       ]);
       expect(mockAPI.searchBookMoves).toHaveBeenCalledTimes(2);
-      expect(mockAPI.searchBookMoves).toHaveBeenNthCalledWith(1, sfen_r);
-      expect(mockAPI.searchBookMoves).toHaveBeenNthCalledWith(2, sfen);
+      expect(mockAPI.searchBookMoves).toHaveBeenNthCalledWith(1, defaultBookSession, sfen_r);
+      expect(mockAPI.searchBookMoves).toHaveBeenNthCalledWith(2, defaultBookSession, sfen);
     });
 
     it("no match", async () => {
@@ -69,7 +70,7 @@ describe("store/book", () => {
       const moves = store.searchMoves(sfen);
       await expect(moves).resolves.toEqual([]);
       expect(mockAPI.searchBookMoves).toHaveBeenCalledTimes(1);
-      expect(mockAPI.searchBookMoves).toHaveBeenNthCalledWith(1, sfen);
+      expect(mockAPI.searchBookMoves).toHaveBeenNthCalledWith(1, defaultBookSession, sfen);
     });
   });
 });

--- a/src/tests/renderer/store/research.spec.ts
+++ b/src/tests/renderer/store/research.spec.ts
@@ -30,17 +30,17 @@ describe("store/research", () => {
     expect(mockAPI.usiReady).toBeCalledTimes(1);
     const record = new Record();
     manager.updatePosition(record);
-    vi.runOnlyPendingTimers(); // 遅延実行
+    await vi.runOnlyPendingTimersAsync(); // 遅延実行
     expect(mockAPI.usiGoInfinite).toBeCalledTimes(1);
     expect(mockAPI.usiGoInfinite).toBeCalledWith(100, "position startpos");
 
     // 時間制限が無いので stop コマンドは送信されない。
-    vi.runOnlyPendingTimers();
+    await vi.runOnlyPendingTimersAsync();
     expect(mockAPI.usiStop).toBeCalledTimes(0);
 
     record.append(record.position.createMoveByUSI("7g7f") as Move);
     manager.updatePosition(record);
-    vi.runOnlyPendingTimers(); // 遅延実行
+    await vi.runOnlyPendingTimersAsync(); // 遅延実行
     expect(mockAPI.usiGoInfinite).toBeCalledTimes(2);
     expect(mockAPI.usiGoInfinite).toBeCalledWith(100, "position startpos moves 7g7f");
   });
@@ -54,11 +54,11 @@ describe("store/research", () => {
     await manager.launch(researchSettingsMax5Seconds);
     const record = new Record();
     manager.updatePosition(record);
-    vi.runOnlyPendingTimers(); // 遅延実行
+    await vi.runOnlyPendingTimersAsync(); // 遅延実行
     expect(mockAPI.usiStop).toBeCalledTimes(0);
 
     // 時間制限があるので stop コマンドが送信される。
-    vi.runOnlyPendingTimers();
+    await vi.runOnlyPendingTimersAsync();
     expect(mockAPI.usiStop).toBeCalledTimes(1);
   });
 
@@ -72,11 +72,11 @@ describe("store/research", () => {
     expect(mockAPI.usiReady).toBeCalledTimes(3);
     const record = new Record();
     manager.updatePosition(record);
-    vi.runOnlyPendingTimers(); // 遅延実行
+    await vi.runOnlyPendingTimersAsync(); // 遅延実行
     expect(mockAPI.usiGoInfinite).toBeCalledTimes(3);
     record.append(record.position.createMoveByUSI("7g7f") as Move);
     manager.updatePosition(record);
-    vi.runOnlyPendingTimers(); // 遅延実行
+    await vi.runOnlyPendingTimersAsync(); // 遅延実行
     expect(mockAPI.usiGoInfinite).toBeCalledTimes(6);
   });
 
@@ -90,7 +90,7 @@ describe("store/research", () => {
     await manager.launch(researchSettingsSecondaryEngines);
     const record = new Record();
     manager.updatePosition(record);
-    vi.runOnlyPendingTimers();
+    await vi.runOnlyPendingTimersAsync();
     expect(mockAPI.usiGoInfinite).toBeCalledTimes(3);
     // all sessions are unpaused
     expect(manager.isPaused(101)).toBeFalsy();
@@ -104,10 +104,11 @@ describe("store/research", () => {
     // update position
     record.append(record.position.createMoveByUSI("7g7f") as Move);
     manager.updatePosition(record);
-    vi.runOnlyPendingTimers();
+    await vi.runOnlyPendingTimersAsync();
     expect(mockAPI.usiGoInfinite).toBeCalledTimes(5);
     // unpause 102
     manager.unpause(102);
+    await vi.advanceTimersByTimeAsync(0); // flush promises
     expect(manager.isPaused(101)).toBeFalsy();
     expect(manager.isPaused(102)).toBeFalsy();
     expect(manager.isPaused(103)).toBeFalsy();
@@ -138,7 +139,7 @@ describe("store/research", () => {
     });
     const record = new Record();
     manager.updatePosition(record);
-    vi.runOnlyPendingTimers();
+    await vi.runOnlyPendingTimersAsync();
     expect(mockAPI.usiGoInfinite).toBeCalledTimes(1);
     expect(mockAPI.usiStop).not.toBeCalled();
     expect(manager.getMultiPV(101)).toBe(4);
@@ -161,7 +162,7 @@ describe("store/research", () => {
     await manager.launch(researchSettings); // without MultiPV option
     const record = new Record();
     manager.updatePosition(record);
-    vi.runOnlyPendingTimers();
+    await vi.runOnlyPendingTimersAsync();
     expect(mockAPI.usiGoInfinite).toBeCalledTimes(1);
     expect(mockAPI.usiStop).not.toBeCalled();
     expect(manager.getMultiPV(101)).toBeUndefined();


### PR DESCRIPTION
# 説明 / Description

#1455 

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/shogihome/blob/main/CONTRIBUTING.md)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated
  - [x] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-session book support: open/close/manage multiple independent book sessions.
  * Engine integration: engines can consult books during search; UI displays book-derived moves.
  * Engine options UI: frontend book controls (enable, file selection, on-the-fly toggle).

* **Tests**
  * Expanded tests covering session-aware book management and engine/book interactions.

* **Chores**
  * Added localization entries for the new frontend book UI.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->