### PR TITLE
Fix for electron update

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,9 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6.4.0
         with:
-          node-version: lts/*
+          # Do not use Node.js v24.16.0 or later
+          # See: https://github.com/electron/electron/issues/51619
+          node-version: v24.15.0
           cache: "npm"
       - run: npm install -g npm@latest
       - run: npm version

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "archiver": "^7.0.1",
         "concurrently": "^9.0.1",
         "depcheck": "^1.4.7",
-        "electron": "^41.1.0",
+        "electron": "^42.2.0",
         "electron-builder": "^26.8.1",
         "electron-devtools-installer": "^4.0.0",
         "eslint": "^9.39.2",
@@ -2042,35 +2042,37 @@
       }
     },
     "node_modules/@electron/get": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
-      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-5.0.0.tgz",
+      "integrity": "sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
-        "env-paths": "^2.2.0",
-        "fs-extra": "^8.1.0",
-        "got": "^11.8.5",
+        "env-paths": "^3.0.0",
+        "graceful-fs": "^4.2.11",
         "progress": "^2.0.3",
-        "semver": "^6.2.0",
+        "semver": "^7.6.3",
         "sumchecker": "^3.0.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=22.12.0"
       },
       "optionalDependencies": {
-        "global-agent": "^3.0.0"
+        "undici": "^7.24.4"
       }
     },
-    "node_modules/@electron/get/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+    "node_modules/@electron/get/node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
       "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@electron/notarize": {
@@ -8475,22 +8477,22 @@
       }
     },
     "node_modules/electron": {
-      "version": "41.1.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-41.1.0.tgz",
-      "integrity": "sha512-0XRFyxRqetmqtkkBvV++wGbHYJ7bD++f6EgJW8y9kX4pPRagwlmKDtzqXZhKiu0DIQppm3sXxzHWK9GYP91OKQ==",
+      "version": "42.2.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-42.2.0.tgz",
+      "integrity": "sha512-b2Tc7sIKiZEl0tBVwFM5GJ+FT5KYhmy9QJHjx8BGVZPVW2SctXWEvrE959ElB56qw7H05dBkhlikDA1DmpaAMw==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@electron/get": "^2.0.0",
+        "@electron/get": "^5.0.0",
         "@types/node": "^24.9.0",
         "extract-zip": "^2.0.1"
       },
       "bin": {
-        "electron": "cli.js"
+        "electron": "cli.js",
+        "install-electron": "install.js"
       },
       "engines": {
-        "node": ">= 12.20.55"
+        "node": ">= 22.12.0"
       }
     },
     "node_modules/electron-builder": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "audit:scripts": "tsx scripts/audit-scripts.ts",
     "install:esbuild": "npm run audit:scripts && node node_modules/esbuild/install.js",
-    "install:electron": "npm run audit:scripts && node node_modules/electron/install.js",
+    "install:electron": "npx install-electron --no",
     "compile": "npm run install:esbuild && vite build",
     "serve": "npm run install:esbuild && vite -c vite.config-pwa.mts",
     "build": "npm run install:esbuild && vite build -c vite.config-pwa.mts --outDir docs/webapp",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "archiver": "^7.0.1",
     "concurrently": "^9.0.1",
     "depcheck": "^1.4.7",
-    "electron": "^41.1.0",
+    "electron": "^42.2.0",
     "electron-builder": "^26.8.1",
     "electron-devtools-installer": "^4.0.0",
     "eslint": "^9.39.2",

--- a/scripts/audit-scripts.ts
+++ b/scripts/audit-scripts.ts
@@ -15,7 +15,6 @@ function checkPackageJson(packageJsonPath: string) {
 
   switch (name) {
     // These packages have install.js scripts
-    case "electron":
     case "esbuild":
       if (!scripts?.postinstall) {
         throw new Error(`Package ${name}@${version} is missing postinstall scripts`);

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -200,7 +200,11 @@ app.whenReady().then(() => {
   app.dock?.setMenu(dockMenu);
 
   session.defaultSession.webRequest.onBeforeRequest((details, callback) => {
-    validateHTTPRequest(details.method, details.url);
+    // Electron 42.2.0 以降では検査後に発行しなおした net.fetch のリクエストも入ってくるようになったため
+    // webContentsId が存在する場合のみ URL を検査する。
+    if (details.webContentsId !== undefined) {
+      validateHTTPRequest(details.method, details.url);
+    }
     callback({});
   });
 


### PR DESCRIPTION
# 説明 / Description

Electron の仕様変更に対応

- postinstall スクリプトによるインストールの廃止に伴う対応
- Electron のインストールスクリプトの問題へのワークアラウンド
- onBeforeRequest の挙動への対応

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/shogihome/blob/main/CONTRIBUTING.md)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Dependencies**
  * Upgraded Electron to version 42.2.0

* **Bug Fixes**
  * Improved HTTP request validation in background processes for better compatibility
  * Enhanced macOS installation with automatic Apple Silicon architecture detection
<!-- end of auto-generated comment: release notes by coderabbit.ai -->