### PR TITLE
矢印に最善手からの評価値の差を表示する機能

### DIFF
--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -323,6 +323,7 @@ export const en: Texts = {
   swapEachTurnChange: "Swap Each Turn Change",
   alwaysSenteIsPositive: "Always Sente is Positive",
   signOfEvaluation: "Sign of Evaluation",
+  showArrowScore: "Show Score on Arrows",
   maxArrows: "Max Arrows",
   winRateCoefficient: "Win Rate Coefficient",
   nodeCountFormat: "Node Count Format",

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -323,6 +323,7 @@ export const ja: Texts = {
   swapEachTurnChange: "手番側有利がプラスの値",
   alwaysSenteIsPositive: "先手有利がプラスの値",
   signOfEvaluation: "評価値の符号",
+  showArrowScore: "矢印に評価値を表示",
   maxArrows: "矢印の表示数",
   winRateCoefficient: "勝率換算係数",
   nodeCountFormat: "ノード数表記",

--- a/src/common/i18n/locales/vi.ts
+++ b/src/common/i18n/locales/vi.ts
@@ -333,6 +333,7 @@ export const vi: Texts = {
   swapEachTurnChange: "Đổi mỗi lượt",
   alwaysSenteIsPositive: "Tiên luôn dương",
   signOfEvaluation: "Dấu giá trị đánh giá",
+  showArrowScore: "矢印に評価値を表示", // TODO: Translate
   maxArrows: "Số mũi tên hiển thị",
   winRateCoefficient: "Hệ số tỷ lệ thắng",
   nodeCountFormat: "Hiển thị số node",

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -330,6 +330,7 @@ export const zh_tw: Texts = {
   swapEachTurnChange: "手番側有利時為正值",
   alwaysSenteIsPositive: "先手有利時為正值",
   signOfEvaluation: "評價值符號",
+  showArrowScore: "矢印に評価値を表示", // TODO: Translate
   maxArrows: "箭頭顯示數量",
   winRateCoefficient: "勝率換算係數",
   nodeCountFormat: "節點數格式",

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -316,6 +316,7 @@ export type Texts = {
   swapEachTurnChange: string;
   alwaysSenteIsPositive: string;
   signOfEvaluation: string;
+  showArrowScore: string;
   maxArrows: string;
   winRateCoefficient: string;
   nodeCountFormat: string;

--- a/src/common/settings/app.ts
+++ b/src/common/settings/app.ts
@@ -231,6 +231,7 @@ export type AppSettings = {
   // Evaluation
   evaluationViewFrom: EvaluationViewFrom;
   maxArrowsPerEngine: number;
+  showArrowScore: boolean;
   coefficientInSigmoid: number;
   badMoveLevelThreshold1: number;
   badMoveLevelThreshold2: number;
@@ -382,6 +383,7 @@ export function defaultAppSettings(opt?: {
     showEngineOptionDetails: false,
     evaluationViewFrom: EvaluationViewFrom.EACH,
     maxArrowsPerEngine: 3,
+    showArrowScore: true,
     coefficientInSigmoid: 600,
     badMoveLevelThreshold1: 5,
     badMoveLevelThreshold2: 10,

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -73,6 +73,11 @@ import { CommentBehavior } from "@/common/settings/comment.js";
 import { Attachment, ListItem } from "@/common/message.js";
 import { ParallelGameManager, ParallelGameProgress } from "@/renderer/game/parallel.js";
 
+type CandidateMove = {
+  move: Move;
+  score?: number; // 手番側視点の数値スコア（showArrowScore が有効な場合のみ設定）
+};
+
 export type PVPreview = {
   position: ImmutablePosition;
   engineName?: string;
@@ -509,16 +514,27 @@ class Store {
     return this.usiMonitor.sessions;
   }
 
-  get candidates(): Move[] {
+  get candidates(): CandidateMove[] {
     const appSettings = useAppSettings();
     const maxScoreDiff = 100;
     const sfen = this.recordManager.record.position.sfen;
-    const candidates: Move[] = [];
+    // 優先度1: 検討の第1エンジン（研究セッションの中で最小の sessionID）
+    // 優先度2: 対局中の手番側エンジン（ポンダー中でないセッション）
+    // 評価値ラベルはこのセッションのみ表示する。他のセッションは矢印のみ表示する。
+    const preferredSession =
+      this.usiMonitor.sessions.find((s) => this.researchManager.isSessionExists(s.sessionID)) ||
+      this.usiMonitor.sessions.find((s) => !s.ponderMove);
+    const candidates: CandidateMove[] = [];
     const usiSet = new Set<string>();
-    for (const session of this.usiMonitor.sessions) {
+    // 優先セッションを先頭に並べ替え、同一手の重複除去で優先セッションが先に登録されるようにする
+    const orderedSessions = preferredSession
+      ? [preferredSession, ...this.usiMonitor.sessions.filter((s) => s !== preferredSession)]
+      : this.usiMonitor.sessions;
+    for (const session of orderedSessions) {
       if (session.ponderMove) {
         continue;
       }
+      const isPreferred = session === preferredSession;
       let entryCount = 0;
       let maxScore = -Infinity;
       for (const info of session.latestInfo) {
@@ -561,7 +577,8 @@ class Store {
         if (!move || !pos.doMove(move)) {
           continue;
         }
-        candidates.push(move);
+        const candidateScore = isPreferred && appSettings.showArrowScore ? score : undefined;
+        candidates.push({ move, score: candidateScore });
         usiSet.add(usi);
         entryCount++;
       }

--- a/src/renderer/store/settings.ts
+++ b/src/renderer/store/settings.ts
@@ -212,6 +212,9 @@ class AppSettingsStore {
   get maxArrowsPerEngine(): number {
     return this.merged.maxArrowsPerEngine;
   }
+  get showArrowScore(): boolean {
+    return this.merged.showArrowScore;
+  }
   get coefficientInSigmoid(): number {
     return this.merged.coefficientInSigmoid;
   }

--- a/src/renderer/view/dialog/AppSettingsDialog.vue
+++ b/src/renderer/view/dialog/AppSettingsDialog.vue
@@ -593,6 +593,11 @@
         <input v-model.number="update.maxArrowsPerEngine" type="number" max="10" min="0" />
         <div class="form-item-small-label">({{ t.between(0, 10) }})</div>
       </div>
+      <!-- 矢印に評価値を表示 -->
+      <div class="form-item">
+        <div class="form-item-label-wide">{{ t.showArrowScore }}</div>
+        <ToggleButton v-model:value="update.showArrowScore" />
+      </div>
       <!-- 勝率換算係数 -->
       <div class="form-item">
         <div class="form-item-label-wide">
@@ -863,6 +868,7 @@ const update = ref({
   nodeCountFormat: org.nodeCountFormat,
   evaluationViewFrom: org.evaluationViewFrom,
   maxArrowsPerEngine: org.maxArrowsPerEngine,
+  showArrowScore: org.showArrowScore,
   coefficientInSigmoid: org.coefficientInSigmoid,
   badMoveLevelThreshold1: org.badMoveLevelThreshold1,
   badMoveLevelThreshold2: org.badMoveLevelThreshold2,

--- a/src/renderer/view/primitive/BoardView.vue
+++ b/src/renderer/view/primitive/BoardView.vue
@@ -74,6 +74,15 @@
         :style="arrow.style"
         style="object-fit: cover; object-position: left top"
       />
+      <div
+        v-for="arrow in arrows"
+        v-show="arrow.labelText"
+        :key="'label-' + arrow.id"
+        class="arrow-label"
+        :style="arrow.labelStyle"
+      >
+        {{ arrow.labelText }}
+      </div>
 
       <!-- 操作用レイヤー -->
       <div ref="boardOpEl" class="board operation" :style="main.boardStyle">
@@ -243,6 +252,11 @@ import {
   portraitHandParams,
 } from "./board/params";
 
+type CandidateMove = {
+  move: Move;
+  score?: number; // 手番側視点の数値スコア（showArrowScore が有効な場合のみ設定）
+};
+
 type State = {
   pointer: Square | Piece | null;
   reservedMove: Move | null;
@@ -318,7 +332,7 @@ const props = defineProps({
     default: null,
   },
   candidates: {
-    type: Array as PropType<Move[]>,
+    type: Array as PropType<CandidateMove[]>,
     required: false,
     default: () => [],
   },
@@ -886,42 +900,74 @@ const whiteHand = computed(() => {
 
 const arrows = computed(() => {
   const arrowWidth = 30 * main.value.ratio;
-  return props.candidates.map((candidate) => {
+  const n = props.candidates.length;
+  const bestScore = props.candidates.reduce<number | undefined>(
+    (best, c) => (c.score !== undefined && (best === undefined || c.score > best) ? c.score : best),
+    undefined,
+  );
+  return props.candidates.map((candidate, index) => {
+    const move = candidate.move;
     const boardBase = layoutBuilder.value.boardBasePoint;
     const blackHandBase = layoutBuilder.value.blackHandBasePoint;
     const whiteHandBase = layoutBuilder.value.whiteHandBasePoint;
     const start =
-      candidate.from instanceof Square
-        ? boardBase.add(boardLayoutBuilder.value.centerOfSquare(candidate.from))
-        : candidate.color === Color.BLACK
+      move.from instanceof Square
+        ? boardBase.add(boardLayoutBuilder.value.centerOfSquare(move.from))
+        : move.color === Color.BLACK
           ? blackHandBase.add(
               handLayoutBuilder.value.centerOfPieceType(
                 props.position.hand(Color.BLACK),
                 Color.BLACK,
-                candidate.from,
+                move.from,
               ),
             )
           : whiteHandBase.add(
               handLayoutBuilder.value.centerOfPieceType(
                 props.position.hand(Color.WHITE),
                 Color.WHITE,
-                candidate.from,
+                move.from,
               ),
             );
-    const end = boardBase.add(boardLayoutBuilder.value.centerOfSquare(candidate.to));
+    const end = boardBase.add(boardLayoutBuilder.value.centerOfSquare(move.to));
     const middle = start.add(end).multiply(0.5);
     const distance = start.distanceTo(end);
     const angle = start.angleTo(end) - Math.PI;
+    // z-index 決定のためスコアに基づいてランクを計算（同率は同順位）
+    let labelText: string;
+    let scoreRank: number;
+    if (candidate.score !== undefined && bestScore !== undefined) {
+      const diff = candidate.score - bestScore;
+      scoreRank =
+        1 +
+        props.candidates.filter((c) => c.score !== undefined && c.score > candidate.score!).length;
+      labelText = diff === 0 ? "Best" : `${diff}`;
+    } else {
+      scoreRank = index + 1;
+      labelText = "";
+    }
     const x = middle.x - distance / 2;
     const y = middle.y - arrowWidth / 2;
+    // 矢印が水平に近いほどラベルをずらす（最大でフォントサイズ12px分）
+    // 矢印が水平より下向き（dy > |dx|）のときは上方向にオフセット
+    const dx = end.x - start.x;
+    const dy = end.y - start.y;
+    const horizontalFactor = distance > 0 ? Math.abs(dx) / distance : 0;
+    const labelOffsetY = dy > 0 ? -horizontalFactor * 12 : horizontalFactor * 12;
     return {
-      id: candidate.usi,
+      id: move.usi,
+      labelText,
       style: {
         left: x + "px",
         top: y + "px",
         width: distance + "px",
         height: arrowWidth + "px",
         transform: `rotate(${angle}rad)`,
+        zIndex: 100 + n - scoreRank,
+      },
+      labelStyle: {
+        left: middle.x + "px",
+        top: middle.y + labelOffsetY + "px",
+        zIndex: 100 + 2 * n - scoreRank,
       },
     };
   });
@@ -1050,6 +1096,20 @@ const whitePlayerTimeSeverity = computed(() => {
 }
 .arrows {
   z-index: 20;
+  pointer-events: none;
+}
+.arrow-label {
+  position: absolute;
+  z-index: 21;
+  transform: translate(-50%, -50%);
+  background: white;
+  color: #fe0000;
+  font-size: 12px;
+  font-weight: bold;
+  padding: 1px 4px;
+  white-space: nowrap;
+  line-height: 1.4;
+  pointer-events: none;
 }
 .board.operation,
 .hand.operation {

--- a/src/tests/renderer/store/index.spec.ts
+++ b/src/tests/renderer/store/index.spec.ts
@@ -386,16 +386,16 @@ describe("store/index", () => {
 
     await useAppSettings().updateAppSettings({ maxArrowsPerEngine: 3 });
     expect(store.candidates).toHaveLength(4);
-    expect(store.candidates[0].usi).toBe("8c8d");
-    expect(store.candidates[1].usi).toBe("4a3b");
-    expect(store.candidates[2].usi).toBe("3c3d");
-    expect(store.candidates[3].usi).toBe("9c9d");
+    expect(store.candidates[0].move.usi).toBe("8c8d");
+    expect(store.candidates[1].move.usi).toBe("4a3b");
+    expect(store.candidates[2].move.usi).toBe("3c3d");
+    expect(store.candidates[3].move.usi).toBe("9c9d");
 
     await useAppSettings().updateAppSettings({ maxArrowsPerEngine: 1 });
     expect(store.candidates).toHaveLength(3);
-    expect(store.candidates[0].usi).toBe("8c8d");
-    expect(store.candidates[1].usi).toBe("9c9d");
-    expect(store.candidates[2].usi).toBe("3c3d");
+    expect(store.candidates[0].move.usi).toBe("8c8d");
+    expect(store.candidates[1].move.usi).toBe("9c9d");
+    expect(store.candidates[2].move.usi).toBe("3c3d");
 
     await useAppSettings().updateAppSettings({ maxArrowsPerEngine: 0 });
     expect(store.candidates).toHaveLength(0);


### PR DESCRIPTION
# 説明 / Description

#1490 

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/shogihome/blob/main/CONTRIBUTING.md)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [x] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Option to display evaluation scores on move arrows; toggle in the Evaluation settings tab (enabled by default)
  * Arrow labels show "Best" for the top move or a numeric score/difference for others
  * Labels are positioned and ranked to improve readability (avoids overlap)
  * Multilingual support added for English, Japanese, Vietnamese, and Chinese
<!-- end of auto-generated comment: release notes by coderabbit.ai -->