### PR TITLE
Avoid SBK export GC thrash under memory pressure

### DIFF
--- a/src/background/book/sbk.ts
+++ b/src/background/book/sbk.ts
@@ -1,5 +1,7 @@
 import events from "node:events";
 import { Writable } from "node:stream";
+import v8 from "node:v8";
+import { setImmediate as setImmediatePromise } from "node:timers/promises";
 import { Move, Position } from "tsshogi";
 import { BinaryWriter } from "@bufbuild/protobuf/wire";
 import {
@@ -142,6 +144,28 @@ export function loadSbkBook(data: Buffer | Uint8Array): SbkBook {
 }
 
 export async function storeSbkBook(book: SbkBook, output: Writable): Promise<void> {
+  // storeSbkBook は巨大な棋譜木を扱う時に CPU を占有しやすいため、
+  // 適度にイベントループへ制御を戻す。
+  const YIELD_INTERVAL = 4096;
+  // 一時データ構築中にヒープが逼迫すると GC ループに入り、
+  // 100% CPU のまま UI が応答不能になるため、OOM 直前で中断する。
+  const MEMORY_CHECK_INTERVAL = 2048;
+  const HEAP_USAGE_ABORT_RATIO = 0.92;
+  let operationCount = 0;
+
+  async function maybeYieldAndCheckMemory() {
+    operationCount++;
+    if (operationCount % YIELD_INTERVAL === 0) {
+      await setImmediatePromise();
+    }
+    if (operationCount % MEMORY_CHECK_INTERVAL === 0) {
+      const { used_heap_size, heap_size_limit } = v8.getHeapStatistics();
+      if (used_heap_size / heap_size_limit >= HEAP_USAGE_ABORT_RATIO) {
+        throw new Error("SBK export aborted: memory pressure is too high.");
+      }
+    }
+  }
+
   // SFEN の記述を最小限にしてデータを削減するためにルートではないノードを列挙する。
   const nonRootSfens = new Set<string>();
 
@@ -175,6 +199,7 @@ export async function storeSbkBook(book: SbkBook, output: Writable): Promise<voi
       }
       const bookMove = frame.bookMoves[frame.index];
       frame.index++;
+      await maybeYieldAndCheckMemory();
       const move = pos.createMoveByUSI(bookMove.usi);
       if (!move || !pos.doMove(move, { ignoreValidation: true })) {
         continue;
@@ -254,6 +279,7 @@ export async function storeSbkBook(book: SbkBook, output: Writable): Promise<voi
   await writeBytes(headerWriter.finish());
 
   async function writeState(sfen: string, entry: BookEntry): Promise<void> {
+    await maybeYieldAndCheckMemory();
     const edges = sfenToEdges.get(sfen) ?? [];
     const sbkMoves: SBookMoveProto[] = edges.map(([bookMove, move, nextSfen]) => ({
       Move: move,


### PR DESCRIPTION
### Motivation
- `storeSbkBook` can process very large game trees and previously held large temporary structures while running long, tight loops without yielding, which can trigger V8 GC thrashing and cause the process to peg CPU at 100% and become unresponsive.

### Description
- Add cooperative yielding and periodic memory checks inside `storeSbkBook` by introducing `maybeYieldAndCheckMemory` and calling it during the DFS and state-writing phases to return control to the event loop regularly.
- Use `v8.getHeapStatistics()` and a configurable threshold (`HEAP_USAGE_ABORT_RATIO = 0.92`) to abort export early with an explicit error when heap usage is dangerously high.
- Define `YIELD_INTERVAL` and `MEMORY_CHECK_INTERVAL` and invoke the helper from the DFS loop and `writeState`, and add imports for `v8` and `setImmediate` from `node:timers/promises`.
- The change preserves export semantics for normal-sized books while improving failure behavior for very large exports by throwing `Error("SBK export aborted: memory pressure is too high.")` before OOM/GC thrash.

### Testing
- Ran `npx vitest run src/tests/background/book/sbk.spec.ts` and all tests in that file passed (`4 tests` passed).
- Running `npm run -s test -- src/tests/background/book/sbk.spec.ts` failed during dependency fetching with a network `ECONNRESET` error, so the project-level test runner was not completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7ceb475388321a464f8602a1b8e96)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of export operations by implementing memory pressure monitoring that gracefully halts exports when memory usage reaches critical thresholds, preventing potential crashes during resource-constrained scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->