### PR TITLE
局面集に対して手数を指定する機能

### DIFF
--- a/src/common/settings/game.ts
+++ b/src/common/settings/game.ts
@@ -73,6 +73,7 @@ export type LinearGameSettings = Omit<SingleGameSettings, "startPosition"> & {
   startPosition: GameStartPositionType; // v1.21.0 から undefined を廃止
   startPositionListFile: string;
   startPositionListOrder: "sequential" | "shuffle";
+  startPositionListPly?: number;
   repeat: number;
   swapPlayers: boolean;
   sprtEnabled: boolean;
@@ -200,6 +201,12 @@ export function validateGameSettings(gameSettings: GameSettings): Error | undefi
     if (!(record instanceof Record)) {
       return record;
     }
+  }
+  if (
+    gameSettings.startPositionListPly !== undefined &&
+    (!Number.isInteger(gameSettings.startPositionListPly) || gameSettings.startPositionListPly < 1)
+  ) {
+    return new Error("Start position list ply must be a positive integer.");
   }
   if (!gameSettings.sprtEnabled && gameSettings.parallelism > gameSettings.repeat) {
     return new Error(t.parallelismMustLessThanOrEqualToRepeats);

--- a/src/renderer/game/coordinator.ts
+++ b/src/renderer/game/coordinator.ts
@@ -37,6 +37,7 @@ export async function buildGameCoordinator(params: {
       swapPlayers: settings.swapPlayers,
       order: settings.startPositionListOrder,
       maxGames: maxGames,
+      ply: settings.startPositionListPly,
     });
   } else if (settings.startPosition === "sfen") {
     startPositionUSI = settings.startPositionSFEN;

--- a/src/renderer/game/start_position.ts
+++ b/src/renderer/game/start_position.ts
@@ -19,6 +19,7 @@ export class StartPositionList {
     swapPlayers: boolean;
     order: "sequential" | "shuffle";
     maxGames: number;
+    ply?: number;
   }): Promise<void> {
     // load SFEN file
     const usiList = await api.loadSFENFile(params.filePath);
@@ -43,7 +44,7 @@ export class StartPositionList {
       }
     }
 
-    // validate USI
+    // validate USI and extract position at specified ply
     if (usiList.length === 0) {
       throw new Error("No available positions in the list.");
     }
@@ -51,6 +52,10 @@ export class StartPositionList {
       const record = Record.newByUSI(usiList[i]);
       if (!(record instanceof Record)) {
         throw record;
+      }
+      if (params.ply !== undefined) {
+        record.goto(params.ply - 1);
+        usiList[i] = record.getUSI();
       }
     }
 

--- a/src/renderer/view/dialog/GameDialog.vue
+++ b/src/renderer/view/dialog/GameDialog.vue
@@ -200,6 +200,19 @@
           <div v-show="gameSettings.startPosition === 'list'" class="form-item">
             <ToggleButton v-model:value="startPositionListShuffle" :label="t.shuffle" />
           </div>
+          <div v-show="gameSettings.startPosition === 'list'" class="form-item">
+            <ToggleButton v-model:value="startPositionListPlyEnabled" />
+            <div class="form-item-small-label">{{ t.plyPrefix }}</div>
+            <input
+              v-model.number="startPositionListPly"
+              class="number small"
+              type="number"
+              min="1"
+              step="1"
+              :disabled="!startPositionListPlyEnabled"
+            />
+            <div class="form-item-small-label">{{ t.plySuffix }}</div>
+          </div>
           <div class="form-item">
             <div class="form-item-label">{{ t.maxMoves }}</div>
             <input v-model.number="gameSettings.maxMoves" class="number" type="number" min="1" />
@@ -397,6 +410,8 @@ const whiteByoyomi = ref(0);
 const whiteIncrement = ref(0);
 const setDifferentTime = ref(false);
 const startPositionListShuffle = ref(false);
+const startPositionListPlyEnabled = ref(false);
+const startPositionListPly = ref(1);
 const gameSettings = ref(defaultGameSettings());
 const engines = ref(new USIEngines());
 const engineMetadataMap = reactive(new Map<string, USIEngineMetadata>());
@@ -423,6 +438,8 @@ onMounted(async () => {
     whiteIncrement.value = whiteTimeLimit.increment;
     setDifferentTime.value = !!gameSettings.value.whiteTimeLimit;
     startPositionListShuffle.value = gameSettings.value.startPositionListOrder === "shuffle";
+    startPositionListPlyEnabled.value = gameSettings.value.startPositionListPly !== undefined;
+    startPositionListPly.value = gameSettings.value.startPositionListPly ?? 1;
     machineSpec.value = await api.getMachineSpec();
   } catch (e) {
     useErrorStore().add(e);
@@ -533,6 +550,9 @@ const onStart = () => {
     },
     startPositionSFEN: gameSettings.value.startPositionSFEN.trim(),
     startPositionListOrder: startPositionListShuffle.value ? "shuffle" : "sequential",
+    startPositionListPly: startPositionListPlyEnabled.value
+      ? startPositionListPly.value
+      : undefined,
     searchCommentFormat: useAppSettings().searchCommentFormat,
   };
   if (newSettings.sprtEnabled) {

--- a/src/tests/common/settings/game.spec.ts
+++ b/src/tests/common/settings/game.spec.ts
@@ -145,6 +145,30 @@ describe("settings/game", () => {
     expect(validateGameSettings(settings)).toBeUndefined();
   });
 
+  it("validateGameSettings/startPositionListPly-valid", () => {
+    expect(
+      validateGameSettings({ ...baseGameSettings(), startPositionListPly: undefined }),
+    ).toBeUndefined();
+    expect(
+      validateGameSettings({ ...baseGameSettings(), startPositionListPly: 1 }),
+    ).toBeUndefined();
+    expect(
+      validateGameSettings({ ...baseGameSettings(), startPositionListPly: 100 }),
+    ).toBeUndefined();
+  });
+
+  it("validateGameSettings/startPositionListPly-invalid", () => {
+    const check = (ply: unknown) =>
+      validateGameSettings({
+        ...baseGameSettings(),
+        startPositionListPly: ply as number,
+      });
+    expect(check(0)?.message).toBe("Start position list ply must be a positive integer.");
+    expect(check(-1)?.message).toBe("Start position list ply must be a positive integer.");
+    expect(check(0.5)?.message).toBe("Start position list ply must be a positive integer.");
+    expect(check("")?.message).toBe("Start position list ply must be a positive integer.");
+  });
+
   it("validateGameSettings/sfen-invalid", () => {
     const settings: GameSettings = {
       ...baseGameSettings(),

--- a/src/tests/renderer/game/start_position.spec.ts
+++ b/src/tests/renderer/game/start_position.spec.ts
@@ -154,6 +154,66 @@ describe("game/start_position", () => {
     ).rejects.toThrow("No available positions in the list.");
   });
 
+  it("StartPositionList/ply", async () => {
+    mockAPI.loadSFENFile.mockImplementation(async () => [
+      "position startpos moves 2g2f 3c3d 7g7f",
+      "position startpos moves 7g7f 8c8d 2g2f",
+    ]);
+    const list = new StartPositionList();
+
+    // ply=1 → goto(0) → initial position (no moves)
+    await expect(
+      list.reset({
+        filePath: "path/to/file.sfen",
+        swapPlayers: false,
+        order: "sequential",
+        maxGames: 2,
+        ply: 1,
+      }),
+    ).resolves.toBeUndefined();
+    expect(list.next()).toBe("position startpos");
+    expect(list.next()).toBe("position startpos");
+
+    // ply=2 → goto(1) → one move
+    await expect(
+      list.reset({
+        filePath: "path/to/file.sfen",
+        swapPlayers: false,
+        order: "sequential",
+        maxGames: 2,
+        ply: 2,
+      }),
+    ).resolves.toBeUndefined();
+    expect(list.next()).toBe("position startpos moves 2g2f");
+    expect(list.next()).toBe("position startpos moves 7g7f");
+
+    // ply=3 → goto(2) → two moves
+    await expect(
+      list.reset({
+        filePath: "path/to/file.sfen",
+        swapPlayers: false,
+        order: "sequential",
+        maxGames: 2,
+        ply: 3,
+      }),
+    ).resolves.toBeUndefined();
+    expect(list.next()).toBe("position startpos moves 2g2f 3c3d");
+    expect(list.next()).toBe("position startpos moves 7g7f 8c8d");
+
+    // ply beyond record length → clamped to full record
+    await expect(
+      list.reset({
+        filePath: "path/to/file.sfen",
+        swapPlayers: false,
+        order: "sequential",
+        maxGames: 2,
+        ply: 100,
+      }),
+    ).resolves.toBeUndefined();
+    expect(list.next()).toBe("position startpos moves 2g2f 3c3d 7g7f");
+    expect(list.next()).toBe("position startpos moves 7g7f 8c8d 2g2f");
+  });
+
   it("StartPositionList/invalid", async () => {
     mockAPI.loadSFENFile.mockImplementation(async () => [
       "position startpos moves 2g2f 3c3d 7g7f",


### PR DESCRIPTION
# 説明 / Description

#1593 

対局開始局面に局面集を使用する際、局面集が USI 形式の棋譜になっている場合の初期局面からの手数を指定できるようにする。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/shogihome/blob/main/CONTRIBUTING.md)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration option for setting a starting move position (ply) when using list-based game starts. Users can now enable a toggle in the game settings dialog and specify a move number to begin games from within their loaded position list, with validation to ensure only positive integer values are accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->