### PR TITLE
エンジンオプション表示画面の微調整

### DIFF
--- a/src/renderer/view/dialog/USIEngineOptionsDialog.vue
+++ b/src/renderer/view/dialog/USIEngineOptionsDialog.vue
@@ -594,6 +594,7 @@ const cancel = () => {
 .option-list {
   width: 740px;
   height: calc(100vh - 250px);
+  padding-bottom: 25px;
   max-height: 800px;
   overflow: auto;
 }


### PR DESCRIPTION
# 説明 / Description

オプション一覧の最下部にパディングを追加する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/shogihome/blob/main/CONTRIBUTING.md)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing in the Engine Options dialog by adjusting bottom padding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->