### PR TITLE
連続対局の経過を表示するエリアを追加

### DIFF
--- a/src/renderer/view/main/ConsecutiveGameProgress.vue
+++ b/src/renderer/view/main/ConsecutiveGameProgress.vue
@@ -1,0 +1,83 @@
+<template>
+  <div class="consecutive-game-progress">
+    <table class="progress-table">
+      <thead>
+        <tr>
+          <th>{{ t.player }}</th>
+          <th>{{ t.winsOnBlack }}</th>
+          <th>{{ t.winsOnWhite }}</th>
+          <th>{{ t.wins }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="player-name">{{ results.player1.name }}</td>
+          <td>{{ results.player1.winBlack }}</td>
+          <td>{{ results.player1.winWhite }}</td>
+          <td>{{ results.player1.win }}</td>
+        </tr>
+        <tr>
+          <td class="player-name">{{ results.player2.name }}</td>
+          <td>{{ results.player2.winBlack }}</td>
+          <td>{{ results.player2.winWhite }}</td>
+          <td>{{ results.player2.win }}</td>
+        </tr>
+      </tbody>
+    </table>
+    <div class="progress-footer">
+      <span>{{ t.draws }}: {{ results.draw }}</span>
+      <span>
+        {{ t.validGames }}: {{ results.total - results.invalid
+        }}<template v-if="totalGames >= 2"> / {{ totalGames }}</template>
+      </span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { t } from "@/common/i18n";
+import { computed } from "vue";
+import { useStore } from "@/renderer/store";
+
+const store = useStore();
+
+const results = computed(() => store.gameResults);
+
+const totalGames = computed(() => store.gameSettings.repeat);
+</script>
+
+<style scoped>
+.consecutive-game-progress {
+  padding: 4px;
+  margin-top: 4px;
+  background-color: var(--text-bg-color);
+  color: var(--text-color);
+}
+.progress-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85em;
+}
+.progress-table th,
+.progress-table td {
+  border: 1px solid var(--main-bg-color);
+  padding: 2px 4px;
+  text-align: right;
+}
+.progress-table th:first-child,
+.progress-table td:first-child {
+  text-align: left;
+}
+.progress-table td.player-name {
+  max-width: 120px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.progress-footer {
+  display: flex;
+  gap: 8px;
+  font-size: 0.85em;
+  padding-top: 2px;
+}
+</style>

--- a/src/renderer/view/main/StandardLayout.vue
+++ b/src/renderer/view/main/StandardLayout.vue
@@ -24,11 +24,17 @@
               :right-control-type="appSettings.rightSideControlType"
               @resize="onBoardPaneResize"
             />
-            <RecordPane
-              :style="recordPaneStyle"
-              :show-comment="appSettings.showCommentInRecordView"
-              :show-elapsed-time="appSettings.showElapsedTimeInRecordView"
-            />
+            <div :style="recordPaneStyle" class="column">
+              <RecordPane
+                class="record-area"
+                :show-comment="appSettings.showCommentInRecordView"
+                :show-elapsed-time="appSettings.showElapsedTimeInRecordView"
+                :show-top-control="!isConsecutiveGame"
+                :show-bottom-control="!isConsecutiveGame"
+                :show-branches="!isConsecutiveGame"
+              />
+              <ConsecutiveGameProgress v-if="isConsecutiveGame" />
+            </div>
           </div>
           <button
             v-if="!isBottomPaneVisible"
@@ -112,6 +118,9 @@ import { t } from "@/common/i18n";
 import { reactive, onMounted, onUnmounted, computed, ref } from "vue";
 import BoardPane from "./BoardPane.vue";
 import RecordPane, { minWidth as minRecordWidth } from "./RecordPane.vue";
+import ConsecutiveGameProgress from "./ConsecutiveGameProgress.vue";
+import { useStore } from "@/renderer/store";
+import { AppState } from "@/common/control/state.js";
 import TabPane, { headerHeight as tabHeaderHeight } from "./TabPane.vue";
 import RecordComment from "@/renderer/view/tab/RecordComment.vue";
 import ControlPane, { ControlGroup } from "./ControlPane.vue";
@@ -132,7 +141,12 @@ const splitterWidth = 8;
 const margin = 10;
 const lazyUpdateDelay = 100;
 
+const store = useStore();
 const appSettings = useAppSettings();
+
+const isConsecutiveGame = computed(
+  () => store.appState === AppState.GAME && store.gameSettings.repeat >= 2,
+);
 const windowSize = reactive(new RectSize(window.innerWidth, window.innerHeight));
 const topPaneHeightPercentage = ref(appSettings.topPaneHeightPercentage);
 const bottomLeftPaneWidthPercentage = ref(appSettings.bottomLeftPaneWidthPercentage);
@@ -308,6 +322,10 @@ const tabPaneSize2a = computed(
 </style>
 
 <style scoped>
+.record-area {
+  flex: 1 1 0;
+  min-height: 0;
+}
 .shadow-bottom {
   box-shadow: 0px 6px 6px -3px var(--shadow-color);
 }


### PR DESCRIPTION
# 説明 / Description

#1624 

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/shogihome/blob/main/CONTRIBUTING.md)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a progress table for consecutive games displaying per-player win statistics (broken down by color), total wins, draws, valid games, and session repeat information for enhanced match tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->