### PR TITLE
Use SVG text elements in SimpleBoardView

### DIFF
--- a/src/tests/renderer/view/primitive/simple-board.spec.ts
+++ b/src/tests/renderer/view/primitive/simple-board.spec.ts
@@ -1,0 +1,84 @@
+import { shallowMount } from "@vue/test-utils";
+import { Position } from "tsshogi";
+import { RectSize } from "@/common/assets/geometry.js";
+import SimpleBoardView from "@/renderer/view/primitive/SimpleBoardView.vue";
+
+const originalUserAgent = window.navigator.userAgent;
+
+const setUserAgent = (value: string) => {
+  Object.defineProperty(window.navigator, "userAgent", {
+    value,
+    configurable: true,
+  });
+};
+
+const mountSimpleBoard = () => {
+  return shallowMount(SimpleBoardView, {
+    props: {
+      maxSize: new RectSize(500, 500),
+      position: new Position(),
+    },
+  });
+};
+
+const mountSimpleBoardWithTypeface = (typeface: "gothic" | "mincho") => {
+  return shallowMount(SimpleBoardView, {
+    props: {
+      maxSize: new RectSize(500, 500),
+      position: new Position(),
+      typeface,
+    },
+  });
+};
+
+const parseDy = (dy: string | undefined) => {
+  return Number.parseFloat(dy ?? "0");
+};
+
+describe("SimpleBoardView", () => {
+  afterAll(() => {
+    setUserAgent(originalUserAgent);
+  });
+
+  it("applies larger positive dy on Windows than on non-Windows", () => {
+    setUserAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64)");
+    const windowsWrapper = mountSimpleBoard();
+    const windowsDy = parseDy(windowsWrapper.findAll("text").slice(18)[0].attributes("dy"));
+
+    setUserAgent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)");
+    const macWrapper = mountSimpleBoard();
+    const macDy = parseDy(macWrapper.findAll("text").slice(18)[0].attributes("dy"));
+
+    expect(windowsDy).toBeGreaterThan(macDy);
+    expect(macDy).toBe(0);
+  });
+
+  it("uses positive dy for both white and black board pieces on Windows mincho", () => {
+    setUserAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64)");
+    const wrapper = mountSimpleBoard();
+    const pieceTexts = wrapper.findAll("text").slice(18);
+
+    const whitePiece = pieceTexts.find((text) => !!text.attributes("transform"));
+    const blackPiece = pieceTexts.find((text) => !text.attributes("transform"));
+    if (!whitePiece || !blackPiece) {
+      throw new Error("board pieces not found");
+    }
+
+    const whiteDy = parseDy(whitePiece.attributes("dy"));
+    const blackDy = parseDy(blackPiece.attributes("dy"));
+
+    expect(whiteDy).toBeGreaterThan(0);
+    expect(blackDy).toBeGreaterThan(0);
+  });
+
+  it("does not apply dy correction to gothic on Windows", () => {
+    setUserAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64)");
+    const wrapper = mountSimpleBoardWithTypeface("gothic");
+    const pieceTexts = wrapper.findAll("text").slice(18);
+    const blackPiece = pieceTexts.find((text) => !text.attributes("transform"));
+    if (!blackPiece) {
+      throw new Error("black piece not found");
+    }
+    expect(parseDy(blackPiece.attributes("dy"))).toBe(0);
+  });
+});


### PR DESCRIPTION
# 説明 / Description

SimpleBoardView で SVG を使うようにしつつ、Windows の場合の文字の縦位置を補正する処理を追加。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/shogihome/blob/main/CONTRIBUTING.md)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Board now renders as scalable SVG for crisper visuals and more precise piece, label and rotation placement.
  * Layout uses explicit coordinates and font sizing (including last-move highlight as a rectangle) for consistent alignment across sizes.
  * Windows-specific vertical offset correction for certain typefaces to fix piece alignment.

* **Tests**
  * Added tests validating rendering and vertical-offset behavior across platforms and typefaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->