### PR TITLE
Fix simple board view

### DIFF
--- a/src/renderer/view/primitive/SimpleBoardView.vue
+++ b/src/renderer/view/primitive/SimpleBoardView.vue
@@ -8,13 +8,6 @@
         {{ footer }}
       </div>
       <svg style="top: 0; left: 0" :width="layout.svgSize" :height="layout.svgSize">
-        <image
-          href="/board/grid_square.svg"
-          :x="layout.boardImage.x"
-          :y="layout.boardImage.y"
-          :width="layout.boardImage.width"
-          :height="layout.boardImage.height"
-        />
         <rect
           v-if="layout.lastMoveRect"
           :x="layout.lastMoveRect.x"
@@ -22,6 +15,13 @@
           :width="layout.lastMoveRect.width"
           :height="layout.lastMoveRect.height"
           fill="gold"
+        />
+        <image
+          href="/board/grid_square.svg"
+          :x="layout.boardImage.x"
+          :y="layout.boardImage.y"
+          :width="layout.boardImage.width"
+          :height="layout.boardImage.height"
         />
         <text
           v-for="(file, index) of layout.files"


### PR DESCRIPTION
# 説明 / Description

局面図のハイライトがマス目の枠の前面に来てしまっているのを修正する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/shogihome/blob/main/CONTRIBUTING.md)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Adjusted the rendering order of the board background image to display correctly in the game board view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->