### PR TITLE
駒をドラッグ&ドロップで操作する機能

### DIFF
--- a/src/renderer/view/primitive/BoardView.vue
+++ b/src/renderer/view/primitive/BoardView.vue
@@ -405,8 +405,6 @@ watch(
   },
 );
 
-// ---- ドラッグ&ドロップ ----
-
 type DragState = {
   pending: boolean; // pointerdown 記録済み、動き待ち
   active: boolean; // ゴースト表示中
@@ -666,8 +664,6 @@ onUnmounted(() => {
   document.removeEventListener("pointercancel", onGlobalPointerCancel);
   document.body.style.cursor = "";
 });
-
-// ---- ドラッグ&ドロップ ここまで ----
 
 const clickFrame = () => {
   if (dragCompletedFlag) {

--- a/src/renderer/view/primitive/BoardView.vue
+++ b/src/renderer/view/primitive/BoardView.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div ref="frameEl" class="frame" :style="main.frame.style" @click="clickFrame()">
+    <div class="frame" :style="main.frame.style" @click="clickFrame()">
       <!-- 後手の駒台 -->
       <div class="hand" :class="flip ? 'front' : 'back'" :style="main.whiteHandStyle">
         <div
@@ -401,6 +401,7 @@ watch(
   [() => props.position, () => props.position.sfen, () => props.allowEdit, () => props.allowMove],
   () => {
     resetState();
+    resetDrag();
   },
 );
 
@@ -411,7 +412,6 @@ type DragState = {
   active: boolean; // ゴースト表示中
   pointerId: number | null;
   source: Square | Piece | null;
-  sourceColor: Color | undefined;
   pieceImagePath: string | null;
   ghostX: number;
   ghostY: number;
@@ -424,7 +424,6 @@ const drag = reactive<DragState>({
   active: false,
   pointerId: null,
   source: null,
-  sourceColor: undefined,
   pieceImagePath: null,
   ghostX: 0,
   ghostY: 0,
@@ -437,7 +436,6 @@ const resetDrag = () => {
   drag.active = false;
   drag.pointerId = null;
   drag.source = null;
-  drag.sourceColor = undefined;
   drag.pieceImagePath = null;
   document.body.style.cursor = "";
 };
@@ -445,7 +443,6 @@ const resetDrag = () => {
 // ドラッグ完了後に click イベントを無効化するフラグ（非リアクティブ）
 let dragCompletedFlag = false;
 
-const frameEl = ref<HTMLElement | null>(null);
 const boardOpEl = ref<HTMLElement | null>(null);
 const blackHandOpEl = ref<HTMLElement | null>(null);
 const whiteHandOpEl = ref<HTMLElement | null>(null);
@@ -481,7 +478,6 @@ const beginDragFromSquare = (
   drag.pending = true;
   drag.pointerId = pointerId;
   drag.source = square;
-  drag.sourceColor = piece.color;
   drag.pieceImagePath = getPieceImagePath(piece);
   drag.startX = clientX;
   drag.startY = clientY;
@@ -504,7 +500,6 @@ const beginDragFromHand = (
   drag.pending = true;
   drag.pointerId = pointerId;
   drag.source = new Piece(color, type);
-  drag.sourceColor = color;
   drag.pieceImagePath = getPieceImagePath(new Piece(color, type));
   drag.startX = clientX;
   drag.startY = clientY;
@@ -642,6 +637,7 @@ const onGlobalPointerCancel = (e: PointerEvent) => {
 
 // 盤上マス：pointerdown
 const onSquarePointerDown = (e: PointerEvent, file: number, rank: number) => {
+  if (e.button !== 0) return; // 左ボタン・タッチのみ
   if (drag.pending || drag.active) return;
   dragCompletedFlag = false;
   beginDragFromSquare(e.clientX, e.clientY, file, rank, e.pointerId);
@@ -649,6 +645,7 @@ const onSquarePointerDown = (e: PointerEvent, file: number, rank: number) => {
 
 // 持ち駒：pointerdown
 const onHandPointerDown = (e: PointerEvent, color: Color, type: PieceType) => {
+  if (e.button !== 0) return; // 左ボタン・タッチのみ
   if (drag.pending || drag.active) return;
   dragCompletedFlag = false;
   beginDragFromHand(e.clientX, e.clientY, color, type, e.pointerId);
@@ -871,7 +868,7 @@ const handLayoutBuilder = computed(() => {
 
 // ドラッグ中の持ち駒を半透明にする
 const applyDragOpacityToHand = (hand: ReturnType<HandLayoutBuilder["build"]>, color: Color) => {
-  if (!drag.active || !(drag.source instanceof Piece) || drag.sourceColor !== color) {
+  if (!drag.active || !(drag.source instanceof Piece) || drag.source.color !== color) {
     return hand;
   }
   const targetId = drag.source.type + "0";

--- a/src/renderer/view/primitive/BoardView.vue
+++ b/src/renderer/view/primitive/BoardView.vue
@@ -582,7 +582,7 @@ const completeDrop = (clientX: number, clientY: number) => {
   const source = drag.source;
   const square = getSquareFromClientPoint(clientX, clientY);
   if (square && source) {
-    // 有効な手・編集がある場合のみ着手し、無効なマスへのドロップは単純キャンセル（駒の再選択はしない）
+    // ドロップ先に駒がある場合に clickSquare() を呼ぶとキャンセルと同時にその駒を選択してしまうため有効な移動かどうかを先に判定する。
     const moveFrom = source instanceof Square ? source : (source as Piece).type;
     const move = props.allowMove ? props.position.createMove(moveFrom, square) : null;
     const validMove =

--- a/src/renderer/view/primitive/BoardView.vue
+++ b/src/renderer/view/primitive/BoardView.vue
@@ -871,7 +871,10 @@ const applyDragOpacityToHand = (hand: ReturnType<HandLayoutBuilder["build"]>, co
   if (!drag.active || !(drag.source instanceof Piece) || drag.source.color !== color) {
     return hand;
   }
-  const targetId = drag.source.type + "0";
+  // 標準レイアウトの piece id は "type+index"（例: "pawn0"）、
+  // コンパクト/ポートレイトは "type" のみ（例: "pawn"）
+  const targetId =
+    props.layoutType === BoardLayoutType.STANDARD ? drag.source.type + "0" : drag.source.type;
   return {
     ...hand,
     pieces: hand.pieces.map((p) =>

--- a/src/renderer/view/primitive/BoardView.vue
+++ b/src/renderer/view/primitive/BoardView.vue
@@ -837,21 +837,14 @@ const boardLayoutBuilder = computed(() => {
 });
 
 const board = computed(() => {
-  const result = boardLayoutBuilder.value.build(
+  const dragSourceSquare = drag.active && drag.source instanceof Square ? drag.source : undefined;
+  return boardLayoutBuilder.value.build(
     props.position.board,
     props.lastMove,
     state.pointer,
     state.reservedMove,
+    dragSourceSquare,
   );
-  // ドラッグ中は移動元マスの駒を非表示にする
-  if (drag.active && drag.source instanceof Square) {
-    const piece = props.position.board.at(drag.source);
-    if (piece) {
-      const sourceId = piece.id + drag.source.index;
-      return { ...result, pieces: result.pieces.filter((p) => p.id !== sourceId) };
-    }
-  }
-  return result;
 });
 
 const handLayoutBuilder = computed(() => {

--- a/src/renderer/view/primitive/BoardView.vue
+++ b/src/renderer/view/primitive/BoardView.vue
@@ -866,34 +866,29 @@ const handLayoutBuilder = computed(() => {
   }
 });
 
-// ドラッグ中の持ち駒を半透明にする
-const applyDragOpacityToHand = (hand: ReturnType<HandLayoutBuilder["build"]>, color: Color) => {
-  if (!drag.active || !(drag.source instanceof Piece) || drag.source.color !== color) {
-    return hand;
-  }
-  // 標準レイアウトの piece id は "type+index"（例: "pawn0"）、
-  // コンパクト/ポートレイトは "type" のみ（例: "pawn"）
-  const targetId =
-    props.layoutType === BoardLayoutType.STANDARD ? drag.source.type + "0" : drag.source.type;
-  return {
-    ...hand,
-    pieces: hand.pieces.map((p) =>
-      p.id === targetId ? { ...p, style: { ...p.style, opacity: "0.3" } } : p,
-    ),
-  };
-};
-
 const blackHand = computed(() => {
-  return applyDragOpacityToHand(
-    handLayoutBuilder.value.build(props.position.hand(Color.BLACK), Color.BLACK, state.pointer),
+  const dragSourceType =
+    drag.active && drag.source instanceof Piece && drag.source.color === Color.BLACK
+      ? drag.source.type
+      : undefined;
+  return handLayoutBuilder.value.build(
+    props.position.hand(Color.BLACK),
     Color.BLACK,
+    state.pointer,
+    dragSourceType,
   );
 });
 
 const whiteHand = computed(() => {
-  return applyDragOpacityToHand(
-    handLayoutBuilder.value.build(props.position.hand(Color.WHITE), Color.WHITE, state.pointer),
+  const dragSourceType =
+    drag.active && drag.source instanceof Piece && drag.source.color === Color.WHITE
+      ? drag.source.type
+      : undefined;
+  return handLayoutBuilder.value.build(
+    props.position.hand(Color.WHITE),
     Color.WHITE,
+    state.pointer,
+    dragSourceType,
   );
 });
 

--- a/src/renderer/view/primitive/BoardView.vue
+++ b/src/renderer/view/primitive/BoardView.vue
@@ -632,6 +632,9 @@ const onGlobalPointerUp = (e: PointerEvent) => {
 
 const onGlobalPointerCancel = (e: PointerEvent) => {
   if (e.pointerId !== drag.pointerId) return;
+  if (drag.active) {
+    resetState();
+  }
   resetDrag();
 };
 

--- a/src/renderer/view/primitive/board/board.ts
+++ b/src/renderer/view/primitive/board/board.ts
@@ -133,9 +133,12 @@ export class BoardLayoutBuilder {
     return labels;
   }
 
-  private getPieces(board: ImmutableBoard): BoardPiece[] {
+  private getPieces(board: ImmutableBoard, dragSourceSquare?: Square): BoardPiece[] {
     const pieces: BoardPiece[] = [];
     board.listNonEmptySquares().forEach((square) => {
+      if (dragSourceSquare && square.equals(dragSourceSquare)) {
+        return;
+      }
       const piece = board.at(square) as Piece;
       const id = piece.id + square.index;
       const displayColor = this.config.flip ? reverseColor(piece.color) : piece.color;
@@ -275,12 +278,13 @@ export class BoardLayoutBuilder {
     lastMove?: Move | null,
     pointer?: Square | Piece | null,
     reservedMoveForPromotion?: Move | null,
+    dragSourceSquare?: Square,
   ): Board {
     const [promote, doNotPromote] = this.getPromotionControls(reservedMoveForPromotion);
     return {
       background: this.background,
       labels: this.labels,
-      pieces: this.getPieces(board),
+      pieces: this.getPieces(board, dragSourceSquare),
       squares: this.getSquares(lastMove, pointer),
       promote,
       doNotPromote,

--- a/src/renderer/view/primitive/board/hand.ts
+++ b/src/renderer/view/primitive/board/hand.ts
@@ -39,7 +39,12 @@ export class HandLayoutBuilder {
     return new Point(x, y).multiply(this.ratio);
   }
 
-  build(hand: ImmutableHand, color: Color, pointer?: Square | Piece | null): Hand {
+  build(
+    hand: ImmutableHand,
+    color: Color,
+    pointer?: Square | Piece | null,
+    dragSourceType?: PieceType,
+  ): Hand {
     const displayColor = this.config.flip ? reverseColor(color) : color;
     const bgColor = pieceStandBackgroundColorMap[this.config.pieceStandImageType];
     const standWidth = handParams.width * this.ratio;
@@ -84,6 +89,7 @@ export class HandLayoutBuilder {
             top: y + "px",
             width: pieceWidth + "px",
             height: pieceHeight + "px",
+            opacity: i === 0 && type === dragSourceType ? "0.3" : "1",
           },
         });
       }
@@ -142,7 +148,12 @@ export class CompactHandLayoutBuilder {
     return new Point(0, 0);
   }
 
-  build(hand: ImmutableHand, color: Color, pointer?: Square | Piece | null): Hand {
+  build(
+    hand: ImmutableHand,
+    color: Color,
+    pointer?: Square | Piece | null,
+    dragSourceType?: PieceType,
+  ): Hand {
     const displayColor = this.config.flip ? reverseColor(color) : color;
     const bgColor = pieceStandBackgroundColorMap[this.config.pieceStandImageType];
     const standWidth = compactHandParams.width * this.ratio;
@@ -182,6 +193,7 @@ export class CompactHandLayoutBuilder {
           top: top + compactHandParams.topPiecePadding * this.ratio + "px",
           width: commonParams.piece.width * this.ratio + "px",
           height: commonParams.piece.height * this.ratio + "px",
+          opacity: type === dragSourceType ? "0.3" : "1",
         },
       });
       if (hand.count(type) > 1) {
@@ -256,7 +268,12 @@ export class PortraitHandLayoutBuilder {
     return new Point(0, 0);
   }
 
-  build(hand: ImmutableHand, color: Color, pointer?: Square | Piece | null): Hand {
+  build(
+    hand: ImmutableHand,
+    color: Color,
+    pointer?: Square | Piece | null,
+    dragSourceType?: PieceType,
+  ): Hand {
     const displayColor = this.config.flip ? reverseColor(color) : color;
     const bgColor = pieceStandBackgroundColorMap[this.config.pieceStandImageType];
     const standWidth = portraitHandParams.width * this.ratio;
@@ -295,6 +312,7 @@ export class PortraitHandLayoutBuilder {
           top: portraitHandParams.topPiecePadding * this.ratio + "px",
           width: commonParams.piece.width * this.ratio + "px",
           height: commonParams.piece.height * this.ratio + "px",
+          opacity: type === dragSourceType ? "0.3" : "1",
         },
       });
       if (hand.count(type) > 1) {


### PR DESCRIPTION
# 説明 / Description

これまでのクリック2回の操作方法に加えて、ドラッグ&ドロップでも駒を移動できるようにする。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/shogihome/blob/main/CONTRIBUTING.md)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full drag-and-drop for board and hand pieces with real-time ghost preview rendered to the page; hides source piece while dragging, shows cursor feedback, and validates drops between board and hand.

* **Improvements**
  * Global pointer handling with activation threshold, improved touch support, hand-region drop detection, ghost sizing/positioning, click-suppression after drags, and proper cleanup on exit/unmount.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->