### PR TITLE
Update sbk stats management

### DIFF
--- a/src/background/book/index.ts
+++ b/src/background/book/index.ts
@@ -37,8 +37,11 @@ import {
   getBlackPlayerName,
   getWhitePlayerName,
   ImmutableNode,
+  ImmutableRecord,
   Move,
   Record,
+  reverseColor,
+  SpecialMoveType,
 } from "tsshogi";
 import { t } from "@/common/i18n/index.js";
 import { hash as aperyHash } from "./apery_zobrist.js";
@@ -495,6 +498,30 @@ function updateBookMovePatch(book: BookHandle, sfen: string, move: BookMove) {
   book.saved = false;
 }
 
+// 棋譜の終端ノードから勝者を判定する。
+// 引き分けや不明な場合は undefined を返す。
+function getRecordWinner(record: ImmutableRecord): Color | undefined {
+  let lastNode = record.first;
+  while (lastNode.next) {
+    lastNode = lastNode.next;
+  }
+  const lastMove = lastNode.move;
+  if (lastMove instanceof Move) return undefined;
+  switch (lastMove.type) {
+    case SpecialMoveType.FOUL_WIN:
+    case SpecialMoveType.ENTERING_OF_KING:
+      return lastNode.nextColor;
+    case SpecialMoveType.RESIGN:
+    case SpecialMoveType.MATE:
+    case SpecialMoveType.TIMEOUT:
+    case SpecialMoveType.FOUL_LOSE:
+    case SpecialMoveType.TRY:
+      return reverseColor(lastNode.nextColor);
+    default:
+      return undefined;
+  }
+}
+
 export async function importBookMoves(
   session: number,
   settings: BookImportSettings,
@@ -540,7 +567,7 @@ export async function importBookMoves(
   let entryCount = 0;
   let duplicateCount = 0;
 
-  function importMove(node: ImmutableNode, sfen: string) {
+  function importMove(node: ImmutableNode, sfen: string, winner: Color | undefined) {
     if (!(node.move instanceof Move)) {
       return;
     }
@@ -551,10 +578,8 @@ export async function importBookMoves(
     }
 
     const usi = node.move.usi;
-    const entry = retrieveEntry(book, sfen);
-    const bookMoves = entry?.moves || [];
-    const moves = bookMoves.map(arrayMoveToCommonBookMove);
-    const existing = moves.find((move) => move.usi === usi);
+    const bookMoves = (retrieveEntry(book, sfen)?.moves || []).map(arrayMoveToCommonBookMove);
+    const existing = bookMoves.find((move) => move.usi === usi);
     if (existing) {
       duplicateCount++;
     } else {
@@ -563,6 +588,18 @@ export async function importBookMoves(
     const bookMove = existing || { usi, comment: "" };
     bookMove.count = (bookMove.count || 0) + 1;
     updateBookMovePatch(book, sfen, bookMove);
+
+    if (book.format === "sbk") {
+      const entry = retrieveEntry(book, sfen);
+      if (entry) {
+        entry.games = (entry.games ?? 0) + 1;
+        if (winner === Color.BLACK) {
+          entry.wonBlack = (entry.wonBlack ?? 0) + 1;
+        } else if (winner === Color.WHITE) {
+          entry.wonWhite = (entry.wonWhite ?? 0) + 1;
+        }
+      }
+    }
   }
 
   for (const path of paths) {
@@ -611,10 +648,11 @@ export async function importBookMoves(
           continue;
         }
         hasValidLines = true;
+        const winner = getRecordWinner(record);
         record.forEach((node) => {
           const prev = node.prev;
           if (prev && targetColorSet[prev.nextColor]) {
-            importMove(node, prev.sfen);
+            importMove(node, prev.sfen, winner);
           }
         });
       }
@@ -653,10 +691,11 @@ export async function importBookMoves(
       }
     }
 
+    const winner = getRecordWinner(record);
     record.forEach((node) => {
       const prev = node.prev;
       if (prev && targetColorSet[prev.nextColor]) {
-        importMove(node, prev.sfen);
+        importMove(node, prev.sfen, winner);
       }
     });
     successFileCount++;

--- a/src/background/book/index.ts
+++ b/src/background/book/index.ts
@@ -37,7 +37,6 @@ import {
   getBlackPlayerName,
   getWhitePlayerName,
   ImmutableNode,
-  ImmutableRecord,
   Move,
   Record,
   reverseColor,
@@ -500,8 +499,8 @@ function updateBookMovePatch(book: BookHandle, sfen: string, move: BookMove) {
 
 // 棋譜の終端ノードから勝者を判定する。
 // 引き分けや不明な場合は undefined を返す。
-function getRecordWinner(record: ImmutableRecord): Color | undefined {
-  let lastNode = record.first;
+function getRecordWinner(node: ImmutableNode): Color | undefined {
+  let lastNode = node;
   while (lastNode.next) {
     lastNode = lastNode.next;
   }
@@ -648,8 +647,13 @@ export async function importBookMoves(
           continue;
         }
         hasValidLines = true;
-        const winner = getRecordWinner(record);
+        let winner: Color | undefined;
+        let lastPly = Infinity;
         record.forEach((node) => {
+          if (node.ply <= lastPly) {
+            winner = getRecordWinner(node);
+          }
+          lastPly = node.ply;
           const prev = node.prev;
           if (prev && targetColorSet[prev.nextColor]) {
             importMove(node, prev.sfen, winner);
@@ -691,8 +695,13 @@ export async function importBookMoves(
       }
     }
 
-    const winner = getRecordWinner(record);
+    let winner: Color | undefined;
+    let lastPly = Infinity;
     record.forEach((node) => {
+      if (node.ply <= lastPly) {
+        winner = getRecordWinner(node);
+      }
+      lastPly = node.ply;
       const prev = node.prev;
       if (prev && targetColorSet[prev.nextColor]) {
         importMove(node, prev.sfen, winner);

--- a/src/tests/background/book/index.spec.ts
+++ b/src/tests/background/book/index.spec.ts
@@ -14,6 +14,7 @@ import {
   updateBookMove,
   updateBookMoveOrder,
 } from "@/background/book/index.js";
+import { loadSbkBook } from "@/background/book/sbk.js";
 import { getTempPathForTesting } from "@/background/proc/env.js";
 import { defaultBookImportSettings, PlayerCriteria, SourceType } from "@/common/settings/book.js";
 import { createTestAperyBookFile } from "@/tests/mock/book.js";
@@ -511,6 +512,42 @@ sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1
         }
       });
     }
+  });
+
+  describe("importBookMoves - SBK specific", () => {
+    it("SBK games/wonBlack/wonWhite updated on import", async () => {
+      await openBook(defaultBookSession, "src/tests/testdata/book/shogihome01.sbk");
+
+      const initialSfen = "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1";
+      const baseline = loadSbkBook(fs.readFileSync("src/tests/testdata/book/shogihome01.sbk"));
+      const baselineGames = baseline.entries.get(initialSfen)?.games ?? 0;
+      const baselineWonBlack = baseline.entries.get(initialSfen)?.wonBlack ?? 0;
+      const baselineWonWhite = baseline.entries.get(initialSfen)?.wonWhite ?? 0;
+
+      // 7g7f 3c3d の後は先手番 → 先手が投了 → 後手勝ち (×2)
+      // 7g7f 3c3d 2g2f の後は後手番 → 後手が投了 → 先手勝ち (×1)
+      const sfenPath = path.join(tmpdir, "import-stats-test.sfen");
+      fs.writeFileSync(
+        sfenPath,
+        "position startpos moves 7g7f 3c3d resign\n" +
+          "position startpos moves 7g7f 3c3d resign\n" +
+          "position startpos moves 7g7f 3c3d 2g2f resign\n",
+      );
+
+      await importBookMoves(defaultBookSession, {
+        ...defaultBookImportSettings(),
+        sourceType: SourceType.FILE,
+        sourceRecordFile: sfenPath,
+        maxPly: 1, // 初期局面からの 7g7f だけを取り込む
+      });
+
+      const tempFilePath = path.join(tmpdir, "stats-test.sbk");
+      await saveBook(defaultBookSession, tempFilePath);
+      const entry = loadSbkBook(fs.readFileSync(tempFilePath)).entries.get(initialSfen);
+      expect(entry?.games).toBe(baselineGames + 3);
+      expect(entry?.wonBlack).toBe(baselineWonBlack + 1);
+      expect(entry?.wonWhite).toBe(baselineWonWhite + 2);
+    });
   });
 
   describe("merge", () => {


### PR DESCRIPTION
# 説明 / Description

#1518 

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/shogihome/blob/main/CONTRIBUTING.md)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved ShogiBook (.sbk) import: per-position counters now increment games and wins by color based on record outcomes.
* **Tests**
  * Added tests validating .sbk import behavior and confirming per-position statistics (games, wins by color) are updated correctly after import.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->