### PR TITLE
Add SPRT pair outcome tracking for parallel games

### DIFF
--- a/src/renderer/game/coordinator.ts
+++ b/src/renderer/game/coordinator.ts
@@ -11,6 +11,8 @@ import { t } from "@/common/i18n/translation_table.js";
 export type GameConditions = {
   gameTitle?: string;
   swapPlayers: boolean;
+  gameIndex: number;
+  pairIndex: number;
 };
 
 export type GameCoordinator = Omit<SingleGameSettings, "startPosition"> & {
@@ -63,7 +65,9 @@ export async function buildGameCoordinator(params: {
       const gameTitle =
         settings.repeat >= 2 ? `連続対局 ${gameCount}/${settings.repeat}` : undefined;
       const swapPlayers = settings.swapPlayers && gameCount % 2 === 0;
-      return { gameTitle, swapPlayers };
+      const gameIndex = gameCount;
+      const pairIndex = Math.floor((gameCount - 1) / 2) + 1;
+      return { gameTitle, swapPlayers, gameIndex, pairIndex };
     },
   };
 }


### PR DESCRIPTION
### Motivation
- Support SPRT-style pair aggregation by tracking paired games (front/back) and collecting their combined outcomes, while deferring the actual SPRT decision logic for now.
- Make pair identification available to higher layers by exposing game/pair indices from the coordinator and surfacing per-game result events from the manager.

### Description
- Added `gameIndex` and `pairIndex` to `GameConditions` and populated them in `buildGameCoordinator` so each game returned by the coordinator carries its indices.
- Extended `GameManager` to emit a new `gameResult` event with `{ gameIndex, pairIndex, result }` when a game ends, and changed `addGameResults` to return the per-game `GameResult` so callers can aggregate pair-level data.
- Implemented SPRT-pair bookkeeping in `ParallelGameManager` by importing `GameResult`, adding a `sprtPairResults` map and `sprtPairCounts` counters, subscribing to `gameResult` events, aggregating two-game pairs into five categories, resetting counts on start, and logging the counts with `console.log` when all workers finish.
- Kept behavior minimal: SPRT algorithm/decision is not implemented — only collection and logging of the five aggregated pair categories (lose-lose, lose-draw, draw/draw or win-lose, win-draw, win-win).

### Testing
- No automated tests were executed for these changes in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975ab94fe7c8321a1654f9525c66168)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced match tracking with automatic game and pair indexing for improved tournament organization and result reporting
  * Introduced real-time per-game result callbacks enabling event-driven result processing and notifications
  * Implemented SPRT pair statistics tracking for comprehensive tournament analysis and performance metrics

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->