### PR TITLE
Update loadSbkBook()

### DIFF
--- a/src/background/book/sbk.ts
+++ b/src/background/book/sbk.ts
@@ -1,6 +1,6 @@
 import events from "node:events";
 import { Writable } from "node:stream";
-import { Position } from "tsshogi";
+import { Move, Position } from "tsshogi";
 import {
   SBook,
   SBookMove as SBookMoveProto,
@@ -36,64 +36,34 @@ function normalizeSfen(position: string): string | undefined {
 export function loadSbkBook(data: Buffer | Uint8Array): SbkBook {
   const book = SBook.decode(data);
 
-  // Position フィールドを持つ局面をシードとして BFS で SFEN を伝播させる
   const idToState = new Map<number, SBookState>();
   const idToSfen = new Map<number, string>();
-  const queue: number[] = [];
+  const rootIds: number[] = [];
   for (const state of book.BookStates) {
     idToState.set(state.Id, state);
     if (state.Position) {
       const sfen = normalizeSfen(state.Position);
       if (sfen && !idToSfen.has(state.Id)) {
         idToSfen.set(state.Id, sfen);
-        queue.push(state.Id);
+        rootIds.push(state.Id);
       }
     }
   }
 
-  for (let head = 0; head < queue.length; head++) {
-    const stateId = queue[head];
-    const sfen = idToSfen.get(stateId)!;
-    const state = idToState.get(stateId);
-    if (!state) {
-      continue;
-    }
-
-    const pos = Position.newBySFEN(sfen);
-    if (!pos) {
-      continue;
-    }
-
-    for (const m of state.Moves) {
-      if (m.NextStateId < 0 || idToSfen.has(m.NextStateId)) {
-        continue;
-      }
-      const usi = fromSbkMove(m.Move);
-      const move = pos.createMoveByUSI(usi);
-      if (!move || !pos.doMove(move)) {
-        continue;
-      }
-      idToSfen.set(m.NextStateId, pos.sfen);
-      queue.push(m.NextStateId);
-      pos.undoMove(move);
-    }
-  }
-
-  // SFEN が確定した局面をエントリーとして登録
   const entries = new Map<string, BookEntry>();
-  for (const state of book.BookStates) {
-    const sfen = idToSfen.get(state.Id);
-    if (!sfen) {
-      continue;
-    }
-
-    const pos = Position.newBySFEN(sfen);
-    const moves: BookMove[] = state.Moves.flatMap((m) => {
-      const usi = fromSbkMove(m.Move);
-      if (!pos || !pos.createMoveByUSI(usi)) {
-        return [];
-      }
-      return [[usi, undefined, undefined, undefined, m.Weight || undefined, "", m.Evaluation]];
+  function addEntry(sfen: string, state: SBookState, moves: Move[]) {
+    const sbkMoves: BookMove[] = state.Moves.flatMap((m, index) => {
+      return [
+        [
+          moves[index].usi,
+          undefined,
+          undefined,
+          undefined,
+          m.Weight || undefined,
+          "",
+          m.Evaluation,
+        ],
+      ];
     });
 
     const sbkEvals: SbkEval[] = state.Evals.map((e) => ({
@@ -108,13 +78,56 @@ export function loadSbkBook(data: Buffer | Uint8Array): SbkBook {
     entries.set(sfen, {
       type: "normal",
       comment: state.Comment ?? "",
-      moves,
+      moves: sbkMoves,
       minPly: 0,
       games: state.Games,
       wonBlack: state.WonBlack,
       wonWhite: state.WonWhite,
       sbkEvals: sbkEvals.length > 0 ? sbkEvals : undefined,
     });
+  }
+
+  for (const rootId of rootIds) {
+    const rootSfen = idToSfen.get(rootId)!;
+    const pos = Position.newBySFEN(rootSfen);
+    if (!pos) {
+      continue;
+    }
+    const stack: { state: SBookState; moves: Move[]; index: number; lastMove?: Move }[] = [];
+    const rootState = idToState.get(rootId)!;
+    const moves = rootState.Moves.map((m) => fromSbkMove(pos, m.Move));
+    stack.push({ state: rootState, moves, index: 0 });
+    addEntry(rootSfen, rootState, moves);
+    while (stack.length > 0) {
+      const frame = stack[stack.length - 1];
+      if (frame.index >= frame.moves.length) {
+        stack.pop();
+        if (frame.lastMove) {
+          pos.undoMove(frame.lastMove);
+        }
+        continue;
+      }
+      const sbkMove = frame.state.Moves[frame.index];
+      const move = frame.moves[frame.index];
+      frame.index++;
+      const nextStateId = sbkMove.NextStateId;
+      if (idToSfen.has(nextStateId)) {
+        continue;
+      }
+      if (!pos.doMove(move, { ignoreValidation: true })) {
+        continue;
+      }
+      const nextState = idToState.get(nextStateId);
+      if (!nextState) {
+        pos.undoMove(move);
+        continue;
+      }
+      const nextSfen = pos.sfen;
+      idToSfen.set(nextStateId, nextSfen);
+      const nextMoves = nextState.Moves.map((m) => fromSbkMove(pos, m.Move));
+      stack.push({ state: nextState, moves: nextMoves, index: 0, lastMove: move });
+      addEntry(nextSfen, nextState, nextMoves);
+    }
   }
 
   return { format: "sbk", entries, sbkAuthor: book.Author, sbkDescription: book.Description };

--- a/src/background/book/sbk.ts
+++ b/src/background/book/sbk.ts
@@ -245,7 +245,12 @@ export async function storeSbkBook(book: SbkBook, output: Writable): Promise<voi
           continue;
         }
         const nextSfen = pos.sfen;
-        const nextStateId = sfenToId.get(nextSfen) ?? -1;
+        const nextStateId = sfenToId.get(nextSfen);
+        if (nextStateId === undefined) {
+          // ロジック上は必ず遷移先の ID が存在するのでここに到達することは無い
+          pos.undoMove(move);
+          continue;
+        }
         sbkMoves.push({
           Move: toSbkMove(move),
           Evaluation: bookMove[IDX_EVALUATION] as SBookMoveEvaluation,

--- a/src/background/book/sbk.ts
+++ b/src/background/book/sbk.ts
@@ -52,6 +52,18 @@ export function loadSbkBook(data: Buffer | Uint8Array): SbkBook {
 
   const entries = new Map<string, BookEntry>();
   function addEntry(sfen: string, state: SBookState, moves: Move[]) {
+    // 何も情報を持たないリーフノードを除外
+    if (
+      state.Moves.length === 0 &&
+      state.Evals.length === 0 &&
+      !state.Comment &&
+      !state.Games &&
+      !state.WonBlack &&
+      !state.WonWhite
+    ) {
+      return;
+    }
+
     const sbkMoves: BookMove[] = state.Moves.flatMap((m, index) => {
       return [
         [

--- a/src/background/book/sbk.ts
+++ b/src/background/book/sbk.ts
@@ -64,17 +64,15 @@ export function loadSbkBook(data: Buffer | Uint8Array): SbkBook {
       return;
     }
 
-    const sbkMoves: BookMove[] = state.Moves.flatMap((m, index) => {
+    const bookMoves: BookMove[] = state.Moves.map((m, index) => {
       return [
-        [
-          moves[index].usi,
-          undefined,
-          undefined,
-          undefined,
-          m.Weight || undefined,
-          "",
-          m.Evaluation,
-        ],
+        moves[index].usi, // usi
+        undefined, // usi2
+        undefined, // score
+        undefined, // depth
+        m.Weight || undefined, // count
+        "", // comment
+        m.Evaluation, // evaluation
       ];
     });
 
@@ -90,7 +88,7 @@ export function loadSbkBook(data: Buffer | Uint8Array): SbkBook {
     entries.set(sfen, {
       type: "normal",
       comment: state.Comment ?? "",
-      moves: sbkMoves,
+      moves: bookMoves,
       minPly: 0,
       games: state.Games,
       wonBlack: state.WonBlack,

--- a/src/background/book/sbk_move.ts
+++ b/src/background/book/sbk_move.ts
@@ -1,6 +1,4 @@
-import { Color, Move, PieceType, Square, pieceTypeToSFEN } from "tsshogi";
-
-const rankChars = "abcdefghi";
+import { Color, ImmutablePosition, Move, PieceType, Square } from "tsshogi";
 
 // C# Piece enum index (with WhiteFlag stripped) → tsshogi PieceType
 // C# order: Pawn=1, Lance=2, Knight=3, Silver=4, Gold=5, Bishop=6, Rook=7, King=8
@@ -45,7 +43,7 @@ function sbkPieceValue(pt: PieceType, color: Color): number {
   return (pieceTypeToSbkIndex[pt] ?? 0) | (color === Color.WHITE ? 0x10 : 0);
 }
 
-export function fromSbkMove(value: number): string {
+export function fromSbkMove(pos: ImmutablePosition, value: number): Move {
   const fromDan = value & 0xf;
   const fromSuji = (value >>> 4) & 0xf;
   const toDan = (value >>> 8) & 0xf;
@@ -53,16 +51,16 @@ export function fromSbkMove(value: number): string {
   const promote = (value >>> 19) & 1;
   const piece = (value >>> 24) & 0x1f;
 
-  const toStr = toSuji.toString() + rankChars[toDan - 1];
+  const pt = sbkPieceTypeMap[piece & 0x0f];
+  const to = new Square(toSuji, toDan);
 
   if (fromDan === 0 && fromSuji === 0) {
-    // Drop move: strip WhiteFlag (bit 4) to get piece type index
-    const pt = sbkPieceTypeMap[piece & 0x0f];
-    return pieceTypeToSFEN(pt) + "*" + toStr;
+    return new Move(pt, to, false, pos.color, pt, null);
   }
 
-  const fromStr = fromSuji.toString() + rankChars[fromDan - 1];
-  return fromStr + toStr + (promote ? "+" : "");
+  const from = new Square(fromSuji, fromDan);
+  const captured = pos.board.at(to);
+  return new Move(from, to, promote === 1, pos.color, pt, captured && captured.type);
 }
 
 export function toSbkMove(move: Move): number {


### PR DESCRIPTION
# 説明 / Description

BFS を DFS へ変更して局面を差分計算することにより .sbk の読み込み速度を改善する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/shogihome/blob/main/CONTRIBUTING.md)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Faster, more memory-efficient book loading via a streamlined traversal.
  * Move lists are precomputed and reused during import, reducing redundant decoding.
  * Improved move decoding during import for more accurate move representation.
  * Skips empty leaf entries (no moves/evals/comments/win) to keep the book cleaner.
  * More robust handling of missing state links to avoid creating invalid entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->