### PR TITLE
「駒の増減」ダイアログに駒数を一括で変更するボタンを設置

### DIFF
--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -202,6 +202,8 @@ export const en: Texts = {
   changeTurn: "Change Turn",
   initializePosition: "Initialize Position",
   changePieceSet: "Change Piece Set",
+  setAllPiecesToStandardCounts: "Set All Pieces to Standard Counts",
+  setAllPiecesToZero: "Set All Pieces to Zero",
   appSettings: "Preferences",
   language: "Languages",
   theme: "Theme",

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -202,6 +202,8 @@ export const ja: Texts = {
   changeTurn: "手番変更",
   initializePosition: "局面の初期化",
   changePieceSet: "駒の増減",
+  setAllPiecesToStandardCounts: "全ての駒を平手の枚数にする",
+  setAllPiecesToZero: "全ての駒を0にする",
   appSettings: "アプリ設定",
   language: "言語",
   theme: "テーマ",

--- a/src/common/i18n/locales/vi.ts
+++ b/src/common/i18n/locales/vi.ts
@@ -202,6 +202,8 @@ export const vi: Texts = {
   changeTurn: "Đổi lượt đi",
   initializePosition: "Đặt lại thế cờ",
   changePieceSet: "Tăng giảm quân",
+  setAllPiecesToStandardCounts: "全ての駒を平手の枚数にする", // TODO: Translate
+  setAllPiecesToZero: "全ての駒を0にする", // TODO: Translate
   appSettings: "Cài đặt ứng dụng",
   language: "Ngôn ngữ",
   theme: "Chủ đề",

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -199,6 +199,8 @@ export const zh_tw: Texts = {
   changeTurn: "變更手番",
   initializePosition: "初始化局面",
   changePieceSet: "調整棋駒數",
+  setAllPiecesToStandardCounts: "全ての駒を平手の枚数にする", // TODO: Translate
+  setAllPiecesToZero: "全ての駒を0にする", // TODO: Translate
   appSettings: "程式設定",
   language: "語言",
   theme: "主題",

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -197,6 +197,8 @@ export type Texts = {
   changeTurn: string;
   initializePosition: string;
   changePieceSet: string;
+  setAllPiecesToStandardCounts: string;
+  setAllPiecesToZero: string;
   appSettings: string;
   language: string;
   theme: string;

--- a/src/renderer/view/dialog/PieceSetChangeDialog.vue
+++ b/src/renderer/view/dialog/PieceSetChangeDialog.vue
@@ -70,7 +70,7 @@ const counts = ref(
 );
 
 // 平手の駒数
-const standardCounts: Record<PieceType, number> = {
+const standardCounts = {
   [PieceType.KING]: 2,
   [PieceType.ROOK]: 2,
   [PieceType.BISHOP]: 2,

--- a/src/renderer/view/dialog/PieceSetChangeDialog.vue
+++ b/src/renderer/view/dialog/PieceSetChangeDialog.vue
@@ -15,6 +15,10 @@
             />
           </div>
         </div>
+        <button class="bulk thin" @click="setStandardCounts">
+          {{ t.setAllPiecesToStandardCounts }}
+        </button>
+        <button class="bulk thin" @click="setAllZero">{{ t.setAllPiecesToZero }}</button>
       </div>
       <div class="main-buttons">
         <button data-hotkey="Enter" autofocus @click="ok()">
@@ -65,6 +69,30 @@ const counts = ref(
   ),
 );
 
+// 平手の駒数
+const standardCounts: Record<PieceType, number> = {
+  [PieceType.KING]: 2,
+  [PieceType.ROOK]: 2,
+  [PieceType.BISHOP]: 2,
+  [PieceType.GOLD]: 4,
+  [PieceType.SILVER]: 4,
+  [PieceType.KNIGHT]: 4,
+  [PieceType.LANCE]: 4,
+  [PieceType.PAWN]: 18,
+} as Record<PieceType, number>;
+
+const setStandardCounts = () => {
+  for (const pieceType of pieceTypes) {
+    counts.value[pieceType] = standardCounts[pieceType];
+  }
+};
+
+const setAllZero = () => {
+  for (const pieceType of pieceTypes) {
+    counts.value[pieceType] = 0;
+  }
+};
+
 const ok = () => {
   const update = Object.fromEntries(
     pieceTypes.map((pieceType) => {
@@ -94,5 +122,9 @@ const cancel = () => {
 }
 .number {
   width: 3em;
+}
+button.bulk {
+  width: 100%;
+  margin-top: 0.5em;
 }
 </style>


### PR DESCRIPTION
# 説明 / Description

局面編集中の「駒の増減」ダイアログに駒数を一括で 0 にするボタンと一括で平手の枚数にするボタンを設置する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/shogihome/blob/main/CONTRIBUTING.md)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [x] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Set All Pieces to Standard Counts" and "Set All Pieces to Zero" bulk-action buttons in the piece configuration dialog.
* **Chores**
  * Added corresponding translations for the new buttons across supported locales and updated the i18n template.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->