### PR TITLE
カスタムレイアウト機能に消費時間チャートを追加

### DIFF
--- a/src/common/settings/layout.ts
+++ b/src/common/settings/layout.ts
@@ -88,6 +88,11 @@ type SimpleBoard = {
   bookmark?: boolean;
 };
 
+type ElapsedTimeChart = {
+  type: "ElapsedTimeChart";
+  showLegend?: boolean;
+};
+
 export type UIComponent = UIComponentCommon &
   (
     | Board
@@ -100,6 +105,7 @@ export type UIComponent = UIComponentCommon &
     | ControlGroup1
     | ControlGroup2
     | SimpleBoard
+    | ElapsedTimeChart
   );
 
 export enum DialogPosition {

--- a/src/renderer/view/dialog/ElapsedTimeChartDialog.vue
+++ b/src/renderer/view/dialog/ElapsedTimeChartDialog.vue
@@ -40,7 +40,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, reactive } from "vue";
+import { computed } from "vue";
 import { Move, ImmutablePosition } from "tsshogi";
 import { useStore } from "@/renderer/store";
 import { useAppSettings } from "@/renderer/store/settings";
@@ -55,7 +55,7 @@ import { getRecordShortcutKeys } from "@/renderer/view/primitive/board/shortcut"
 
 const store = useStore();
 const appSettings = useAppSettings();
-const boardMaxSize = reactive(new RectSize(200, 500));
+const boardMaxSize = new RectSize(200, 200);
 
 const shortcutKeys = computed(() => getRecordShortcutKeys(appSettings.recordShortcutKeys));
 

--- a/src/renderer/view/dialog/ElapsedTimeChartDialog.vue
+++ b/src/renderer/view/dialog/ElapsedTimeChartDialog.vue
@@ -15,8 +15,7 @@
       <div class="chart-area">
         <ElapsedTimeChart
           :thema="appSettings.thema"
-          :moves="store.record.moves"
-          :selected-ply="selectedPly"
+          :record="store.record"
           :show-legend="true"
           @click-ply="(ply) => store.changePly(ply)"
         />
@@ -59,8 +58,6 @@ const appSettings = useAppSettings();
 const boardMaxSize = reactive(new RectSize(200, 500));
 
 const shortcutKeys = computed(() => getRecordShortcutKeys(appSettings.recordShortcutKeys));
-
-const selectedPly = computed(() => store.record.current.ply);
 
 const selectedPosition = computed<ImmutablePosition>(() => store.record.position);
 

--- a/src/renderer/view/dialog/ElapsedTimeChartDialog.vue
+++ b/src/renderer/view/dialog/ElapsedTimeChartDialog.vue
@@ -13,7 +13,13 @@
         </div>
       </div>
       <div class="chart-area">
-        <canvas ref="canvas"></canvas>
+        <ElapsedTimeChart
+          :thema="appSettings.thema"
+          :moves="store.record.moves"
+          :selected-ply="selectedPly"
+          :show-legend="true"
+          @click-ply="(ply) => store.changePly(ply)"
+        />
       </div>
     </div>
     <div class="main-buttons">
@@ -35,58 +41,22 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, reactive, ref, watch } from "vue";
-import { Color, Move, ImmutablePosition, reverseColor } from "tsshogi";
-import { Chart, ActiveElement, ChartEvent } from "chart.js";
+import { computed, reactive } from "vue";
+import { Move, ImmutablePosition } from "tsshogi";
 import { useStore } from "@/renderer/store";
 import { useAppSettings } from "@/renderer/store/settings";
-import { Thema } from "@/common/settings/app";
 import { t } from "@/common/i18n";
 import { RectSize } from "@/common/assets/geometry";
 import DialogFrame from "./DialogFrame.vue";
 import SimpleBoardView from "@/renderer/view/primitive/SimpleBoardView.vue";
+import ElapsedTimeChart from "@/renderer/view/primitive/ElapsedTimeChart.vue";
 import Icon from "@/renderer/view/primitive/Icon.vue";
 import { IconType } from "@/renderer/assets/icons";
 import { getRecordShortcutKeys } from "@/renderer/view/primitive/board/shortcut";
 
-type ColorPalette = {
-  main: string;
-  ticks: string;
-  grid: string;
-  blackPlayer: string;
-  whitePlayer: string;
-  selected: string;
-};
-
-function getColorPalette(thema: Thema): ColorPalette {
-  switch (thema) {
-    default:
-      return {
-        main: "black",
-        ticks: "dimgray",
-        grid: "lightgray",
-        blackPlayer: "#1480C9",
-        whitePlayer: "#FB7D00",
-        selected: "red",
-      };
-    case Thema.DARK_GREEN:
-    case Thema.DARK:
-      return {
-        main: "white",
-        ticks: "darkgray",
-        grid: "dimgray",
-        blackPlayer: "#36A2EB",
-        whitePlayer: "#FF9F40",
-        selected: "red",
-      };
-  }
-}
-
 const store = useStore();
 const appSettings = useAppSettings();
-const canvas = ref<HTMLCanvasElement>();
 const boardMaxSize = reactive(new RectSize(200, 500));
-let chart: Chart | undefined;
 
 const shortcutKeys = computed(() => getRecordShortcutKeys(appSettings.recordShortcutKeys));
 
@@ -94,7 +64,7 @@ const selectedPly = computed(() => store.record.current.ply);
 
 const selectedPosition = computed<ImmutablePosition>(() => store.record.position);
 
-const selectedLastMove = computed<Move | null>(() => {
+const selectedLastMove = computed(() => {
   const move = store.record.current.move;
   return move instanceof Move ? move : null;
 });
@@ -107,210 +77,9 @@ const selectedMoveText = computed(() => {
   return `${plyText} ${node.displayText} ${timeText}`;
 });
 
-const buildChart = () => {
-  if (!canvas.value) {
-    return;
-  }
-  const palette = getColorPalette(appSettings.thema);
-
-  // Build label and data arrays, always showing at least up to ply 30
-  const labels: string[] = [];
-  const blackData: (number | null)[] = [];
-  const whiteData: (number | null)[] = [];
-
-  const nodes = store.record.moves;
-  const nodeMap = new Map<number, (typeof nodes)[0]>();
-  for (const node of nodes) {
-    if (node.ply > 0) {
-      nodeMap.set(node.ply, node);
-    }
-  }
-  const lastPly = nodes.length > 1 ? nodes[nodes.length - 1].ply : 0;
-  const maxPly = Math.max(30, lastPly);
-
-  for (let ply = 1; ply <= maxPly; ply++) {
-    labels.push(String(ply));
-    const node = nodeMap.get(ply);
-    if (node) {
-      // 通常の指し手は nextColor が次手番（指した人の反対色）なので reverseColor が必要。
-      // 投了等のスペシャルムーブは局面が更新されず nextColor が指した人自身の色になる。
-      const moverColor = node.move instanceof Move ? reverseColor(node.nextColor) : node.nextColor;
-      const isBlack = moverColor === Color.BLACK;
-      const seconds = node.elapsedMs > 0 ? node.elapsedMs / 1000 : null;
-      if (isBlack) {
-        blackData.push(seconds);
-        whiteData.push(null);
-      } else {
-        blackData.push(null);
-        whiteData.push(seconds);
-      }
-    } else {
-      blackData.push(null);
-      whiteData.push(null);
-    }
-  }
-
-  const plyIndicatorPlugin = {
-    id: "plyIndicator",
-    afterDraw(ch: Chart) {
-      const ply = selectedPly.value;
-      if (ply <= 0) {
-        return;
-      }
-      const index = ply - 1;
-      let barX: number | null = null;
-      let barTopY: number | null = null;
-      for (let di = 0; di < ch.data.datasets.length; di++) {
-        const value = ch.data.datasets[di].data[index];
-        if (value === null || value === undefined) {
-          continue;
-        }
-        const bar = ch.getDatasetMeta(di).data[index];
-        if (!bar) {
-          continue;
-        }
-        barX = bar.x;
-        barTopY = bar.y;
-        break;
-      }
-      if (barX === null) {
-        // バーデータがない場合（消費時間が 0 など）はスケールから X 座標を取得する。
-        const xScale = ch.scales.x;
-        if (!xScale) {
-          return;
-        }
-        barX = xScale.getPixelForValue(index);
-        barTopY = ch.chartArea.bottom;
-      }
-      if (barX === null || barTopY === null) {
-        return;
-      }
-      const size = 7;
-      const ctx = ch.ctx;
-      ctx.save();
-      ctx.beginPath();
-      ctx.moveTo(barX - size, barTopY - size * 2 - 2);
-      ctx.lineTo(barX + size, barTopY - size * 2 - 2);
-      ctx.lineTo(barX, barTopY - 2);
-      ctx.closePath();
-      ctx.fillStyle = palette.selected;
-      ctx.fill();
-      ctx.restore();
-    },
-  };
-
-  const context = canvas.value.getContext("2d", {
-    desynchronized: true,
-  }) as CanvasRenderingContext2D;
-  chart = new Chart(context, {
-    type: "bar",
-    plugins: [plyIndicatorPlugin],
-    data: {
-      labels,
-      datasets: [
-        {
-          label: t.sente,
-          data: blackData,
-          backgroundColor: palette.blackPlayer,
-        },
-        {
-          label: t.gote,
-          data: whiteData,
-          backgroundColor: palette.whitePlayer,
-        },
-      ],
-    },
-    options: {
-      animation: false,
-      responsive: true,
-      maintainAspectRatio: false,
-      color: palette.main,
-      scales: {
-        x: {
-          stacked: true,
-          ticks: { color: palette.ticks },
-          grid: { color: palette.grid },
-        },
-        y: {
-          stacked: true,
-          beginAtZero: true,
-          ticks: { color: palette.ticks },
-          grid: { color: palette.grid },
-        },
-      },
-      plugins: {
-        legend: { display: true },
-        tooltip: { enabled: false },
-      },
-      events: ["click"],
-      onClick: onChartClick,
-    },
-  });
-};
-
-const updateChartSelection = () => {
-  chart?.update();
-};
-
-const onChartClick = (event: ChartEvent, elements: ActiveElement[]) => {
-  let index: number;
-  if (elements.length > 0) {
-    index = elements[0].index;
-  } else if (chart && event.x !== null) {
-    const xScale = chart.scales.x;
-    if (!xScale) {
-      return;
-    }
-    const value = xScale.getValueForPixel(event.x);
-    if (value === undefined || value === null) {
-      return;
-    }
-    index = Math.round(value);
-    const maxIndex = (chart.data.labels?.length ?? 1) - 1;
-    if (index < 0 || index > maxIndex) {
-      return;
-    }
-  } else {
-    return;
-  }
-  const ply = index + 1;
-  store.changePly(ply);
-};
-
-const updateBoardSize = () => {
-  boardMaxSize.width = Math.min(window.innerWidth * 0.2, 220);
-  boardMaxSize.height = Math.min(window.innerHeight * 0.8, 550);
-};
-
 const onClose = () => {
   store.closeModalDialog();
 };
-
-onMounted(() => {
-  updateBoardSize();
-  buildChart();
-  window.addEventListener("resize", updateBoardSize);
-});
-
-onBeforeUnmount(() => {
-  if (chart) {
-    chart.destroy();
-  }
-  window.removeEventListener("resize", updateBoardSize);
-});
-
-watch(selectedPly, () => {
-  updateChartSelection();
-});
-
-watch(
-  () => appSettings.thema,
-  () => {
-    chart?.destroy();
-    chart = undefined;
-    buildChart();
-  },
-);
 </script>
 
 <style scoped>
@@ -338,7 +107,6 @@ watch(
   min-width: 0;
   min-height: 0;
   position: relative;
-  background-color: var(--chart-bg-color);
 }
 .board-area {
   display: flex;

--- a/src/renderer/view/layout/LayoutManager.vue
+++ b/src/renderer/view/layout/LayoutManager.vue
@@ -93,6 +93,7 @@
             <option value="ControlGroup1">{{ t.controlGroup }}1</option>
             <option value="ControlGroup2">{{ t.controlGroup }}2</option>
             <option value="SimpleBoard">{{ t.bookStyleDiagram }}</option>
+            <option value="ElapsedTimeChart">{{ t.elapsedTimeChart }}</option>
           </select>
           <button class="thin" @click="insertCustomProfileComponent">{{ t.insert }}</button>
         </div>
@@ -108,6 +109,7 @@
             <span v-if="component.type === 'ControlGroup1'">{{ t.controlGroup }}1</span>
             <span v-if="component.type === 'ControlGroup2'">{{ t.controlGroup }}2</span>
             <span v-if="component.type === 'SimpleBoard'">{{ t.bookStyleDiagram }}</span>
+            <span v-if="component.type === 'ElapsedTimeChart'">{{ t.elapsedTimeChart }}</span>
           </div>
           <div>
             <span class="property">
@@ -309,6 +311,15 @@
                 @update:value="
                   (value) => updateCustomProfileComponent(index, 'showSuggestionsCount', value)
                 "
+              />
+            </span>
+          </div>
+          <div v-if="component.type === 'ElapsedTimeChart'">
+            <span class="property">
+              <ToggleButton
+                :value="!!component.showLegend"
+                :label="t.legends"
+                @update:value="(value) => updateCustomProfileComponent(index, 'showLegend', value)"
               />
             </span>
           </div>
@@ -641,6 +652,15 @@ const insertCustomProfileComponent = () => {
         top: 0,
         width: 400,
         height: 300,
+      });
+      break;
+    case "ElapsedTimeChart":
+      components.unshift({
+        type,
+        left: 0,
+        top: 0,
+        width: 600,
+        height: 200,
       });
       break;
   }

--- a/src/renderer/view/main/CustomLayout.vue
+++ b/src/renderer/view/main/CustomLayout.vue
@@ -69,8 +69,7 @@
         v-else-if="c.type === 'ElapsedTimeChart'"
         :size="c.size"
         :thema="appSettings.thema"
-        :moves="store.record.moves"
-        :selected-ply="store.record.current.ply"
+        :record="store.record"
         :show-legend="!!c.showLegend"
         @click-ply="(ply) => store.changePly(ply)"
       />

--- a/src/renderer/view/main/CustomLayout.vue
+++ b/src/renderer/view/main/CustomLayout.vue
@@ -65,6 +65,15 @@
         class="full"
         :group="ControlGroup.Group2"
       />
+      <ElapsedTimeChart
+        v-else-if="c.type === 'ElapsedTimeChart'"
+        :size="c.size"
+        :thema="appSettings.thema"
+        :moves="store.record.moves"
+        :selected-ply="store.record.current.ply"
+        :show-legend="!!c.showLegend"
+        @click-ply="(ply) => store.changePly(ply)"
+      />
       <SimpleBoardView
         v-else-if="c.type === 'SimpleBoard'"
         :max-size="c.size"
@@ -99,6 +108,7 @@ import BoardPane from "./BoardPane.vue";
 import RecordPane from "./RecordPane.vue";
 import EngineAnalytics from "@/renderer/view/tab/EngineAnalytics.vue";
 import EvaluationChart from "@/renderer/view/tab/EvaluationChart.vue";
+import ElapsedTimeChart from "@/renderer/view/primitive/ElapsedTimeChart.vue";
 import ControlPane, { ControlGroup } from "./ControlPane.vue";
 import { useAppSettings } from "@/renderer/store/settings";
 import RecordComment from "@/renderer/view/tab/RecordComment.vue";

--- a/src/renderer/view/primitive/ElapsedTimeChart.vue
+++ b/src/renderer/view/primitive/ElapsedTimeChart.vue
@@ -7,7 +7,7 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { Chart, ActiveElement, ChartEvent } from "chart.js";
-import { Color, ImmutableNode, Move, reverseColor } from "tsshogi";
+import { Color, ImmutableNode, ImmutableRecord, Move, reverseColor } from "tsshogi";
 import { Thema } from "@/common/settings/app";
 import { t } from "@/common/i18n";
 import { RectSize } from "@/common/assets/geometry";
@@ -48,8 +48,7 @@ function getColorPalette(thema: Thema): ColorPalette {
 const props = defineProps<{
   size?: RectSize;
   thema: Thema;
-  moves: ImmutableNode[];
-  selectedPly: number;
+  record: ImmutableRecord;
   showLegend?: boolean;
 }>();
 
@@ -64,25 +63,19 @@ const style = computed(() =>
   props.size ? { width: `${props.size.width}px`, height: `${props.size.height}px` } : {},
 );
 
-const buildChart = () => {
-  if (!canvas.value) {
-    return;
-  }
-  const palette = getColorPalette(props.thema);
-
-  const labels: string[] = [];
-  const blackData: (number | null)[] = [];
-  const whiteData: (number | null)[] = [];
-
+const data = computed(() => {
   const nodeMap = new Map<number, ImmutableNode>();
-  for (const node of props.moves) {
+  for (const node of props.record.moves) {
     if (node.ply > 0) {
       nodeMap.set(node.ply, node);
     }
   }
-  const lastPly = props.moves.length > 1 ? props.moves[props.moves.length - 1].ply : 0;
+  const lastPly =
+    props.record.moves.length > 1 ? props.record.moves[props.record.moves.length - 1].ply : 0;
   const maxPly = Math.max(30, lastPly);
-
+  const labels: string[] = [];
+  const blackData: (number | null)[] = [];
+  const whiteData: (number | null)[] = [];
   for (let ply = 1; ply <= maxPly; ply++) {
     labels.push(String(ply));
     const node = nodeMap.get(ply);
@@ -102,11 +95,19 @@ const buildChart = () => {
       whiteData.push(null);
     }
   }
+  return { labels, blackData, whiteData };
+});
+
+const buildChart = () => {
+  if (!canvas.value) {
+    return;
+  }
+  const palette = getColorPalette(props.thema);
 
   const plyIndicatorPlugin = {
     id: "plyIndicator",
     afterDraw(ch: Chart) {
-      const ply = props.selectedPly;
+      const ply = props.record.current.ply;
       if (ply <= 0) {
         return;
       }
@@ -158,16 +159,16 @@ const buildChart = () => {
     type: "bar",
     plugins: [plyIndicatorPlugin],
     data: {
-      labels,
+      labels: data.value.labels,
       datasets: [
         {
           label: t.sente,
-          data: blackData,
+          data: data.value.blackData,
           backgroundColor: palette.blackPlayer,
         },
         {
           label: t.gote,
-          data: whiteData,
+          data: data.value.whiteData,
           backgroundColor: palette.whitePlayer,
         },
       ],
@@ -233,7 +234,7 @@ onBeforeUnmount(() => {
 });
 
 watch(
-  () => props.selectedPly,
+  () => props.record.current.ply,
   () => {
     chart?.update();
   },
@@ -249,7 +250,7 @@ watch(
 );
 
 watch(
-  () => props.moves,
+  () => data.value,
   () => {
     chart?.destroy();
     chart = undefined;

--- a/src/renderer/view/primitive/ElapsedTimeChart.vue
+++ b/src/renderer/view/primitive/ElapsedTimeChart.vue
@@ -1,0 +1,278 @@
+<template>
+  <div class="root" :style="style">
+    <canvas ref="canvas" class="full"></canvas>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { Chart, ActiveElement, ChartEvent } from "chart.js";
+import { Color, ImmutableNode, Move, reverseColor } from "tsshogi";
+import { Thema } from "@/common/settings/app";
+import { t } from "@/common/i18n";
+import { RectSize } from "@/common/assets/geometry";
+
+type ColorPalette = {
+  main: string;
+  ticks: string;
+  grid: string;
+  blackPlayer: string;
+  whitePlayer: string;
+  selected: string;
+};
+
+function getColorPalette(thema: Thema): ColorPalette {
+  switch (thema) {
+    default:
+      return {
+        main: "black",
+        ticks: "dimgray",
+        grid: "lightgray",
+        blackPlayer: "#1480C9",
+        whitePlayer: "#FB7D00",
+        selected: "red",
+      };
+    case Thema.DARK_GREEN:
+    case Thema.DARK:
+      return {
+        main: "white",
+        ticks: "darkgray",
+        grid: "dimgray",
+        blackPlayer: "#36A2EB",
+        whitePlayer: "#FF9F40",
+        selected: "red",
+      };
+  }
+}
+
+const props = defineProps<{
+  size?: RectSize;
+  thema: Thema;
+  moves: ImmutableNode[];
+  selectedPly: number;
+  showLegend?: boolean;
+}>();
+
+const emit = defineEmits<{
+  clickPly: [ply: number];
+}>();
+
+const canvas = ref<HTMLCanvasElement>();
+let chart: Chart | undefined;
+
+const style = computed(() =>
+  props.size ? { width: `${props.size.width}px`, height: `${props.size.height}px` } : {},
+);
+
+const buildChart = () => {
+  if (!canvas.value) {
+    return;
+  }
+  const palette = getColorPalette(props.thema);
+
+  const labels: string[] = [];
+  const blackData: (number | null)[] = [];
+  const whiteData: (number | null)[] = [];
+
+  const nodeMap = new Map<number, ImmutableNode>();
+  for (const node of props.moves) {
+    if (node.ply > 0) {
+      nodeMap.set(node.ply, node);
+    }
+  }
+  const lastPly = props.moves.length > 1 ? props.moves[props.moves.length - 1].ply : 0;
+  const maxPly = Math.max(30, lastPly);
+
+  for (let ply = 1; ply <= maxPly; ply++) {
+    labels.push(String(ply));
+    const node = nodeMap.get(ply);
+    if (node) {
+      const moverColor = node.move instanceof Move ? reverseColor(node.nextColor) : node.nextColor;
+      const isBlack = moverColor === Color.BLACK;
+      const seconds = node.elapsedMs > 0 ? node.elapsedMs / 1000 : null;
+      if (isBlack) {
+        blackData.push(seconds);
+        whiteData.push(null);
+      } else {
+        blackData.push(null);
+        whiteData.push(seconds);
+      }
+    } else {
+      blackData.push(null);
+      whiteData.push(null);
+    }
+  }
+
+  const plyIndicatorPlugin = {
+    id: "plyIndicator",
+    afterDraw(ch: Chart) {
+      const ply = props.selectedPly;
+      if (ply <= 0) {
+        return;
+      }
+      const index = ply - 1;
+      let barX: number | null = null;
+      let barTopY: number | null = null;
+      for (let di = 0; di < ch.data.datasets.length; di++) {
+        const value = ch.data.datasets[di].data[index];
+        if (value === null || value === undefined) {
+          continue;
+        }
+        const bar = ch.getDatasetMeta(di).data[index];
+        if (!bar) {
+          continue;
+        }
+        barX = bar.x;
+        barTopY = bar.y;
+        break;
+      }
+      if (barX === null) {
+        const xScale = ch.scales.x;
+        if (!xScale) {
+          return;
+        }
+        barX = xScale.getPixelForValue(index);
+        barTopY = ch.chartArea.bottom;
+      }
+      if (barX === null || barTopY === null) {
+        return;
+      }
+      const size = 7;
+      const ctx = ch.ctx;
+      ctx.save();
+      ctx.beginPath();
+      ctx.moveTo(barX - size, barTopY - size * 2 - 2);
+      ctx.lineTo(barX + size, barTopY - size * 2 - 2);
+      ctx.lineTo(barX, barTopY - 2);
+      ctx.closePath();
+      ctx.fillStyle = palette.selected;
+      ctx.fill();
+      ctx.restore();
+    },
+  };
+
+  const context = canvas.value.getContext("2d", {
+    desynchronized: true,
+  }) as CanvasRenderingContext2D;
+  chart = new Chart(context, {
+    type: "bar",
+    plugins: [plyIndicatorPlugin],
+    data: {
+      labels,
+      datasets: [
+        {
+          label: t.sente,
+          data: blackData,
+          backgroundColor: palette.blackPlayer,
+        },
+        {
+          label: t.gote,
+          data: whiteData,
+          backgroundColor: palette.whitePlayer,
+        },
+      ],
+    },
+    options: {
+      animation: false,
+      responsive: true,
+      maintainAspectRatio: false,
+      color: palette.main,
+      scales: {
+        x: {
+          stacked: true,
+          ticks: { color: palette.ticks },
+          grid: { color: palette.grid },
+        },
+        y: {
+          stacked: true,
+          beginAtZero: true,
+          ticks: { color: palette.ticks },
+          grid: { color: palette.grid },
+        },
+      },
+      plugins: {
+        legend: { display: !!props.showLegend },
+        tooltip: { enabled: false },
+      },
+      events: ["click"],
+      onClick: onChartClick,
+    },
+  });
+};
+
+const onChartClick = (event: ChartEvent, elements: ActiveElement[]) => {
+  let index: number;
+  if (elements.length > 0) {
+    index = elements[0].index;
+  } else if (chart && event.x !== null) {
+    const xScale = chart.scales.x;
+    if (!xScale) {
+      return;
+    }
+    const value = xScale.getValueForPixel(event.x);
+    if (value === undefined || value === null) {
+      return;
+    }
+    index = Math.round(value);
+    const maxIndex = (chart.data.labels?.length ?? 1) - 1;
+    if (index < 0 || index > maxIndex) {
+      return;
+    }
+  } else {
+    return;
+  }
+  emit("clickPly", index + 1);
+};
+
+onMounted(() => {
+  buildChart();
+});
+
+onBeforeUnmount(() => {
+  chart?.destroy();
+});
+
+watch(
+  () => props.selectedPly,
+  () => {
+    chart?.update();
+  },
+);
+
+watch(
+  () => props.thema,
+  () => {
+    chart?.destroy();
+    chart = undefined;
+    buildChart();
+  },
+);
+
+watch(
+  () => props.moves,
+  () => {
+    chart?.destroy();
+    chart = undefined;
+    buildChart();
+  },
+);
+
+watch(
+  () => props.showLegend,
+  (value) => {
+    if (chart?.options.plugins?.legend) {
+      chart.options.plugins.legend.display = !!value;
+      chart.update();
+    }
+  },
+);
+</script>
+
+<style scoped>
+.root {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background-color: var(--chart-bg-color);
+}
+</style>

--- a/src/renderer/view/primitive/ElapsedTimeChart.vue
+++ b/src/renderer/view/primitive/ElapsedTimeChart.vue
@@ -57,13 +57,13 @@ const emit = defineEmits<{
 }>();
 
 const canvas = ref<HTMLCanvasElement>();
-let chart: Chart | undefined;
+let chart: Chart;
 
 const style = computed(() =>
   props.size ? { width: `${props.size.width}px`, height: `${props.size.height}px` } : {},
 );
 
-const data = computed(() => {
+const chartData = computed(() => {
   const nodeMap = new Map<number, ImmutableNode>();
   for (const node of props.record.moves) {
     if (node.ply > 0) {
@@ -98,10 +98,58 @@ const data = computed(() => {
   return { labels, blackData, whiteData };
 });
 
-const buildChart = () => {
-  if (!canvas.value) {
+const updateChart = () => {
+  const palette = getColorPalette(props.thema);
+  const { labels, blackData, whiteData } = chartData.value;
+  chart.data.labels = labels;
+  chart.data.datasets[0].data = blackData;
+  chart.data.datasets[0].backgroundColor = palette.blackPlayer;
+  chart.data.datasets[1].data = whiteData;
+  chart.data.datasets[1].backgroundColor = palette.whitePlayer;
+  chart.options.color = palette.main;
+  if (chart.options.scales?.x?.ticks) {
+    chart.options.scales.x.ticks.color = palette.ticks;
+  }
+  if (chart.options.scales?.x?.grid) {
+    chart.options.scales.x.grid.color = palette.grid;
+  }
+  if (chart.options.scales?.y?.ticks) {
+    chart.options.scales.y.ticks.color = palette.ticks;
+  }
+  if (chart.options.scales?.y?.grid) {
+    chart.options.scales.y.grid.color = palette.grid;
+  }
+  if (chart.options.plugins?.legend) {
+    chart.options.plugins.legend.display = !!props.showLegend;
+  }
+  chart.update();
+};
+
+const onChartClick = (event: ChartEvent, elements: ActiveElement[]) => {
+  let index: number;
+  if (elements.length > 0) {
+    index = elements[0].index;
+  } else if (event.x !== null) {
+    const xScale = chart.scales.x;
+    if (!xScale) {
+      return;
+    }
+    const value = xScale.getValueForPixel(event.x);
+    if (value === undefined || value === null) {
+      return;
+    }
+    index = Math.round(value);
+    const maxIndex = (chart.data.labels?.length ?? 1) - 1;
+    if (index < 0 || index > maxIndex) {
+      return;
+    }
+  } else {
     return;
   }
+  emit("clickPly", index + 1);
+};
+
+onMounted(() => {
   const palette = getColorPalette(props.thema);
 
   const plyIndicatorPlugin = {
@@ -146,31 +194,23 @@ const buildChart = () => {
       ctx.lineTo(barX + size, barTopY - size * 2 - 2);
       ctx.lineTo(barX, barTopY - 2);
       ctx.closePath();
-      ctx.fillStyle = palette.selected;
+      ctx.fillStyle = getColorPalette(props.thema).selected;
       ctx.fill();
       ctx.restore();
     },
   };
 
-  const context = canvas.value.getContext("2d", {
+  const context = canvas.value!.getContext("2d", {
     desynchronized: true,
   }) as CanvasRenderingContext2D;
   chart = new Chart(context, {
     type: "bar",
     plugins: [plyIndicatorPlugin],
     data: {
-      labels: data.value.labels,
+      labels: [],
       datasets: [
-        {
-          label: t.sente,
-          data: data.value.blackData,
-          backgroundColor: palette.blackPlayer,
-        },
-        {
-          label: t.gote,
-          data: data.value.whiteData,
-          backgroundColor: palette.whitePlayer,
-        },
+        { label: t.sente, data: [], backgroundColor: palette.blackPlayer },
+        { label: t.gote, data: [], backgroundColor: palette.whitePlayer },
       ],
     },
     options: {
@@ -199,74 +239,23 @@ const buildChart = () => {
       onClick: onChartClick,
     },
   });
-};
 
-const onChartClick = (event: ChartEvent, elements: ActiveElement[]) => {
-  let index: number;
-  if (elements.length > 0) {
-    index = elements[0].index;
-  } else if (chart && event.x !== null) {
-    const xScale = chart.scales.x;
-    if (!xScale) {
-      return;
-    }
-    const value = xScale.getValueForPixel(event.x);
-    if (value === undefined || value === null) {
-      return;
-    }
-    index = Math.round(value);
-    const maxIndex = (chart.data.labels?.length ?? 1) - 1;
-    if (index < 0 || index > maxIndex) {
-      return;
-    }
-  } else {
-    return;
-  }
-  emit("clickPly", index + 1);
-};
+  updateChart();
 
-onMounted(() => {
-  buildChart();
+  watch(
+    () => props.record.current.ply,
+    () => chart.update(),
+  );
+
+  watch(
+    () => [chartData.value, props.thema, props.showLegend] as const,
+    () => updateChart(),
+  );
 });
 
 onBeforeUnmount(() => {
   chart?.destroy();
 });
-
-watch(
-  () => props.record.current.ply,
-  () => {
-    chart?.update();
-  },
-);
-
-watch(
-  () => props.thema,
-  () => {
-    chart?.destroy();
-    chart = undefined;
-    buildChart();
-  },
-);
-
-watch(
-  () => data.value,
-  () => {
-    chart?.destroy();
-    chart = undefined;
-    buildChart();
-  },
-);
-
-watch(
-  () => props.showLegend,
-  (value) => {
-    if (chart?.options.plugins?.legend) {
-      chart.options.plugins.legend.display = !!value;
-      chart.update();
-    }
-  },
-);
 </script>
 
 <style scoped>


### PR DESCRIPTION
# 説明 / Description

#1522 

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/shogihome/blob/main/CONTRIBUTING.md)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Elapsed Time Chart component for custom layouts—interactive stacked-bar view of both players' elapsed times.
  * Tap/click a bar to jump to that move; current move is highlighted with a marker.
  * Optional legend toggle, theme-aware styling, automatic updates when data or theme change.
  * Integrated into layout editor with sensible default size and a dedicated property panel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->