### PR TITLE
定跡フォーマット変換機能

### DIFF
--- a/src/background/book/index.ts
+++ b/src/background/book/index.ts
@@ -357,7 +357,9 @@ export async function saveBook(session: number, path: string) {
         await storeSbkBook(book, file);
         break;
     }
-    book.path = path;
+    if (book.type === "in-memory") {
+      book.path = path;
+    }
     book.saved = true;
   } finally {
     file.close();

--- a/src/background/book/index.ts
+++ b/src/background/book/index.ts
@@ -396,18 +396,16 @@ export async function exportBook(
   }
 
   // fullBook is yane2016 or sbk — both are SFEN-keyed
-  const sfenEntries = fullBook.entries;
-
   let targetBook: YaneBook | AperyBook | SbkBook;
   switch (targetFormat) {
     case "yane2016":
       if (!path.endsWith(".db")) throw new Error("Invalid file extension: " + path);
-      targetBook = { format: "yane2016", entries: sfenEntries };
+      targetBook = { format: "yane2016", entries: fullBook.entries };
       break;
     case "apery": {
       if (!path.endsWith(".bin")) throw new Error("Invalid file extension: " + path);
       const aperyEntries = new Map<bigint, BookEntry>();
-      for (const [sfen, entry] of sfenEntries) {
+      for (const [sfen, entry] of fullBook.entries) {
         aperyEntries.set(aperyHash(sfen), entry);
       }
       targetBook = { format: "apery", entries: aperyEntries };
@@ -415,7 +413,7 @@ export async function exportBook(
     }
     case "sbk":
       if (!path.endsWith(".sbk")) throw new Error("Invalid file extension: " + path);
-      targetBook = { format: "sbk", entries: sfenEntries };
+      targetBook = { format: "sbk", entries: fullBook.entries };
       break;
   }
 

--- a/src/background/book/index.ts
+++ b/src/background/book/index.ts
@@ -371,6 +371,12 @@ export async function exportBook(
   path: string,
   targetFormat: BookFormat,
 ): Promise<void> {
+  const expectedExt =
+    targetFormat === "yane2016" ? ".db" : targetFormat === "apery" ? ".bin" : ".sbk";
+  if (!path.endsWith(expectedExt)) {
+    throw new Error("Invalid file extension: " + path);
+  }
+
   const book = getBook(session);
 
   if (book.format === targetFormat) {
@@ -380,12 +386,6 @@ export async function exportBook(
 
   if (book.format === "apery") {
     throw new Error(t.cannotConvertAperyBookToOtherFormat);
-  }
-
-  const expectedExt =
-    targetFormat === "yane2016" ? ".db" : targetFormat === "apery" ? ".bin" : ".sbk";
-  if (!path.endsWith(expectedExt)) {
-    throw new Error("Invalid file extension: " + path);
   }
 
   // Build a fully merged in-memory book

--- a/src/background/book/index.ts
+++ b/src/background/book/index.ts
@@ -357,6 +357,7 @@ export async function saveBook(session: number, path: string) {
         await storeSbkBook(book, file);
         break;
     }
+    book.path = path;
     book.saved = true;
   } finally {
     file.close();

--- a/src/background/book/index.ts
+++ b/src/background/book/index.ts
@@ -379,6 +379,12 @@ export async function exportBook(
     throw new Error(t.cannotConvertAperyBookToOtherFormat);
   }
 
+  const expectedExt =
+    targetFormat === "yane2016" ? ".db" : targetFormat === "apery" ? ".bin" : ".sbk";
+  if (!path.endsWith(expectedExt)) {
+    throw new Error("Invalid file extension: " + path);
+  }
+
   // Build a fully merged in-memory book
   let fullBook: Book;
   if (book.type === "in-memory") {
@@ -399,11 +405,9 @@ export async function exportBook(
   let targetBook: YaneBook | AperyBook | SbkBook;
   switch (targetFormat) {
     case "yane2016":
-      if (!path.endsWith(".db")) throw new Error("Invalid file extension: " + path);
       targetBook = { format: "yane2016", entries: fullBook.entries };
       break;
     case "apery": {
-      if (!path.endsWith(".bin")) throw new Error("Invalid file extension: " + path);
       const aperyEntries = new Map<bigint, BookEntry>();
       for (const [sfen, entry] of fullBook.entries) {
         aperyEntries.set(aperyHash(sfen), entry);
@@ -412,7 +416,6 @@ export async function exportBook(
       break;
     }
     case "sbk":
-      if (!path.endsWith(".sbk")) throw new Error("Invalid file extension: " + path);
       targetBook = { format: "sbk", entries: fullBook.entries };
       break;
   }

--- a/src/background/book/index.ts
+++ b/src/background/book/index.ts
@@ -375,6 +375,10 @@ export async function exportBook(
     return;
   }
 
+  if (book.format === "apery") {
+    throw new Error(t.cannotConvertAperyBookToOtherFormat);
+  }
+
   // Build a fully merged in-memory book
   let fullBook: Book;
   if (book.type === "in-memory") {
@@ -387,24 +391,8 @@ export async function exportBook(
       if (merged) base.entries.set(sfen, merged);
     }
     fullBook = base;
-  } else if (book.format === "apery") {
-    const stream = book.file.createReadStream({
-      autoClose: false,
-      start: 0,
-      highWaterMark: 128 * 1024,
-    });
-    const base = await loadAperyBook(stream);
-    for (const [hash, patch] of book.entries) {
-      const merged = mergeBookEntries(base.entries.get(hash), patch);
-      if (merged) base.entries.set(hash, merged);
-    }
-    fullBook = base;
   } else {
     throw new Error("On-the-fly mode is not supported for this book format");
-  }
-
-  if (fullBook.format === "apery") {
-    throw new Error(t.cannotConvertAperyBookToOtherFormat);
   }
 
   // fullBook is yane2016 or sbk — both are SFEN-keyed

--- a/src/background/book/index.ts
+++ b/src/background/book/index.ts
@@ -8,6 +8,7 @@ import {
 } from "@/common/book.js";
 import { getAppLogger } from "@/background/log.js";
 import {
+  AperyBook,
   arrayMoveToCommonBookMove,
   Book,
   BookEntry,
@@ -15,6 +16,8 @@ import {
   IDX_COUNT,
   IDX_USI,
   mergeBookEntries,
+  SbkBook,
+  YaneBook,
 } from "./types.js";
 import {
   loadYaneuraOuBook,
@@ -355,6 +358,92 @@ export async function saveBook(session: number, path: string) {
         break;
     }
     book.saved = true;
+  } finally {
+    file.close();
+  }
+}
+
+export async function exportBook(
+  session: number,
+  path: string,
+  targetFormat: BookFormat,
+): Promise<void> {
+  const book = getBook(session);
+
+  if (book.format === targetFormat) {
+    await saveBook(session, path);
+    return;
+  }
+
+  // Build a fully merged in-memory book
+  let fullBook: Book;
+  if (book.type === "in-memory") {
+    fullBook = book;
+  } else if (book.format === "yane2016") {
+    const stream = book.file.createReadStream({ encoding: "utf-8", autoClose: false, start: 0 });
+    const base = await loadYaneuraOuBook(stream);
+    for (const [sfen, patch] of book.entries) {
+      const merged = mergeBookEntries(base.entries.get(sfen), patch);
+      if (merged) base.entries.set(sfen, merged);
+    }
+    fullBook = base;
+  } else if (book.format === "apery") {
+    const stream = book.file.createReadStream({
+      autoClose: false,
+      start: 0,
+      highWaterMark: 128 * 1024,
+    });
+    const base = await loadAperyBook(stream);
+    for (const [hash, patch] of book.entries) {
+      const merged = mergeBookEntries(base.entries.get(hash), patch);
+      if (merged) base.entries.set(hash, merged);
+    }
+    fullBook = base;
+  } else {
+    throw new Error("On-the-fly mode is not supported for this book format");
+  }
+
+  if (fullBook.format === "apery") {
+    throw new Error(t.cannotConvertAperyBookToOtherFormat);
+  }
+
+  // fullBook is yane2016 or sbk — both are SFEN-keyed
+  const sfenEntries = fullBook.entries;
+
+  let targetBook: YaneBook | AperyBook | SbkBook;
+  switch (targetFormat) {
+    case "yane2016":
+      if (!path.endsWith(".db")) throw new Error("Invalid file extension: " + path);
+      targetBook = { format: "yane2016", entries: sfenEntries };
+      break;
+    case "apery": {
+      if (!path.endsWith(".bin")) throw new Error("Invalid file extension: " + path);
+      const aperyEntries = new Map<bigint, BookEntry>();
+      for (const [sfen, entry] of sfenEntries) {
+        aperyEntries.set(aperyHash(sfen), entry);
+      }
+      targetBook = { format: "apery", entries: aperyEntries };
+      break;
+    }
+    case "sbk":
+      if (!path.endsWith(".sbk")) throw new Error("Invalid file extension: " + path);
+      targetBook = { format: "sbk", entries: sfenEntries };
+      break;
+  }
+
+  const file = fs.createWriteStream(path);
+  try {
+    switch (targetBook.format) {
+      case "yane2016":
+        await storeYaneuraOuBook(targetBook, file);
+        break;
+      case "apery":
+        await storeAperyBook(targetBook, file);
+        break;
+      case "sbk":
+        await storeSbkBook(targetBook, file);
+        break;
+    }
   } finally {
     file.close();
   }

--- a/src/background/window/ipc.ts
+++ b/src/background/window/ipc.ts
@@ -111,6 +111,7 @@ import { openPath } from "@/background/helpers/electron.js";
 import {
   clearBook,
   closeBookSession,
+  exportBook,
   getBookFormat,
   importBookMoves,
   isBookUnsaved,
@@ -644,6 +645,35 @@ ipcMain.handle(
     validateIPCSender(event.senderFrame);
     getAppLogger().debug(`save book: ${path}`);
     await saveBook(session, path);
+  },
+);
+
+ipcMain.handle(
+  Background.SHOW_EXPORT_BOOK_DIALOG,
+  async (event, _session: number, targetFormat: BookFormat): Promise<string> => {
+    validateIPCSender(event.senderFrame);
+    const appSettings = await loadAppSettings();
+    getAppLogger().debug("show export-book dialog: targetFormat=%s", targetFormat);
+    const filter =
+      targetFormat === "yane2016"
+        ? { name: "YaneuraOu Book Database", extensions: ["db"] }
+        : targetFormat === "apery"
+          ? { name: "Apery Book", extensions: ["bin"] }
+          : { name: "Shogi Book", extensions: ["sbk"] };
+    const ret = await showSaveDialog(appSettings.lastBookFilePath, [filter]);
+    if (ret) {
+      updateAppSettings({ lastBookFilePath: ret });
+    }
+    return ret;
+  },
+);
+
+ipcMain.handle(
+  Background.EXPORT_BOOK,
+  async (event, session: number, path: string, targetFormat: BookFormat): Promise<void> => {
+    validateIPCSender(event.senderFrame);
+    getAppLogger().debug(`export book: ${path} as ${targetFormat}`);
+    await exportBook(session, path, targetFormat);
   },
 );
 

--- a/src/background/window/ipc.ts
+++ b/src/background/window/ipc.ts
@@ -588,23 +588,27 @@ ipcMain.handle(Background.SHOW_OPEN_BOOK_DIALOG, async (event): Promise<string> 
   return ret;
 });
 
-ipcMain.handle(Background.SHOW_SAVE_BOOK_DIALOG, async (event, session): Promise<string> => {
-  validateIPCSender(event.senderFrame);
-  const appSettings = await loadAppSettings();
-  getAppLogger().debug("show save-book dialog");
-  const fmt = getBookFormat(session);
-  const filter =
-    fmt === "yane2016"
-      ? { name: "YaneuraOu Book Database", extensions: ["db"] }
-      : fmt === "apery"
-        ? { name: "Apery Book", extensions: ["bin"] }
-        : { name: "Shogi Book", extensions: ["sbk"] };
-  const ret = await showSaveDialog(appSettings.lastBookFilePath, [filter]);
-  if (ret) {
-    updateAppSettings({ lastBookFilePath: ret });
-  }
-  return ret;
-});
+ipcMain.handle(
+  Background.SHOW_SAVE_BOOK_DIALOG,
+  async (event, session: number, targetFormat?: BookFormat): Promise<string> => {
+    validateIPCSender(event.senderFrame);
+    const appSettings = await loadAppSettings();
+    getAppLogger().debug("show save-book dialog");
+    const fmt = targetFormat ?? getBookFormat(session);
+    const filter =
+      fmt === "yane2016"
+        ? { name: "YaneuraOu Book Database", extensions: ["db"] }
+        : fmt === "apery"
+          ? { name: "Apery Book", extensions: ["bin"] }
+          : { name: "Shogi Book", extensions: ["sbk"] };
+    const defaultPath = appSettings.lastBookFilePath.replace(/\.(db|bin|sbk)$/, "");
+    const ret = await showSaveDialog(defaultPath, [filter]);
+    if (ret) {
+      updateAppSettings({ lastBookFilePath: ret });
+    }
+    return ret;
+  },
+);
 
 ipcMain.handle(Background.CLEAR_BOOK, (event, session: number, format?: BookFormat) => {
   validateIPCSender(event.senderFrame);
@@ -645,26 +649,6 @@ ipcMain.handle(
     validateIPCSender(event.senderFrame);
     getAppLogger().debug(`save book: ${path}`);
     await saveBook(session, path);
-  },
-);
-
-ipcMain.handle(
-  Background.SHOW_EXPORT_BOOK_DIALOG,
-  async (event, _session: number, targetFormat: BookFormat): Promise<string> => {
-    validateIPCSender(event.senderFrame);
-    const appSettings = await loadAppSettings();
-    getAppLogger().debug("show export-book dialog: targetFormat=%s", targetFormat);
-    const filter =
-      targetFormat === "yane2016"
-        ? { name: "YaneuraOu Book Database", extensions: ["db"] }
-        : targetFormat === "apery"
-          ? { name: "Apery Book", extensions: ["bin"] }
-          : { name: "Shogi Book", extensions: ["sbk"] };
-    const ret = await showSaveDialog(appSettings.lastBookFilePath, [filter]);
-    if (ret) {
-      updateAppSettings({ lastBookFilePath: ret });
-    }
-    return ret;
   },
 );
 

--- a/src/background/window/menu.ts
+++ b/src/background/window/menu.ts
@@ -391,6 +391,20 @@ function createMenuTemplate(window: BrowserWindow) {
         menuItem(t.clear, MenuEvent.RESET_BOOK, [AppState.NORMAL]),
         menuItem(t.open, MenuEvent.OPEN_BOOK_FILE, [AppState.NORMAL]),
         menuItem(t.saveAs, MenuEvent.SAVE_BOOK_FILE, [AppState.NORMAL]),
+        {
+          label: t.export,
+          submenu: [
+            menuItem(`${t.yane2016BookFile} (.db)`, MenuEvent.EXPORT_BOOK_AS_YANE2016, [
+              AppState.NORMAL,
+            ]),
+            menuItem(`${t.aperyBookFile} (.bin)`, MenuEvent.EXPORT_BOOK_AS_APERY, [
+              AppState.NORMAL,
+            ]),
+            menuItem(`${t.shogiGUIBookFile} (.sbk)`, MenuEvent.EXPORT_BOOK_AS_SBK, [
+              AppState.NORMAL,
+            ]),
+          ],
+        },
         menuItem(t.addMoves, MenuEvent.ADD_BOOK_MOVES, [AppState.NORMAL]),
         { type: "separator" },
         {

--- a/src/command/common/preload.ts
+++ b/src/command/common/preload.ts
@@ -170,9 +170,6 @@ const bridge: Bridge = {
   async showSaveBookDialog(): Promise<string> {
     throw new Error("This feature is not available on command line tool");
   },
-  async showExportBookDialog(): Promise<string> {
-    throw new Error("This feature is not available on command line tool");
-  },
   async clearBook(): Promise<void> {
     throw new Error("This feature is not available on command line tool");
   },

--- a/src/command/common/preload.ts
+++ b/src/command/common/preload.ts
@@ -170,6 +170,9 @@ const bridge: Bridge = {
   async showSaveBookDialog(): Promise<string> {
     throw new Error("This feature is not available on command line tool");
   },
+  async showExportBookDialog(): Promise<string> {
+    throw new Error("This feature is not available on command line tool");
+  },
   async clearBook(): Promise<void> {
     throw new Error("This feature is not available on command line tool");
   },
@@ -183,6 +186,9 @@ const bridge: Bridge = {
     throw new Error("This feature is not available on command line tool");
   },
   async saveBook(): Promise<void> {
+    throw new Error("This feature is not available on command line tool");
+  },
+  async exportBook(): Promise<void> {
     throw new Error("This feature is not available on command line tool");
   },
   async getBookFormat(): Promise<BookFormat> {

--- a/src/common/control/menu.ts
+++ b/src/common/control/menu.ts
@@ -70,4 +70,7 @@ export enum MenuEvent {
   OPEN_BOOK_FILE = "openBookFile",
   SAVE_BOOK_FILE = "saveBookFile",
   ADD_BOOK_MOVES = "addBookMoves",
+  EXPORT_BOOK_AS_YANE2016 = "exportBookAsYane2016",
+  EXPORT_BOOK_AS_APERY = "exportBookAsApery",
+  EXPORT_BOOK_AS_SBK = "exportBookAsSbk",
 }

--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -570,6 +570,7 @@ export const en: Texts = {
   play: "Play",
   edit: "Edit",
   addMoves: "Add Moves",
+  export: "Export",
   flippedBook: "Flipped Book",
   addBookMoves: "Add Book Moves",
   fromCurrentRecord: "From Current Record",
@@ -782,6 +783,9 @@ export const en: Texts = {
     "Any book moves are unsaved. Do you really want to discard them and close the app?",
   cannotOverwriteOnTheFlyBook: "On-the-fly books cannot be overwritten.",
   pleaseSpecifyOtherFileName: "Please specify another file name.",
+  memoryShortageOnBookConversionMayLoseUnsavedData:
+    "Memory shortage during book data conversion may cause loss of unsaved data.",
+  cannotConvertAperyBookToOtherFormat: "Apery book cannot be converted to other formats.",
   sourceRecordFileNotSet: "Source record file is not set.",
   sourceDirectoryNotSet: "Source directory is not set.",
   minPlyMustBeLessThanMaxPly: "Min ply must be less than max ply.",

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -570,6 +570,7 @@ export const ja: Texts = {
   play: "着手",
   edit: "編集",
   addMoves: "指し手追加",
+  export: "エクスポート",
   flippedBook: "反転も検索",
   addBookMoves: "定跡手追加",
   fromCurrentRecord: "現在の棋譜から",
@@ -784,6 +785,9 @@ export const ja: Texts = {
     "保存されていない定跡があります。破棄してアプリを終了しますか？",
   cannotOverwriteOnTheFlyBook: "On-the-fly モードで読み込み中の定跡は上書き保存できません。",
   pleaseSpecifyOtherFileName: "別のファイル名を指定してください。",
+  memoryShortageOnBookConversionMayLoseUnsavedData:
+    "定跡データの変換中にメモリが不足すると保存していないデータは失われる可能性があります。",
+  cannotConvertAperyBookToOtherFormat: "Apery 定跡は他の形式に変換できません。",
   sourceRecordFileNotSet: "棋譜ファイルが指定されていません。",
   sourceDirectoryNotSet: "フォルダを選択してください。",
   minPlyMustBeLessThanMaxPly: "最小手数は最大手数より小さくしてください。",

--- a/src/common/i18n/locales/vi.ts
+++ b/src/common/i18n/locales/vi.ts
@@ -580,6 +580,7 @@ export const vi: Texts = {
   play: "Chơi",
   edit: "Sửa",
   addMoves: "Thêm nước đi",
+  export: "エクスポート", // TODO: Translate
   flippedBook: "Sử dụng book lật ngược",
   addBookMoves: "Thêm định thức",
   fromCurrentRecord: "Từ kỳ phổ này",
@@ -790,6 +791,9 @@ export const vi: Texts = {
     "Có các nước định thức chưa lưu. Bạn có muốn hủy bỏ chúng và đóng ứng dụng?",
   cannotOverwriteOnTheFlyBook: "Không thể ghi đè lên sách đang sử dụng chế độ On-the-fly.",
   pleaseSpecifyOtherFileName: "Vui lòng chọn tên tệp khác.",
+  memoryShortageOnBookConversionMayLoseUnsavedData:
+    "定跡データの変換中にメモリが不足すると保存していないデータは失われる可能性があります。", // TODO: Translate
+  cannotConvertAperyBookToOtherFormat: "Apery 定跡は他の形式に変換できません。", // TODO: Translate
   sourceRecordFileNotSet: "Chưa chỉ định tệp kỳ phổ gốc.",
   sourceDirectoryNotSet: "Vui lòng chọn một tập tin.",
   minPlyMustBeLessThanMaxPly: "Số nước ít nhất phải nhỏ hơn số nước lớn nhất.",

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -577,6 +577,7 @@ export const zh_tw: Texts = {
   play: "著手",
   edit: "編輯",
   addMoves: "新增該手",
+  export: "エクスポート", // TODO: Translate
   flippedBook: "亦檢索先後逆局面",
   addBookMoves: "增加定跡手",
   fromCurrentRecord: "從現在棋譜",
@@ -779,6 +780,9 @@ export const zh_tw: Texts = {
     "存在尚未保存的定跡。您確定要捨棄並關閉本程式嗎？",
   cannotOverwriteOnTheFlyBook: "On-the-fly モードで読み込み中の定跡は上書き保存できません。", // TODO: Translate
   pleaseSpecifyOtherFileName: "別のファイル名を指定してください。", // TODO: Translate
+  memoryShortageOnBookConversionMayLoseUnsavedData:
+    "定跡データの変換中にメモリが不足すると保存していないデータは失われる可能性があります。", // TODO: Translate
+  cannotConvertAperyBookToOtherFormat: "Apery 定跡は他の形式に変換できません。", // TODO: Translate
   sourceRecordFileNotSet: "尚未指定棋譜檔案。",
   sourceDirectoryNotSet: "請選擇目錄。",
   minPlyMustBeLessThanMaxPly: "最小手數應小於最大手數。",

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -563,6 +563,7 @@ export type Texts = {
   play: string;
   edit: string;
   addMoves: string;
+  export: string;
   flippedBook: string;
   addBookMoves: string;
   fromCurrentRecord: string;
@@ -752,6 +753,8 @@ export type Texts = {
   anyBookMovesAreUnsavedDoYouReallyWantToDiscardThemAndCloseTheApp: string;
   cannotOverwriteOnTheFlyBook: string;
   pleaseSpecifyOtherFileName: string;
+  memoryShortageOnBookConversionMayLoseUnsavedData: string;
+  cannotConvertAperyBookToOtherFormat: string;
   sourceRecordFileNotSet: string;
   sourceDirectoryNotSet: string;
   minPlyMustBeLessThanMaxPly: string;

--- a/src/common/ipc/channel.ts
+++ b/src/common/ipc/channel.ts
@@ -44,7 +44,6 @@ export enum Background {
   OPEN_BOOK_AS_NEW_SESSION = "openBookAsNewSession",
   CLOSE_BOOK_SESSION = "closeBookSession",
   SAVE_BOOK = "saveBook",
-  SHOW_EXPORT_BOOK_DIALOG = "showExportBookDialog",
   EXPORT_BOOK = "exportBook",
   SEARCH_BOOK_MOVES = "searchBookMoves",
   UPDATE_BOOK_MOVE = "updateBookMove",

--- a/src/common/ipc/channel.ts
+++ b/src/common/ipc/channel.ts
@@ -44,6 +44,8 @@ export enum Background {
   OPEN_BOOK_AS_NEW_SESSION = "openBookAsNewSession",
   CLOSE_BOOK_SESSION = "closeBookSession",
   SAVE_BOOK = "saveBook",
+  SHOW_EXPORT_BOOK_DIALOG = "showExportBookDialog",
+  EXPORT_BOOK = "exportBook",
   SEARCH_BOOK_MOVES = "searchBookMoves",
   UPDATE_BOOK_MOVE = "updateBookMove",
   REMOVE_BOOK_MOVE = "removeBookMove",

--- a/src/renderer/ipc/api.ts
+++ b/src/renderer/ipc/api.ts
@@ -78,8 +78,7 @@ export interface API {
 
   // Book
   showOpenBookDialog(): Promise<string>;
-  showSaveBookDialog(session: number): Promise<string>;
-  showExportBookDialog(session: number, targetFormat: BookFormat): Promise<string>;
+  showSaveBookDialog(session: number, targetFormat?: BookFormat): Promise<string>;
   openBook(session: number, path: string, options: BookLoadingOptions): Promise<void>;
   openBookAsNewSession(path: string, options: BookLoadingOptions): Promise<number>;
   closeBookSession(session: number): Promise<void>;

--- a/src/renderer/ipc/api.ts
+++ b/src/renderer/ipc/api.ts
@@ -79,10 +79,12 @@ export interface API {
   // Book
   showOpenBookDialog(): Promise<string>;
   showSaveBookDialog(session: number): Promise<string>;
+  showExportBookDialog(session: number, targetFormat: BookFormat): Promise<string>;
   openBook(session: number, path: string, options: BookLoadingOptions): Promise<void>;
   openBookAsNewSession(path: string, options: BookLoadingOptions): Promise<number>;
   closeBookSession(session: number): Promise<void>;
   saveBook(session: number, path: string): Promise<void>;
+  exportBook(session: number, path: string, targetFormat: BookFormat): Promise<void>;
   clearBook(session: number, format?: BookFormat): Promise<void>;
   getBookFormat(session: number): Promise<BookFormat>;
   searchBookMoves(session: number, sfen: string): Promise<BookMove[]>;

--- a/src/renderer/ipc/bridge.ts
+++ b/src/renderer/ipc/bridge.ts
@@ -58,8 +58,7 @@ export interface Bridge {
 
   // Book
   showOpenBookDialog(): Promise<string>;
-  showSaveBookDialog(session: number): Promise<string>;
-  showExportBookDialog(session: number, targetFormat: BookFormat): Promise<string>;
+  showSaveBookDialog(session: number, targetFormat?: BookFormat): Promise<string>;
   openBook(session: number, path: string, json: string): Promise<void>;
   openBookAsNewSession(path: string, json: string): Promise<number>;
   closeBookSession(session: number): Promise<void>;

--- a/src/renderer/ipc/bridge.ts
+++ b/src/renderer/ipc/bridge.ts
@@ -59,10 +59,12 @@ export interface Bridge {
   // Book
   showOpenBookDialog(): Promise<string>;
   showSaveBookDialog(session: number): Promise<string>;
+  showExportBookDialog(session: number, targetFormat: BookFormat): Promise<string>;
   openBook(session: number, path: string, json: string): Promise<void>;
   openBookAsNewSession(path: string, json: string): Promise<number>;
   closeBookSession(session: number): Promise<void>;
   saveBook(session: number, path: string): Promise<void>;
+  exportBook(session: number, path: string, targetFormat: BookFormat): Promise<void>;
   clearBook(session: number, format?: BookFormat): Promise<void>;
   getBookFormat(session: number): Promise<BookFormat>;
   searchBookMoves(session: number, sfen: string): Promise<string>;

--- a/src/renderer/ipc/preload.ts
+++ b/src/renderer/ipc/preload.ts
@@ -151,11 +151,8 @@ const api: Bridge = {
   async showOpenBookDialog(): Promise<string> {
     return await ipcRenderer.invoke(Background.SHOW_OPEN_BOOK_DIALOG);
   },
-  async showSaveBookDialog(session: number): Promise<string> {
-    return await ipcRenderer.invoke(Background.SHOW_SAVE_BOOK_DIALOG, session);
-  },
-  async showExportBookDialog(session: number, targetFormat: BookFormat): Promise<string> {
-    return await ipcRenderer.invoke(Background.SHOW_EXPORT_BOOK_DIALOG, session, targetFormat);
+  async showSaveBookDialog(session: number, targetFormat?: BookFormat): Promise<string> {
+    return await ipcRenderer.invoke(Background.SHOW_SAVE_BOOK_DIALOG, session, targetFormat);
   },
   async clearBook(session: number, format?: BookFormat): Promise<void> {
     return await ipcRenderer.invoke(Background.CLEAR_BOOK, session, format);

--- a/src/renderer/ipc/preload.ts
+++ b/src/renderer/ipc/preload.ts
@@ -154,6 +154,9 @@ const api: Bridge = {
   async showSaveBookDialog(session: number): Promise<string> {
     return await ipcRenderer.invoke(Background.SHOW_SAVE_BOOK_DIALOG, session);
   },
+  async showExportBookDialog(session: number, targetFormat: BookFormat): Promise<string> {
+    return await ipcRenderer.invoke(Background.SHOW_EXPORT_BOOK_DIALOG, session, targetFormat);
+  },
   async clearBook(session: number, format?: BookFormat): Promise<void> {
     return await ipcRenderer.invoke(Background.CLEAR_BOOK, session, format);
   },
@@ -168,6 +171,9 @@ const api: Bridge = {
   },
   async saveBook(session: number, path: string): Promise<void> {
     return await ipcRenderer.invoke(Background.SAVE_BOOK, session, path);
+  },
+  async exportBook(session: number, path: string, targetFormat: BookFormat): Promise<void> {
+    return await ipcRenderer.invoke(Background.EXPORT_BOOK, session, path, targetFormat);
   },
   async getBookFormat(session: number): Promise<BookFormat> {
     return await ipcRenderer.invoke(Background.GET_BOOK_FORMAT, session);

--- a/src/renderer/ipc/setup.ts
+++ b/src/renderer/ipc/setup.ts
@@ -311,6 +311,15 @@ export function setup(): void {
       case MenuEvent.ADD_BOOK_MOVES:
         store.showAddBookMovesDialog();
         break;
+      case MenuEvent.EXPORT_BOOK_AS_YANE2016:
+        useBookStore().exportBookFile("yane2016");
+        break;
+      case MenuEvent.EXPORT_BOOK_AS_APERY:
+        useBookStore().exportBookFile("apery");
+        break;
+      case MenuEvent.EXPORT_BOOK_AS_SBK:
+        useBookStore().exportBookFile("sbk");
+        break;
     }
   });
 

--- a/src/renderer/ipc/web.ts
+++ b/src/renderer/ipc/web.ts
@@ -257,9 +257,6 @@ export const webAPI: Bridge = {
   async showSaveBookDialog(): Promise<string> {
     throw new Error(t.thisFeatureNotAvailableOnWebApp);
   },
-  async showExportBookDialog(): Promise<string> {
-    throw new Error(t.thisFeatureNotAvailableOnWebApp);
-  },
   async clearBook(): Promise<void> {
     throw new Error(t.thisFeatureNotAvailableOnWebApp);
   },

--- a/src/renderer/ipc/web.ts
+++ b/src/renderer/ipc/web.ts
@@ -257,6 +257,9 @@ export const webAPI: Bridge = {
   async showSaveBookDialog(): Promise<string> {
     throw new Error(t.thisFeatureNotAvailableOnWebApp);
   },
+  async showExportBookDialog(): Promise<string> {
+    throw new Error(t.thisFeatureNotAvailableOnWebApp);
+  },
   async clearBook(): Promise<void> {
     throw new Error(t.thisFeatureNotAvailableOnWebApp);
   },
@@ -270,6 +273,9 @@ export const webAPI: Bridge = {
     throw new Error(t.thisFeatureNotAvailableOnWebApp);
   },
   async saveBook(): Promise<void> {
+    throw new Error(t.thisFeatureNotAvailableOnWebApp);
+  },
+  async exportBook(): Promise<void> {
     throw new Error(t.thisFeatureNotAvailableOnWebApp);
   },
   async getBookFormat(): Promise<BookFormat> {

--- a/src/renderer/store/book.ts
+++ b/src/renderer/store/book.ts
@@ -133,7 +133,7 @@ export class BookStore {
     const doExport = () => {
       useBusyState().retain();
       api
-        .showExportBookDialog(defaultBookSession, targetFormat)
+        .showSaveBookDialog(defaultBookSession, targetFormat)
         .then(async (path) => {
           if (path) {
             await api.exportBook(defaultBookSession, path, targetFormat);

--- a/src/renderer/store/book.ts
+++ b/src/renderer/store/book.ts
@@ -126,6 +126,36 @@ export class BookStore {
       });
   }
 
+  exportBookFile(targetFormat: BookFormat) {
+    if (useBusyState().isBusy) {
+      return;
+    }
+    const doExport = () => {
+      useBusyState().retain();
+      api
+        .showExportBookDialog(defaultBookSession, targetFormat)
+        .then(async (path) => {
+          if (path) {
+            await api.exportBook(defaultBookSession, path, targetFormat);
+          }
+        })
+        .catch((e) => {
+          useErrorStore().add(e);
+        })
+        .finally(() => {
+          useBusyState().release();
+        });
+    };
+    if (targetFormat === "sbk") {
+      useConfirmationStore().show({
+        message: t.memoryShortageOnBookConversionMayLoseUnsavedData,
+        onOk: doExport,
+      });
+    } else {
+      doExport();
+    }
+  }
+
   async updateMove(sfen: string, move: BookMove) {
     useBusyState().retain();
     return api

--- a/src/renderer/store/book.ts
+++ b/src/renderer/store/book.ts
@@ -146,14 +146,10 @@ export class BookStore {
           useBusyState().release();
         });
     };
-    if (targetFormat === "sbk") {
-      useConfirmationStore().show({
-        message: t.memoryShortageOnBookConversionMayLoseUnsavedData,
-        onOk: doExport,
-      });
-    } else {
-      doExport();
-    }
+    useConfirmationStore().show({
+      message: t.memoryShortageOnBookConversionMayLoseUnsavedData,
+      onOk: doExport,
+    });
   }
 
   async updateMove(sfen: string, move: BookMove) {

--- a/src/tests/background/book/index.spec.ts
+++ b/src/tests/background/book/index.spec.ts
@@ -4,6 +4,7 @@ import crypto from "node:crypto";
 import {
   clearBook,
   closeBookSession,
+  exportBook,
   getBookFormat,
   importBookMoves,
   openBook,
@@ -692,6 +693,98 @@ sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1
       expect(mode).toBe("on-the-fly");
       await expect(saveBook(defaultBookSession, path)).rejects.toThrowError(
         "On-the-fly モードで読み込み中の定跡は上書き保存できません。 別のファイル名を指定してください。",
+      );
+    });
+  });
+
+  describe("exportBook", () => {
+    const sfen1 = "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1";
+    const sfen2 = "lnsgkgsnl/1r5b1/ppppppppp/9/9/2P6/PP1PPPPPP/1B5R1/LNSGKGSNL w - 1";
+
+    it("yane2016 → yane2016 (in-memory)", async () => {
+      await updateBookMove(defaultBookSession, sfen1, {
+        usi: "2g2f",
+        score: 50,
+        depth: 10,
+        count: 1,
+        comment: "",
+      });
+
+      const outPath = path.join(tmpdir, "export-yane-same.db");
+      await exportBook(defaultBookSession, outPath, "yane2016");
+
+      const output = fs.readFileSync(outPath, "utf-8");
+      expect(output).toContain("2g2f");
+    });
+
+    it("apery → apery (in-memory)", async () => {
+      await openBook(defaultBookSession, "src/tests/testdata/book/apery.bin");
+      await updateBookMove(defaultBookSession, sfen2, {
+        usi: "8c8d",
+        score: 0,
+        count: 1,
+        comment: "",
+      });
+
+      const outPath = path.join(tmpdir, "export-apery-same.bin");
+      await exportBook(defaultBookSession, outPath, "apery");
+
+      expect(fs.readFileSync(outPath, "hex").length).toBeGreaterThan(0);
+    });
+
+    it("yane2016 → sbk: moves preserved", async () => {
+      await openBook(defaultBookSession, "src/tests/testdata/book/yaneuraou.db");
+      const outPath = path.join(tmpdir, "export-yane-to-sbk.sbk");
+      await exportBook(defaultBookSession, outPath, "sbk");
+
+      const sbk = loadSbkBook(fs.readFileSync(outPath));
+      expect(sbk.entries.get(sfen1)?.moves.length).toBeGreaterThan(0);
+      expect(sbk.entries.get(sfen2)?.moves.length).toBeGreaterThan(0);
+    });
+
+    it("yane2016 → yane2016 (on-the-fly): moves preserved", async () => {
+      const mode = await openBook(defaultBookSession, "src/tests/testdata/book/yaneuraou.db", {
+        onTheFlyThresholdMB: 0.0001,
+      });
+      expect(mode).toBe("on-the-fly");
+
+      const outPath = path.join(tmpdir, "export-yane-otf-same.db");
+      await exportBook(defaultBookSession, outPath, "yane2016");
+
+      const expected = fs.readFileSync("src/tests/testdata/book/yaneuraou-copy.db", "utf-8");
+      expect(fs.readFileSync(outPath, "utf-8")).toBe(expected);
+    });
+
+    it("yane2016 (on-the-fly) → sbk: moves preserved", async () => {
+      const mode = await openBook(defaultBookSession, "src/tests/testdata/book/yaneuraou.db", {
+        onTheFlyThresholdMB: 0.0001,
+      });
+      expect(mode).toBe("on-the-fly");
+
+      const outPath = path.join(tmpdir, "export-yane-otf-to-sbk.sbk");
+      await exportBook(defaultBookSession, outPath, "sbk");
+
+      const sbk = loadSbkBook(fs.readFileSync(outPath));
+      expect(sbk.entries.get(sfen1)?.moves.length).toBeGreaterThan(0);
+    });
+
+    it("apery → yane2016: throws", async () => {
+      await openBook(defaultBookSession, "src/tests/testdata/book/apery.bin");
+      const outPath = path.join(tmpdir, "export-apery-to-yane.db");
+      await expect(exportBook(defaultBookSession, outPath, "yane2016")).rejects.toThrow();
+    });
+
+    it("wrong extension: throws", async () => {
+      await updateBookMove(defaultBookSession, sfen1, {
+        usi: "2g2f",
+        score: 0,
+        count: 1,
+        comment: "",
+      });
+      // cross-format export to sbk but with wrong .db extension
+      const outPath = path.join(tmpdir, "export-wrong-ext.db");
+      await expect(exportBook(defaultBookSession, outPath, "sbk")).rejects.toThrow(
+        "Invalid file extension",
       );
     });
   });


### PR DESCRIPTION
# 説明 / Description

#1518 

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/shogihome/blob/main/CONTRIBUTING.md)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [x] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Export books to Yane2016, Apery, and SBK formats via new Export menu with confirmation about potential memory-related data loss.

* **Integration**
  * Renderer and background flows wired so the save dialog and export action invoke the export operation; UI shows busy state and surfaces errors.

* **Behavior**
  * Enforces correct filename extensions, blocks unsupported conversions, and preserves existing data when converting across formats.

* **Localization**
  * Added export label and conversion messages for EN/JA/VI/ZH_TW.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->