### PR TITLE
Windows のメニーコア環境で論理スレッド数が少なく見える問題を修正

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -26,6 +26,7 @@ import { createWindow } from "./window/main.js";
 import { spawn } from "child_process";
 import { invoke as invokeHeadless } from "./headless/invoke.js";
 import { setProcessArgs } from "./window/ipc.js";
+import { prefetchWindowsLogicalProcessorCount } from "./proc/state.js";
 
 const args = parseProcessArgs(process.argv);
 if (args instanceof Error) {
@@ -50,6 +51,8 @@ switch (args.type) {
       });
     break;
 }
+
+prefetchWindowsLogicalProcessorCount();
 
 const appSettings = loadAppSettingsOnce();
 for (const type of Object.values(LogType)) {

--- a/src/background/window/ipc.ts
+++ b/src/background/window/ipc.ts
@@ -984,9 +984,9 @@ ipcMain.on(
   },
 );
 
-ipcMain.handle(Background.GET_MACHINE_SPEC, (event) => {
+ipcMain.handle(Background.GET_MACHINE_SPEC, async (event) => {
   validateIPCSender(event.senderFrame);
-  return JSON.stringify(getMachineSpec());
+  return JSON.stringify(await getMachineSpec());
 });
 
 ipcMain.on(

--- a/src/background/window/menu.ts
+++ b/src/background/window/menu.ts
@@ -647,8 +647,8 @@ function createMenuTemplate(window: BrowserWindow) {
         },
         {
           label: "CPU Information",
-          click: () => {
-            const cpu = getCPUInfo();
+          click: async () => {
+            const cpu = await getCPUInfo();
             sendMessage({
               text: "CPU Information",
               attachments: [

--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -781,6 +781,8 @@ export const en: Texts = {
   doYouReallyWantToIncreaseTheSuggestionsCount:
     "Do you really want to increase the suggestions count?",
   recommendLowerSettingsForDailyUse: "Recommend lower settings for daily use.",
+  checkEngineCompatibilityForNumaEnvironments:
+    "This machine may have multiple CPU sockets or processor groups (NUMA). Not all engines handle NUMA environments optimally. Please check whether your engine supports NUMA.",
   aiPerformanceMayDegrade: "AI performance may degrade.",
   yourPCMayBecomeSlow: "Your PC may become slow.",
   increasingItMayImproveAIPerformance: "Increasing it may improve AI performance.",

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -782,6 +782,8 @@ export const ja: Texts = {
     "候補手を増やしすぎると動作が重くなる可能性があります。",
   doYouReallyWantToIncreaseTheSuggestionsCount: "本当に候補手の数を増やしますか？",
   recommendLowerSettingsForDailyUse: "日常利用のPCでは低めの設定を推奨します。",
+  checkEngineCompatibilityForNumaEnvironments:
+    "このPCは複数のCPUソケットまたはプロセッサーグループ（NUMA）を持つ可能性があります。NUMA環境に対応していないエンジンでは性能が低下する場合があります。エンジンのNUMA対応状況をご確認ください。",
   aiPerformanceMayDegrade: "AIの性能が低下する可能性があります。",
   yourPCMayBecomeSlow: "PCの動作が重くなる可能性があります。",
   increasingItMayImproveAIPerformance: "大きくすることでAIの性能が向上する可能性があります。",

--- a/src/common/i18n/locales/vi.ts
+++ b/src/common/i18n/locales/vi.ts
@@ -788,6 +788,8 @@ export const vi: Texts = {
     "Số nước đề xuất quá lớn có thể làm ứng dụng chậm đi đáng kể.",
   doYouReallyWantToIncreaseTheSuggestionsCount: "Bạn có thực sự muốn tăng số nước đề xuất?",
   recommendLowerSettingsForDailyUse: "Nên sử dụng cài đặt thấp hơn cho PC thông thường.",
+  checkEngineCompatibilityForNumaEnvironments:
+    "このPCは複数のCPUソケットまたはプロセッサーグループ（NUMA）を持つ可能性があります。NUMA環境に対応していないエンジンでは性能が低下する場合があります。エンジンのNUMA対応状況をご確認ください。", // TODO: Translate
   aiPerformanceMayDegrade: "Tính năng phần mềm có thể suy giảm.",
   yourPCMayBecomeSlow: "Thao tác PC có thể bị chậm lại.",
   increasingItMayImproveAIPerformance: "Có thể cải thiện tính năng phần mềm bằng cách tăng lên.",

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -776,6 +776,8 @@ export const zh_tw: Texts = {
   largeSuggestionsCountMayCausePerformanceDegradation: "增加候補手可能會導致效能下降。",
   doYouReallyWantToIncreaseTheSuggestionsCount: "您確定要增加候選手數嗎？",
   recommendLowerSettingsForDailyUse: "日常利用のPCでは低めの設定を推奨します。", // TODO: Translate
+  checkEngineCompatibilityForNumaEnvironments:
+    "このPCは複数のCPUソケットまたはプロセッサーグループ（NUMA）を持つ可能性があります。NUMA環境に対応していないエンジンでは性能が低下する場合があります。エンジンのNUMA対応状況をご確認ください。", // TODO: Translate
   aiPerformanceMayDegrade: "AIの性能が低下する可能性があります。", // TODO: Translate
   yourPCMayBecomeSlow: "PCの動作が重くなる可能性があります。", // TODO: Translate
   increasingItMayImproveAIPerformance: "大きくすることでAIの性能が向上する可能性があります。", // TODO: Translate

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -748,6 +748,7 @@ export type Texts = {
   largeSuggestionsCountMayCausePerformanceDegradation: string;
   doYouReallyWantToIncreaseTheSuggestionsCount: string;
   recommendLowerSettingsForDailyUse: string;
+  checkEngineCompatibilityForNumaEnvironments: string;
   aiPerformanceMayDegrade: string;
   yourPCMayBecomeSlow: string;
   increasingItMayImproveAIPerformance: string;

--- a/src/renderer/view/dialog/USIEngineOptionsDialog.vue
+++ b/src/renderer/view/dialog/USIEngineOptionsDialog.vue
@@ -173,6 +173,12 @@
                   {{ t.cpuUsageExceedsNPercent(50) }}{{ t.recommendLowerSettingsForDailyUse }}
                 </div>
               </div>
+              <div
+                v-if="machineSpec.cpuCores > 32 && option.currentValue > 32"
+                class="form-group warning"
+              >
+                <div class="note">{{ t.checkEngineCompatibilityForNumaEnvironments }}</div>
+              </div>
             </div>
             <!-- USI_Hash -->
             <div

--- a/src/tests/background/proc/state.spec.ts
+++ b/src/tests/background/proc/state.spec.ts
@@ -1,8 +1,8 @@
 import { getCPUInfo, getMachineSpec } from "@/background/proc/state";
 
 describe("proc/state", () => {
-  it("getMachineSpec", () => {
-    const spec = getMachineSpec();
+  it("getMachineSpec", async () => {
+    const spec = await getMachineSpec();
     expect(spec).toHaveProperty("cpuCores");
     expect(spec).toHaveProperty("memory");
     expect(typeof spec.cpuCores).toBe("number");
@@ -11,8 +11,8 @@ describe("proc/state", () => {
     expect(spec.memory).toBeGreaterThan(0);
   });
 
-  it("getCPUInfo", () => {
-    const cpuInfo = getCPUInfo();
+  it("getCPUInfo", async () => {
+    const cpuInfo = await getCPUInfo();
     expect(cpuInfo).toHaveProperty("architecture");
     expect(cpuInfo).toHaveProperty("availableCores");
     expect(cpuInfo).toHaveProperty("cores");


### PR DESCRIPTION
# 説明 / Description

Windows では最大 64 コアで論理コアが複数グループに分けて管理される。
全ての論理コアの数を取得するように修正する。

また、そのようなコア数はNUMA環境である可能性があるが、エンジンがNUMAに対応していないとそれを活かすことはできない。
32 スレッドを超える場合はエンジンの仕様を確認するように促す表示をする。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/shogihome/blob/main/CONTRIBUTING.md)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows CPU/core detection and prefetch at startup so machine and CPU info are more accurate and available sooner.
  * Background requests and the CPU Info menu now wait for updated CPU/machine data, ensuring dialogs show current details.

* **New Content**
  * Added NUMA/engine-compatibility warning in engine options when high core counts are selected.
  * Added corresponding localization strings for multiple languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->