### PR TITLE
メモリ使用量の上昇を警告する機能

### DIFF
--- a/src/background/window/heap_monitor.ts
+++ b/src/background/window/heap_monitor.ts
@@ -1,0 +1,21 @@
+import { t } from "@/common/i18n/index.js";
+
+const heapUpperGB = 1.6;
+const heapLowerGB = 1.4;
+const heapUpperBytes = heapUpperGB * 1024 * 1024 * 1024;
+const heapLowerBytes = heapLowerGB * 1024 * 1024 * 1024;
+const intervalMs = 5_000; // 5seconds
+
+export function startHeapMonitor(onWarning: (message: string) => void): () => void {
+  let warningActive = false;
+  const id = setInterval(() => {
+    const { heapUsed } = process.memoryUsage();
+    if (!warningActive && heapUsed > heapUpperBytes) {
+      warningActive = true;
+      onWarning(t.heapUsageExceedsNGBMayHang(heapUpperGB));
+    } else if (warningActive && heapUsed < heapLowerBytes) {
+      warningActive = false;
+    }
+  }, intervalMs);
+  return () => clearInterval(id);
+}

--- a/src/background/window/main.ts
+++ b/src/background/window/main.ts
@@ -16,6 +16,7 @@ import { checkUpdates } from "@/background/version.js";
 import { setupMenu } from "@/background/window/menu.js";
 import { t } from "@/common/i18n/index.js";
 import { ghioDomain } from "@/common/links/github.js";
+import { startHeapMonitor } from "@/background/window/heap_monitor.js";
 
 export function createWindow(onClosed: () => void) {
   let settings = loadWindowSettings();
@@ -84,6 +85,9 @@ export function createWindow(onClosed: () => void) {
   }
 
   win.once("ready-to-show", () => {
+    const stopHeapMonitor = startHeapMonitor((message) => sendError(new Error(message)));
+    win.once("closed", stopHeapMonitor);
+
     // レンダラー側の準備ができたら uncaughtException はレンダラーへ送る。
     process.on("uncaughtException", (e, origin) => {
       // ホストの解決ができない場合に uncaughtException が発生する。

--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -870,4 +870,7 @@ export const en: Texts = {
   totalUSIHashExceedsNPercentOfMemory(n: number): string {
     return `The total USI_Hash exceeds ${n}% of memory.`;
   },
+  heapUsageExceedsNGBMayHang(gb: number): string {
+    return `Memory usage has exceeded ${gb} GB. If the upward trend continues, the app may hang.`;
+  },
 };

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -870,4 +870,7 @@ export const ja: Texts = {
   totalUSIHashExceedsNPercentOfMemory(n: number): string {
     return `USI_Hash の合計が全メモリの${n}%を超えています。`;
   },
+  heapUsageExceedsNGBMayHang(gb: number): string {
+    return `メモリ使用量が ${gb}GB を超えました。増加傾向が続くとハングアップする可能性があります。`;
+  },
 };

--- a/src/common/i18n/locales/vi.ts
+++ b/src/common/i18n/locales/vi.ts
@@ -876,4 +876,7 @@ export const vi: Texts = {
   totalUSIHashExceedsNPercentOfMemory(n: number): string {
     return `Tổng USI_HASH vượt quá ${n}% RAM.`;
   },
+  heapUsageExceedsNGBMayHang(gb: number): string {
+    return `メモリ使用量が ${gb}GB を超えました。増加傾向が続くとハングアップする可能性があります。`; // TODO: Translate
+  },
 };

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -864,4 +864,7 @@ export const zh_tw: Texts = {
   totalUSIHashExceedsNPercentOfMemory(n: number): string {
     return `USI_Hash の合計が全メモリの${n}%を超えています。`; // TODO: Translate
   },
+  heapUsageExceedsNGBMayHang(gb: number): string {
+    return `メモリ使用量が ${gb}GB を超えました。増加傾向が続くとハングアップする可能性があります。`; // TODO: Translate
+  },
 };

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -799,4 +799,5 @@ export type Texts = {
   memoryUsageExceedsNPercent(n: number): string;
   memoryUsageIsLessThanNPercent(n: number): string;
   totalUSIHashExceedsNPercentOfMemory(n: number): string;
+  heapUsageExceedsNGBMayHang(gb: number): string;
 };


### PR DESCRIPTION
# 説明 / Description

2〜4 GB のヒープを使うと OOM でハングする可能性があるので 1.6GB 以上に達したところで警告を表示する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/shogihome/blob/main/CONTRIBUTING.md)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added heap memory monitoring that tracks memory usage and alerts users when thresholds are exceeded.

* **Localization**
  * Memory usage alerts now available in English, Japanese, Vietnamese, and Traditional Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->