### PR TITLE
ダイアログをドラッグできる機能

### DIFF
--- a/src/renderer/css/dialog.css
+++ b/src/renderer/css/dialog.css
@@ -140,6 +140,7 @@ dialog.message-box {
   color: var(--info-dialog-color);
   background-color: var(--info-dialog-bg-color);
   border: 3px solid var(--info-dialog-border-color);
+  cursor: default;
 }
 
 dialog.message-box .message-area {

--- a/src/renderer/helpers/draggable.ts
+++ b/src/renderer/helpers/draggable.ts
@@ -1,0 +1,134 @@
+import { computed, onBeforeUnmount, reactive, Ref } from "vue";
+
+export function useDraggableDialog(containerRef: Ref<HTMLElement | undefined>) {
+  const translate = reactive({ x: 0, y: 0 });
+  let isDragging = false;
+  let dragStartX = 0;
+  let dragStartY = 0;
+  let translateStartX = 0;
+  let translateStartY = 0;
+  let naturalRect = new DOMRect();
+  let dragCursorStyle: HTMLStyleElement | null = null;
+
+  const dragStyle = computed(() =>
+    translate.x !== 0 || translate.y !== 0
+      ? { transform: `translate(${translate.x}px, ${translate.y}px)` }
+      : undefined,
+  );
+
+  function isInScrollableArea(target: EventTarget | null): boolean {
+    const container = containerRef.value;
+    if (!container) {
+      return false;
+    }
+    let el = target as Element | null;
+    while (el && el !== container) {
+      const style = window.getComputedStyle(el);
+      const overflow = style.overflow + style.overflowX + style.overflowY;
+      if (
+        /auto|scroll/.test(overflow) &&
+        (el.scrollHeight > el.clientHeight || el.scrollWidth > el.clientWidth)
+      ) {
+        return true;
+      }
+      el = el.parentElement;
+    }
+    return false;
+  }
+
+  function isInteractiveElement(target: EventTarget | null): boolean {
+    const container = containerRef.value;
+    if (!container) {
+      return false;
+    }
+    let el = target as Element | null;
+    while (el && el !== container) {
+      if (el instanceof Element && el.matches("button, input, select, textarea, a")) {
+        return true;
+      }
+      el = el.parentElement;
+    }
+    return false;
+  }
+
+  function onDragMouseDown(event: MouseEvent): void {
+    if (event.button !== 0) {
+      return;
+    }
+    if (isInteractiveElement(event.target)) {
+      return;
+    }
+    if (isInScrollableArea(event.target)) {
+      return;
+    }
+
+    const container = containerRef.value;
+    if (!container) {
+      return;
+    }
+
+    const currentRect = container.getBoundingClientRect();
+    naturalRect = new DOMRect(
+      currentRect.left - translate.x,
+      currentRect.top - translate.y,
+      currentRect.width,
+      currentRect.height,
+    );
+
+    isDragging = true;
+    dragStartX = event.clientX;
+    dragStartY = event.clientY;
+    translateStartX = translate.x;
+    translateStartY = translate.y;
+
+    dragCursorStyle = document.createElement("style");
+    dragCursorStyle.textContent =
+      "* { cursor: grabbing !important; user-select: none !important; }";
+    document.head.appendChild(dragCursorStyle);
+
+    document.addEventListener("mousemove", onMouseMove);
+    document.addEventListener("mouseup", onMouseUp);
+  }
+
+  function onMouseMove(event: MouseEvent): void {
+    if (!isDragging) {
+      return;
+    }
+
+    let newX = translateStartX + (event.clientX - dragStartX);
+    let newY = translateStartY + (event.clientY - dragStartY);
+
+    const newLeft = naturalRect.left + newX;
+    const newRight = naturalRect.right + newX;
+    const newTop = naturalRect.top + newY;
+    const newBottom = naturalRect.bottom + newY;
+
+    if (newLeft < 0) {
+      newX -= newLeft;
+    } else if (newRight > window.innerWidth) {
+      newX -= newRight - window.innerWidth;
+    }
+    if (newTop < 0) {
+      newY -= newTop;
+    } else if (newBottom > window.innerHeight) {
+      newY -= newBottom - window.innerHeight;
+    }
+
+    translate.x = newX;
+    translate.y = newY;
+  }
+
+  function onMouseUp(): void {
+    isDragging = false;
+    dragCursorStyle?.remove();
+    dragCursorStyle = null;
+    document.removeEventListener("mousemove", onMouseMove);
+    document.removeEventListener("mouseup", onMouseUp);
+  }
+
+  onBeforeUnmount(() => {
+    onMouseUp();
+  });
+
+  return { dragStyle, onDragMouseDown };
+}

--- a/src/renderer/helpers/draggable.ts
+++ b/src/renderer/helpers/draggable.ts
@@ -98,20 +98,20 @@ export function useDraggableDialog(containerRef: Ref<HTMLElement | undefined>) {
     let newX = translateStartX + (event.clientX - dragStartX);
     let newY = translateStartY + (event.clientY - dragStartY);
 
-    const newLeft = naturalRect.left + newX;
     const newRight = naturalRect.right + newX;
-    const newTop = naturalRect.top + newY;
     const newBottom = naturalRect.bottom + newY;
 
-    if (newLeft < 0) {
-      newX -= newLeft;
-    } else if (newRight > window.innerWidth) {
+    if (newRight > window.innerWidth) {
       newX -= newRight - window.innerWidth;
     }
-    if (newTop < 0) {
-      newY -= newTop;
-    } else if (newBottom > window.innerHeight) {
+    if (naturalRect.left + newX < 0) {
+      newX = -naturalRect.left;
+    }
+    if (newBottom > window.innerHeight) {
       newY -= newBottom - window.innerHeight;
+    }
+    if (naturalRect.top + newY < 0) {
+      newY = -naturalRect.top;
     }
 
     translate.x = newX;
@@ -126,8 +126,36 @@ export function useDraggableDialog(containerRef: Ref<HTMLElement | undefined>) {
     document.removeEventListener("mouseup", onMouseUp);
   }
 
+  function clampTranslate(): void {
+    const container = containerRef.value;
+    if (!container) {
+      return;
+    }
+    const rect = container.getBoundingClientRect();
+    let dx = 0;
+    if (rect.right > window.innerWidth) {
+      dx -= rect.right - window.innerWidth;
+    }
+    if (rect.left + dx < 0) {
+      dx = -rect.left;
+    }
+    translate.x += dx;
+
+    let dy = 0;
+    if (rect.bottom > window.innerHeight) {
+      dy -= rect.bottom - window.innerHeight;
+    }
+    if (rect.top + dy < 0) {
+      dy = -rect.top;
+    }
+    translate.y += dy;
+  }
+
+  window.addEventListener("resize", clampTranslate);
+
   onBeforeUnmount(() => {
     onMouseUp();
+    window.removeEventListener("resize", clampTranslate);
   });
 
   return { dragStyle, onDragMouseDown };

--- a/src/renderer/view/dialog/BusyMessage.vue
+++ b/src/renderer/view/dialog/BusyMessage.vue
@@ -1,5 +1,5 @@
 <template>
-  <dialog ref="dialog" class="message-box">
+  <dialog ref="dialog" class="message-box" :style="dragStyle" @mousedown="onDragMouseDown">
     <div class="message-area">
       <Icon :icon="IconType.BUSY" />
       <div class="message">{{ t.processingPleaseWait }}</div>
@@ -11,16 +11,19 @@
 <script setup lang="ts">
 import { t } from "@/common/i18n";
 import { showModalDialog } from "@/renderer/helpers/dialog.js";
+import { useDraggableDialog } from "@/renderer/helpers/draggable";
 import { computed, onMounted, ref } from "vue";
 import Icon from "@/renderer/view/primitive/Icon.vue";
 import { IconType } from "@/renderer/assets/icons";
 import { useBusyState } from "@/renderer/store/busy";
 
 const busyState = useBusyState();
-const dialog = ref();
+const dialog = ref<HTMLDialogElement>();
+
+const { dragStyle, onDragMouseDown } = useDraggableDialog(dialog);
 
 onMounted(() => {
-  showModalDialog(dialog.value);
+  showModalDialog(dialog.value!);
 });
 
 const progressPercent = computed(() => {

--- a/src/renderer/view/dialog/CSAGameReadyDialog.vue
+++ b/src/renderer/view/dialog/CSAGameReadyDialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <dialog ref="dialog" class="message-box">
+  <dialog ref="dialog" class="message-box" :style="dragStyle" @mousedown="onDragMouseDown">
     <div class="message-area">
       <Icon :icon="IconType.BUSY" />
       <div class="message">
@@ -39,6 +39,7 @@
 
 <script setup lang="ts">
 import { showModalDialog } from "@/renderer/helpers/dialog.js";
+import { useDraggableDialog } from "@/renderer/helpers/draggable";
 import { onBeforeUnmount, onMounted, ref, watch } from "vue";
 import Icon from "@/renderer/view/primitive/Icon.vue";
 import { IconType } from "@/renderer/assets/icons";
@@ -51,17 +52,19 @@ import { PromptTarget } from "@/common/advanced/prompt";
 import { useErrorStore } from "@/renderer/store/error";
 
 const store = useStore();
-const dialog = ref();
+const dialog = ref<HTMLDialogElement>();
 const remainingSeconds = ref(0);
 let remainingTimer = 0;
 
+const { dragStyle, onDragMouseDown } = useDraggableDialog(dialog);
+
 onMounted(() => {
-  showModalDialog(dialog.value);
-  installHotKeyForDialog(dialog.value);
+  showModalDialog(dialog.value!);
+  installHotKeyForDialog(dialog.value!);
 });
 
 onBeforeUnmount(() => {
-  uninstallHotKeyForDialog(dialog.value);
+  uninstallHotKeyForDialog(dialog.value!);
   window.clearInterval(remainingTimer);
 });
 

--- a/src/renderer/view/dialog/ConfirmDialog.vue
+++ b/src/renderer/view/dialog/ConfirmDialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <dialog ref="dialog" class="message-box">
+  <dialog ref="dialog" class="message-box" :style="dragStyle" @mousedown="onDragMouseDown">
     <div class="message-area">
       <Icon :icon="IconType.QUESTION" />
       <div class="message">{{ store.message }}</div>
@@ -16,6 +16,7 @@
 <script setup lang="ts">
 import { t } from "@/common/i18n";
 import { showModalDialog } from "@/renderer/helpers/dialog.js";
+import { useDraggableDialog } from "@/renderer/helpers/draggable";
 import { onBeforeUnmount, onMounted, ref } from "vue";
 import Icon from "@/renderer/view/primitive/Icon.vue";
 import { IconType } from "@/renderer/assets/icons";
@@ -23,7 +24,9 @@ import { installHotKeyForDialog, uninstallHotKeyForDialog } from "@/renderer/dev
 import { useConfirmationStore } from "@/renderer/store/confirm";
 
 const store = useConfirmationStore();
-const dialog = ref();
+const dialog = ref<HTMLDialogElement>();
+
+const { dragStyle, onDragMouseDown } = useDraggableDialog(dialog);
 
 const onOk = () => {
   store.ok();
@@ -34,11 +37,11 @@ const onClose = () => {
 };
 
 onMounted(() => {
-  showModalDialog(dialog.value, onClose);
-  installHotKeyForDialog(dialog.value);
+  showModalDialog(dialog.value!, onClose);
+  installHotKeyForDialog(dialog.value!);
 });
 
 onBeforeUnmount(() => {
-  uninstallHotKeyForDialog(dialog.value);
+  uninstallHotKeyForDialog(dialog.value!);
 });
 </script>

--- a/src/renderer/view/dialog/DialogFrame.vue
+++ b/src/renderer/view/dialog/DialogFrame.vue
@@ -1,6 +1,12 @@
 <template>
   <dialog ref="dialog">
-    <div class="frame" :class="{ limited }">
+    <div
+      ref="frame"
+      class="frame"
+      :class="{ limited }"
+      :style="frameStyle"
+      @mousedown="onMouseDown"
+    >
       <slot />
     </div>
   </dialog>
@@ -9,9 +15,10 @@
 <script setup lang="ts">
 import { installHotKeyForDialog, uninstallHotKeyForDialog } from "@/renderer/devices/hotkey";
 import { showModalDialog } from "@/renderer/helpers/dialog";
-import { onBeforeUnmount, onMounted, ref } from "vue";
+import { computed, onBeforeUnmount, onMounted, reactive, ref } from "vue";
 
-const dialog = ref();
+const dialog = ref<HTMLDialogElement>();
+const frame = ref<HTMLElement>();
 
 defineProps<{
   limited?: boolean;
@@ -21,13 +28,133 @@ const emit = defineEmits<{
   cancel: [];
 }>();
 
+const translate = reactive({ x: 0, y: 0 });
+let isDragging = false;
+let dragStartX = 0;
+let dragStartY = 0;
+let translateStartX = 0;
+let translateStartY = 0;
+let naturalRect = new DOMRect();
+let dragCursorStyle: HTMLStyleElement | null = null;
+
+const frameStyle = computed(() =>
+  translate.x !== 0 || translate.y !== 0
+    ? { transform: `translate(${translate.x}px, ${translate.y}px)` }
+    : undefined,
+);
+
+function isInScrollableArea(target: EventTarget | null): boolean {
+  const container = frame.value;
+  if (!container) {
+    return false;
+  }
+  let el = target as Element | null;
+  while (el && el !== container) {
+    const style = window.getComputedStyle(el);
+    const overflow = style.overflow + style.overflowX + style.overflowY;
+    if (
+      /auto|scroll/.test(overflow) &&
+      (el.scrollHeight > el.clientHeight || el.scrollWidth > el.clientWidth)
+    ) {
+      return true;
+    }
+    el = el.parentElement;
+  }
+  return false;
+}
+
+function isInteractiveElement(target: EventTarget | null): boolean {
+  const container = frame.value;
+  if (!container) {
+    return false;
+  }
+  let el = target as Element | null;
+  while (el && el !== container) {
+    if (el instanceof Element && el.matches("button, input, select, textarea, a")) {
+      return true;
+    }
+    el = el.parentElement;
+  }
+  return false;
+}
+
+function onMouseDown(event: MouseEvent): void {
+  if (event.button !== 0) {
+    return;
+  }
+  if (isInteractiveElement(event.target)) {
+    return;
+  }
+  if (isInScrollableArea(event.target)) {
+    return;
+  }
+
+  const currentRect = frame.value!.getBoundingClientRect();
+  naturalRect = new DOMRect(
+    currentRect.left - translate.x,
+    currentRect.top - translate.y,
+    currentRect.width,
+    currentRect.height,
+  );
+
+  isDragging = true;
+  dragStartX = event.clientX;
+  dragStartY = event.clientY;
+  translateStartX = translate.x;
+  translateStartY = translate.y;
+
+  dragCursorStyle = document.createElement("style");
+  dragCursorStyle.textContent = "* { cursor: grabbing !important; user-select: none !important; }";
+  document.head.appendChild(dragCursorStyle);
+
+  document.addEventListener("mousemove", onMouseMove);
+  document.addEventListener("mouseup", onMouseUp);
+}
+
+function onMouseMove(event: MouseEvent): void {
+  if (!isDragging) {
+    return;
+  }
+
+  let newX = translateStartX + (event.clientX - dragStartX);
+  let newY = translateStartY + (event.clientY - dragStartY);
+
+  const newLeft = naturalRect.left + newX;
+  const newRight = naturalRect.right + newX;
+  const newTop = naturalRect.top + newY;
+  const newBottom = naturalRect.bottom + newY;
+
+  if (newLeft < 0) {
+    newX -= newLeft;
+  } else if (newRight > window.innerWidth) {
+    newX -= newRight - window.innerWidth;
+  }
+  if (newTop < 0) {
+    newY -= newTop;
+  } else if (newBottom > window.innerHeight) {
+    newY -= newBottom - window.innerHeight;
+  }
+
+  translate.x = newX;
+  translate.y = newY;
+}
+
+function onMouseUp(): void {
+  isDragging = false;
+  dragCursorStyle?.remove();
+  dragCursorStyle = null;
+  document.removeEventListener("mousemove", onMouseMove);
+  document.removeEventListener("mouseup", onMouseUp);
+}
+
 onMounted(() => {
-  showModalDialog(dialog.value, () => emit("cancel"));
-  installHotKeyForDialog(dialog.value);
+  showModalDialog(dialog.value!, () => emit("cancel"));
+  installHotKeyForDialog(dialog.value!);
 });
 
 onBeforeUnmount(() => {
-  uninstallHotKeyForDialog(dialog.value);
+  uninstallHotKeyForDialog(dialog.value!);
+  onMouseUp();
 });
 </script>
 
@@ -63,6 +190,7 @@ dialog {
   border-radius: 10px 10px 10px 10px;
   padding: 15px;
 }
+
 .frame.limited {
   max-width: 100%;
   max-height: 100%;

--- a/src/renderer/view/dialog/DialogFrame.vue
+++ b/src/renderer/view/dialog/DialogFrame.vue
@@ -4,8 +4,8 @@
       ref="frame"
       class="frame"
       :class="{ limited }"
-      :style="frameStyle"
-      @mousedown="onMouseDown"
+      :style="dragStyle"
+      @mousedown="onDragMouseDown"
     >
       <slot />
     </div>
@@ -15,7 +15,8 @@
 <script setup lang="ts">
 import { installHotKeyForDialog, uninstallHotKeyForDialog } from "@/renderer/devices/hotkey";
 import { showModalDialog } from "@/renderer/helpers/dialog";
-import { computed, onBeforeUnmount, onMounted, reactive, ref } from "vue";
+import { useDraggableDialog } from "@/renderer/helpers/draggable";
+import { onBeforeUnmount, onMounted, ref } from "vue";
 
 const dialog = ref<HTMLDialogElement>();
 const frame = ref<HTMLElement>();
@@ -28,124 +29,7 @@ const emit = defineEmits<{
   cancel: [];
 }>();
 
-const translate = reactive({ x: 0, y: 0 });
-let isDragging = false;
-let dragStartX = 0;
-let dragStartY = 0;
-let translateStartX = 0;
-let translateStartY = 0;
-let naturalRect = new DOMRect();
-let dragCursorStyle: HTMLStyleElement | null = null;
-
-const frameStyle = computed(() =>
-  translate.x !== 0 || translate.y !== 0
-    ? { transform: `translate(${translate.x}px, ${translate.y}px)` }
-    : undefined,
-);
-
-function isInScrollableArea(target: EventTarget | null): boolean {
-  const container = frame.value;
-  if (!container) {
-    return false;
-  }
-  let el = target as Element | null;
-  while (el && el !== container) {
-    const style = window.getComputedStyle(el);
-    const overflow = style.overflow + style.overflowX + style.overflowY;
-    if (
-      /auto|scroll/.test(overflow) &&
-      (el.scrollHeight > el.clientHeight || el.scrollWidth > el.clientWidth)
-    ) {
-      return true;
-    }
-    el = el.parentElement;
-  }
-  return false;
-}
-
-function isInteractiveElement(target: EventTarget | null): boolean {
-  const container = frame.value;
-  if (!container) {
-    return false;
-  }
-  let el = target as Element | null;
-  while (el && el !== container) {
-    if (el instanceof Element && el.matches("button, input, select, textarea, a")) {
-      return true;
-    }
-    el = el.parentElement;
-  }
-  return false;
-}
-
-function onMouseDown(event: MouseEvent): void {
-  if (event.button !== 0) {
-    return;
-  }
-  if (isInteractiveElement(event.target)) {
-    return;
-  }
-  if (isInScrollableArea(event.target)) {
-    return;
-  }
-
-  const currentRect = frame.value!.getBoundingClientRect();
-  naturalRect = new DOMRect(
-    currentRect.left - translate.x,
-    currentRect.top - translate.y,
-    currentRect.width,
-    currentRect.height,
-  );
-
-  isDragging = true;
-  dragStartX = event.clientX;
-  dragStartY = event.clientY;
-  translateStartX = translate.x;
-  translateStartY = translate.y;
-
-  dragCursorStyle = document.createElement("style");
-  dragCursorStyle.textContent = "* { cursor: grabbing !important; user-select: none !important; }";
-  document.head.appendChild(dragCursorStyle);
-
-  document.addEventListener("mousemove", onMouseMove);
-  document.addEventListener("mouseup", onMouseUp);
-}
-
-function onMouseMove(event: MouseEvent): void {
-  if (!isDragging) {
-    return;
-  }
-
-  let newX = translateStartX + (event.clientX - dragStartX);
-  let newY = translateStartY + (event.clientY - dragStartY);
-
-  const newLeft = naturalRect.left + newX;
-  const newRight = naturalRect.right + newX;
-  const newTop = naturalRect.top + newY;
-  const newBottom = naturalRect.bottom + newY;
-
-  if (newLeft < 0) {
-    newX -= newLeft;
-  } else if (newRight > window.innerWidth) {
-    newX -= newRight - window.innerWidth;
-  }
-  if (newTop < 0) {
-    newY -= newTop;
-  } else if (newBottom > window.innerHeight) {
-    newY -= newBottom - window.innerHeight;
-  }
-
-  translate.x = newX;
-  translate.y = newY;
-}
-
-function onMouseUp(): void {
-  isDragging = false;
-  dragCursorStyle?.remove();
-  dragCursorStyle = null;
-  document.removeEventListener("mousemove", onMouseMove);
-  document.removeEventListener("mouseup", onMouseUp);
-}
+const { dragStyle, onDragMouseDown } = useDraggableDialog(frame);
 
 onMounted(() => {
   showModalDialog(dialog.value!, () => emit("cancel"));
@@ -154,7 +38,6 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   uninstallHotKeyForDialog(dialog.value!);
-  onMouseUp();
 });
 </script>
 
@@ -189,6 +72,7 @@ dialog {
   border: 1px solid var(--dialog-border-color);
   border-radius: 10px 10px 10px 10px;
   padding: 15px;
+  cursor: default;
 }
 
 .frame.limited {

--- a/src/renderer/view/dialog/ErrorMessage.vue
+++ b/src/renderer/view/dialog/ErrorMessage.vue
@@ -1,5 +1,5 @@
 <template>
-  <dialog ref="dialog" class="message-box">
+  <dialog ref="dialog" class="message-box" :style="dragStyle" @mousedown="onDragMouseDown">
     <div class="message-area">
       <Icon :icon="IconType.ERROR" />
       <div class="column">
@@ -30,20 +30,24 @@
 import { t } from "@/common/i18n";
 import { onBeforeUnmount, onMounted, ref } from "vue";
 import { showModalDialog } from "@/renderer/helpers/dialog.js";
+import { useDraggableDialog } from "@/renderer/helpers/draggable";
 import Icon from "@/renderer/view/primitive/Icon.vue";
 import { IconType } from "@/renderer/assets/icons";
 import { installHotKeyForDialog, uninstallHotKeyForDialog } from "@/renderer/devices/hotkey";
 import { useErrorStore } from "@/renderer/store/error";
+
 const store = useErrorStore();
-const dialog = ref();
+const dialog = ref<HTMLDialogElement>();
+
+const { dragStyle, onDragMouseDown } = useDraggableDialog(dialog);
 
 onMounted(() => {
-  showModalDialog(dialog.value, onClose);
-  installHotKeyForDialog(dialog.value);
+  showModalDialog(dialog.value!, onClose);
+  installHotKeyForDialog(dialog.value!);
 });
 
 onBeforeUnmount(() => {
-  uninstallHotKeyForDialog(dialog.value);
+  uninstallHotKeyForDialog(dialog.value!);
 });
 
 const copyMessage = () => {

--- a/src/renderer/view/dialog/InfoMessage.vue
+++ b/src/renderer/view/dialog/InfoMessage.vue
@@ -1,5 +1,5 @@
 <template>
-  <dialog ref="dialog" class="message-box">
+  <dialog ref="dialog" class="message-box" :style="dragStyle" @mousedown="onDragMouseDown">
     <div class="message-area">
       <Icon :icon="IconType.INFO" />
       <div class="message">
@@ -37,6 +37,7 @@
 <script setup lang="ts">
 import { t } from "@/common/i18n";
 import { showModalDialog } from "@/renderer/helpers/dialog.js";
+import { useDraggableDialog } from "@/renderer/helpers/draggable";
 import { onBeforeUnmount, onMounted, ref } from "vue";
 import Icon from "@/renderer/view/primitive/Icon.vue";
 import { IconType } from "@/renderer/assets/icons";
@@ -46,15 +47,17 @@ import api from "@/renderer/ipc/api";
 import { toMarkdown } from "@/common/message";
 
 const store = useMessageStore();
-const dialog = ref();
+const dialog = ref<HTMLDialogElement>();
+
+const { dragStyle, onDragMouseDown } = useDraggableDialog(dialog);
 
 onMounted(() => {
-  showModalDialog(dialog.value, onClose);
-  installHotKeyForDialog(dialog.value);
+  showModalDialog(dialog.value!, onClose);
+  installHotKeyForDialog(dialog.value!);
 });
 
 onBeforeUnmount(() => {
-  uninstallHotKeyForDialog(dialog.value);
+  uninstallHotKeyForDialog(dialog.value!);
 });
 
 const copyMessage = () => {


### PR DESCRIPTION
# 説明 / Description

ダイアログの表示位置をマウスで移動できるようにする。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/shogihome/blob/main/CONTRIBUTING.md)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dialogs can be repositioned by dragging with the mouse.
  * Drag uses a grabbing cursor and temporarily disables text selection while dragging.
  * Dragging is constrained so dialogs remain within the application window.
* **Bug Fixes / UX**
  * Dragging is suppressed when interacting with controls (buttons, inputs, links) to avoid accidental moves.
  * Message-box dialogs now use a default cursor for clearer pointer behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sunfish-shogi/shogihome/pull/1588)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->