### PR TITLE
矢印表示の対象とする評価値の範囲を指定する設定項目を追加

### DIFF
--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -324,6 +324,7 @@ export const en: Texts = {
   alwaysSenteIsPositive: "Always Sente is Positive",
   signOfEvaluation: "Sign of Evaluation",
   showArrowScore: "Show Score on Arrows",
+  arrowScoreDiffRange: "Arrow Score Range",
   maxArrows: "Max Arrows",
   winRateCoefficient: "Win Rate Coefficient",
   nodeCountFormat: "Node Count Format",

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -324,6 +324,7 @@ export const ja: Texts = {
   alwaysSenteIsPositive: "先手有利がプラスの値",
   signOfEvaluation: "評価値の符号",
   showArrowScore: "矢印に評価値を表示",
+  arrowScoreDiffRange: "矢印の評価値範囲",
   maxArrows: "矢印の表示数",
   winRateCoefficient: "勝率換算係数",
   nodeCountFormat: "ノード数表記",

--- a/src/common/i18n/locales/vi.ts
+++ b/src/common/i18n/locales/vi.ts
@@ -334,6 +334,7 @@ export const vi: Texts = {
   alwaysSenteIsPositive: "Tiên luôn dương",
   signOfEvaluation: "Dấu giá trị đánh giá",
   showArrowScore: "矢印に評価値を表示", // TODO: Translate
+  arrowScoreDiffRange: "矢印の評価値範囲", // TODO: Translate
   maxArrows: "Số mũi tên hiển thị",
   winRateCoefficient: "Hệ số tỷ lệ thắng",
   nodeCountFormat: "Hiển thị số node",

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -331,6 +331,7 @@ export const zh_tw: Texts = {
   alwaysSenteIsPositive: "先手有利時為正值",
   signOfEvaluation: "評價值符號",
   showArrowScore: "矢印に評価値を表示", // TODO: Translate
+  arrowScoreDiffRange: "矢印の評価値範囲", // TODO: Translate
   maxArrows: "箭頭顯示數量",
   winRateCoefficient: "勝率換算係數",
   nodeCountFormat: "節點數格式",

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -317,6 +317,7 @@ export type Texts = {
   alwaysSenteIsPositive: string;
   signOfEvaluation: string;
   showArrowScore: string;
+  arrowScoreDiffRange: string;
   maxArrows: string;
   winRateCoefficient: string;
   nodeCountFormat: string;

--- a/src/common/settings/app.ts
+++ b/src/common/settings/app.ts
@@ -231,6 +231,7 @@ export type AppSettings = {
   // Evaluation
   evaluationViewFrom: EvaluationViewFrom;
   maxArrowsPerEngine: number;
+  arrowScoreDiffRange: number;
   showArrowScore: boolean;
   coefficientInSigmoid: number;
   badMoveLevelThreshold1: number;
@@ -383,6 +384,7 @@ export function defaultAppSettings(opt?: {
     showEngineOptionDetails: false,
     evaluationViewFrom: EvaluationViewFrom.EACH,
     maxArrowsPerEngine: 3,
+    arrowScoreDiffRange: 100,
     showArrowScore: true,
     coefficientInSigmoid: 600,
     badMoveLevelThreshold1: 5,

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -516,7 +516,7 @@ class Store {
 
   get candidates(): CandidateMove[] {
     const appSettings = useAppSettings();
-    const maxScoreDiff = 100;
+    const maxScoreDiff = appSettings.arrowScoreDiffRange;
     const sfen = this.recordManager.record.position.sfen;
     // 優先度1: 検討の第1エンジン（研究セッションの中で最小の sessionID）
     // 優先度2: 対局中の手番側エンジン（ポンダー中でないセッション）

--- a/src/renderer/store/settings.ts
+++ b/src/renderer/store/settings.ts
@@ -212,6 +212,9 @@ class AppSettingsStore {
   get maxArrowsPerEngine(): number {
     return this.merged.maxArrowsPerEngine;
   }
+  get arrowScoreDiffRange(): number {
+    return this.merged.arrowScoreDiffRange;
+  }
   get showArrowScore(): boolean {
     return this.merged.showArrowScore;
   }

--- a/src/renderer/view/dialog/AppSettingsDialog.vue
+++ b/src/renderer/view/dialog/AppSettingsDialog.vue
@@ -593,6 +593,11 @@
         <input v-model.number="update.maxArrowsPerEngine" type="number" max="10" min="0" />
         <div class="form-item-small-label">({{ t.between(0, 10) }})</div>
       </div>
+      <!-- 矢印の評価値範囲 -->
+      <div class="form-item">
+        <div class="form-item-label-wide">{{ t.arrowScoreDiffRange }}</div>
+        <input v-model.number="update.arrowScoreDiffRange" type="number" min="0" />
+      </div>
       <!-- 矢印に評価値を表示 -->
       <div class="form-item">
         <div class="form-item-label-wide">{{ t.showArrowScore }}</div>
@@ -868,6 +873,7 @@ const update = ref({
   nodeCountFormat: org.nodeCountFormat,
   evaluationViewFrom: org.evaluationViewFrom,
   maxArrowsPerEngine: org.maxArrowsPerEngine,
+  arrowScoreDiffRange: org.arrowScoreDiffRange,
   showArrowScore: org.showArrowScore,
   coefficientInSigmoid: org.coefficientInSigmoid,
   badMoveLevelThreshold1: org.badMoveLevelThreshold1,


### PR DESCRIPTION
# 説明 / Description

これまで矢印を表示するのは最善手から評価値差が 100 までの指し手だった。
この閾値をアプリ設定で調整可能にする。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/shogihome/blob/main/CONTRIBUTING.md)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [x] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Arrow Score Range" numeric setting (default 100, min 0) to customize score-difference filtering.
  * Setting control added to the App Settings dialog under Evaluation.
  * Localization added for English, Japanese, Vietnamese and Traditional Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->