### PR TITLE
対局開始局面に SFEN を指定する機能

### DIFF
--- a/src/renderer/view/dialog/GameDialog.vue
+++ b/src/renderer/view/dialog/GameDialog.vue
@@ -148,6 +148,7 @@
             <div class="form-item-label">{{ t.startPosition }}</div>
             <select v-model="gameSettings.startPosition">
               <option value="current">{{ t.currentPosition }}</option>
+              <option value="sfen">SFEN</option>
               <option value="list">{{ t.positionList }}</option>
               <option :value="InitialPositionType.STANDARD">
                 {{ t.noHandicap }}
@@ -187,6 +188,14 @@
           <div v-show="gameSettings.startPosition === 'list'" class="form-item">
             <input v-model="gameSettings.startPositionListFile" type="text" placeholder="*.sfen" />
             <button class="thin" @click="onSelectStartPositionListFile">{{ t.select }}</button>
+          </div>
+          <div v-show="gameSettings.startPosition === 'sfen'" class="form-item">
+            <input
+              v-model="gameSettings.startPositionSFEN"
+              class="sfen"
+              type="text"
+              placeholder="sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1"
+            />
           </div>
           <div v-show="gameSettings.startPosition === 'list'" class="form-item">
             <ToggleButton v-model:value="startPositionListShuffle" :label="t.shuffle" />
@@ -528,6 +537,7 @@ const onStart = () => {
       byoyomi: byoyomi.value,
       increment: increment.value,
     },
+    startPositionSFEN: gameSettings.value.startPositionSFEN.trim(),
     startPositionListOrder: startPositionListShuffle.value ? "shuffle" : "sequential",
     searchCommentFormat: useAppSettings().searchCommentFormat,
   };
@@ -661,5 +671,8 @@ input.number.small {
 .preset button {
   margin: 0 1px 0 0;
   padding: 4px 6px;
+}
+.sfen {
+  width: 100%;
 }
 </style>

--- a/src/renderer/view/menu/MobileGameMenu.vue
+++ b/src/renderer/view/menu/MobileGameMenu.vue
@@ -83,6 +83,7 @@ const selectTurn = (turn: Color) => {
       increment: 0,
     },
     startPosition: InitialPositionType.STANDARD,
+    startPositionSFEN: "",
     startPositionListFile: "",
     startPositionListOrder: "sequential",
     enableEngineTimeout: false,

--- a/src/tests/mock/game.ts
+++ b/src/tests/mock/game.ts
@@ -46,6 +46,7 @@ export const gameSettings10m30s: GameSettings = {
   white: whitePlayerSettings,
   timeLimit: timeLimitSettings,
   startPosition: InitialPositionType.STANDARD,
+  startPositionSFEN: "",
   startPositionListFile: "",
   startPositionListOrder: "sequential",
   enableEngineTimeout: false,

--- a/src/tests/renderer/game/coordinator.spec.ts
+++ b/src/tests/renderer/game/coordinator.spec.ts
@@ -1,0 +1,36 @@
+import { buildGameCoordinator } from "@/renderer/game/coordinator.js";
+import { RecordManager } from "@/renderer/record/manager.js";
+import { gameSettings10m30s } from "@/tests/mock/game.js";
+
+describe("game/coordinator", () => {
+  it("buildGameCoordinator/startPositionSFEN", async () => {
+    const sfen = "ln2kgsnl/1r1sg2b1/p1pppp1pp/6p2/1p7/2PP5/PPBSPPPPP/7R1/LN1GKGSNL b - 1";
+    const coordinator = await buildGameCoordinator({
+      settings: {
+        ...gameSettings10m30s,
+        startPosition: "sfen",
+        startPositionSFEN: sfen,
+      },
+      currentPly: 1,
+    });
+    const recordManager = new RecordManager();
+
+    const result = coordinator.next(recordManager);
+    expect(result).not.toBeNull();
+    expect(result).not.toBeInstanceOf(Error);
+    expect(recordManager.record.usi).toBe(`position sfen ${sfen}`);
+  });
+
+  it("buildGameCoordinator/startPositionSFEN-invalid", async () => {
+    await expect(
+      buildGameCoordinator({
+        settings: {
+          ...gameSettings10m30s,
+          startPosition: "sfen",
+          startPositionSFEN: "invalid sfen",
+        },
+        currentPly: 1,
+      }),
+    ).rejects.toThrow("Invalid USI");
+  });
+});


### PR DESCRIPTION
# 説明 / Description

ローカル対局の開始局面に SFEN 文字列を指定可能にする。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/shogihome/blob/main/CONTRIBUTING.md)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SFEN string support for custom game starting positions. Users can now select "SFEN" as a start position option and input a custom SFEN string to begin games from specific board configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->