### PR TITLE
メニューバー内の配置を調整

### DIFF
--- a/src/background/window/menu.ts
+++ b/src/background/window/menu.ts
@@ -556,30 +556,6 @@ function createMenuTemplate(window: BrowserWindow) {
       label: t.folders,
       submenu: [
         {
-          label: t.app,
-          click: () => {
-            openPath(path.dirname(getAppPath("exe"))).catch(sendError);
-          },
-        },
-        {
-          label: t.settings,
-          click: () => {
-            openSettingsDirectory().catch(sendError);
-          },
-        },
-        {
-          label: t.log,
-          click: () => {
-            openPath(getRootLogDir()).catch(sendError);
-          },
-        },
-        {
-          label: t.cache,
-          click: () => {
-            openCacheDirectory().catch(sendError);
-          },
-        },
-        {
           label: `${t.autoSaving} (Local)`,
           click: () => {
             openAutoSaveDirectory().catch(sendError);
@@ -590,6 +566,38 @@ function createMenuTemplate(window: BrowserWindow) {
           click: () => {
             openAutoSaveDirectoryForCSA().catch(sendError);
           },
+        },
+        {
+          type: "separator",
+        },
+        {
+          label: t.forDevelopers,
+          submenu: [
+            {
+              label: t.app,
+              click: () => {
+                openPath(path.dirname(getAppPath("exe"))).catch(sendError);
+              },
+            },
+            {
+              label: t.settings,
+              click: () => {
+                openSettingsDirectory().catch(sendError);
+              },
+            },
+            {
+              label: t.log,
+              click: () => {
+                openPath(getRootLogDir()).catch(sendError);
+              },
+            },
+            {
+              label: t.cache,
+              click: () => {
+                openCacheDirectory().catch(sendError);
+              },
+            },
+          ],
         },
       ],
     },


### PR DESCRIPTION
# 説明 / Description

開発者以外がアプリや設定のフォルダを開かないように、それらのフォルダを開くメニューを深い階層に配置する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/shogihome/blob/main/CONTRIBUTING.md)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n
