### PR TITLE
リリースに Linux の .deb を追加

### DIFF
--- a/.electron-builder.config.mjs
+++ b/.electron-builder.config.mjs
@@ -78,7 +78,9 @@ const config = {
     },
   },
   linux: {
-    target: "AppImage",
+    target: ["AppImage", "deb"],
+    executableName: "shogihome",
+    icon: "public/favicon.png",
     fileAssociations: [
       { name: "KIF", ext: "kif" },
       { name: "KIFU", ext: "kifu" },
@@ -87,6 +89,9 @@ const config = {
       { name: "CSA", ext: "csa" },
       { name: "JKF", ext: "jkf" },
     ],
+  },
+  deb: {
+    packageName: "shogihome",
   },
   publish: null,
 

--- a/scripts/archive.mjs
+++ b/scripts/archive.mjs
@@ -5,50 +5,55 @@ import fs from "node:fs";
 const platform = process.argv[2];
 const version = process.argv[3];
 const variant = process.argv[4] || "installer";
-const outputPath =
-  variant === "portable"
-    ? `dist/release-${version}-portable.zip`
-    : `dist/release-${version}-${platform}.zip`;
 
 const packageJson = JSON.parse(fs.readFileSync("./package.json"));
 if (`v${packageJson.version}` !== version) {
   throw new Error("invalid release version");
 }
 
-const output = fs.createWriteStream(outputPath).on("error", function (err) {
-  throw err;
-});
-const archive = archiver
-  .create("zip")
-  .on("warning", function (err) {
-    if (err.code === "ENOENT") {
-      console.log(err);
-    } else {
-      throw err;
-    }
-  })
-  .on("error", function (err) {
-    throw err;
+function createArchive(outputPath, globPattern) {
+  return new Promise((resolve, reject) => {
+    const output = fs.createWriteStream(outputPath).on("error", reject);
+    const archive = archiver
+      .create("zip")
+      .on("warning", function (err) {
+        if (err.code === "ENOENT") {
+          console.log(err);
+        } else {
+          reject(err);
+        }
+      })
+      .on("error", reject)
+      .on("finish", resolve);
+    archive.pipe(output);
+    archive.glob(globPattern, { cwd: "dist" });
+    archive.file("LICENSE", { name: "LICENSE.txt" });
+    archive.file("docs/third-party-licenses.html", {
+      name: "third-party-licenses.html",
+    });
+    archive.glob("third-party-licenses/*.txt", { cwd: "docs" });
+    archive.finalize();
   });
-archive.pipe(output);
+}
 
 switch (platform) {
   case "win":
-    archive.glob("*.exe", { cwd: "dist" });
+    await createArchive(
+      variant === "portable"
+        ? `dist/release-${version}-portable.zip`
+        : `dist/release-${version}-win.zip`,
+      "*.exe",
+    );
     break;
   case "mac":
-    archive.glob("*.dmg", { cwd: "dist" });
+    await createArchive(`dist/release-${version}-mac.zip`, "*.dmg");
     break;
   case "linux":
-    archive.glob("*.AppImage", { cwd: "dist" });
+    await Promise.all([
+      createArchive(`dist/release-${version}-linux-appimage.zip`, "*.AppImage"),
+      createArchive(`dist/release-${version}-linux-deb.zip`, "*.deb"),
+    ]);
     break;
   default:
     throw new Error("unknown platform");
 }
-archive.file("LICENSE", { name: "LICENSE.txt" });
-archive.file("docs/third-party-licenses.html", {
-  name: "third-party-licenses.html",
-});
-archive.glob("third-party-licenses/*.txt", { cwd: "docs" });
-
-archive.finalize();

--- a/scripts/archive.mjs
+++ b/scripts/archive.mjs
@@ -13,7 +13,7 @@ if (`v${packageJson.version}` !== version) {
 
 function createArchive(outputPath, globPattern) {
   return new Promise((resolve, reject) => {
-    const output = fs.createWriteStream(outputPath).on("error", reject);
+    const output = fs.createWriteStream(outputPath).on("error", reject).on("finish", resolve);
     const archive = archiver
       .create("zip")
       .on("warning", function (err) {
@@ -23,8 +23,7 @@ function createArchive(outputPath, globPattern) {
           reject(err);
         }
       })
-      .on("error", reject)
-      .on("finish", resolve);
+      .on("error", reject);
     archive.pipe(output);
     archive.glob(globPattern, { cwd: "dist" });
     archive.file("LICENSE", { name: "LICENSE.txt" });
@@ -32,7 +31,7 @@ function createArchive(outputPath, globPattern) {
       name: "third-party-licenses.html",
     });
     archive.glob("third-party-licenses/*.txt", { cwd: "docs" });
-    archive.finalize();
+    archive.finalize().catch(reject);
   });
 }
 


### PR DESCRIPTION
# 説明 / Description

リリースのアセットに Linux の .deb を加える。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/shogihome/blob/main/CONTRIBUTING.md)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Linux users can now install via Debian package format (deb) in addition to AppImage.
  * Improved application metadata configuration for Linux distributions.

* **Chores**
  * Enhanced archive creation process for packaging efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->