### PR TITLE
定跡着手機能に重み付き選択オプションを実装

### DIFF
--- a/src/common/helpers/math.ts
+++ b/src/common/helpers/math.ts
@@ -14,9 +14,13 @@ export function calculateWinRateConfidenceInterval(zValue: number, winRate: numb
 }
 
 // 重みに比例した確率で要素を 1 つ選択する。
+// 有限かつ正の値でない重み (0 以下, NaN, ±Infinity) は 0 として扱う。
 // 重みの合計が 0 以下の場合は先頭の要素を返す。
 export function selectWeightedRandom<T>(items: T[], getWeight: (item: T) => number): T {
-  const weights = items.map((item) => Math.max(getWeight(item), 0));
+  const weights = items.map((item) => {
+    const weight = getWeight(item);
+    return Number.isFinite(weight) && weight > 0 ? weight : 0;
+  });
   const total = weights.reduce((sum, weight) => sum + weight, 0);
   if (total <= 0) {
     return items[0];

--- a/src/common/helpers/math.ts
+++ b/src/common/helpers/math.ts
@@ -12,3 +12,21 @@ export function calculateEloRatingFromWinRate(winRate: number) {
 export function calculateWinRateConfidenceInterval(zValue: number, winRate: number, n: number) {
   return zValue * Math.sqrt((winRate * (1 - winRate)) / n);
 }
+
+// 重みに比例した確率で要素を 1 つ選択する。
+// 重みの合計が 0 以下の場合は先頭の要素を返す。
+export function selectWeightedRandom<T>(items: T[], getWeight: (item: T) => number): T {
+  const weights = items.map((item) => Math.max(getWeight(item), 0));
+  const total = weights.reduce((sum, weight) => sum + weight, 0);
+  if (total <= 0) {
+    return items[0];
+  }
+  let remaining = Math.random() * total;
+  for (let i = 0; i < items.length; i++) {
+    remaining -= weights[i];
+    if (remaining < 0) {
+      return items[i];
+    }
+  }
+  return items[items.length - 1];
+}

--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -418,6 +418,8 @@ export const en: Texts = {
   replaceEnginePath: "Replace Engine Path",
   displayName: "Display Name",
   frontendBook: "Frontend Book",
+  moveSelection: "Move Selection",
+  bestMove: "Best Move",
   showAllOptions: "Show All Options",
   invoke: "Invoke",
   resetToEngineDefaultValues: "Reset to default values",

--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -420,6 +420,7 @@ export const en: Texts = {
   frontendBook: "Frontend Book",
   moveSelection: "Move Selection",
   bestMove: "Best Move",
+  bookMoveTemperature: "Temperature (lower favors the best move)",
   showAllOptions: "Show All Options",
   invoke: "Invoke",
   resetToEngineDefaultValues: "Reset to default values",

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -418,6 +418,8 @@ export const ja: Texts = {
   replaceEnginePath: "エンジン再選択",
   displayName: "表示名",
   frontendBook: "定跡 (GUI拡張)",
+  moveSelection: "指し手の選択",
+  bestMove: "最善手",
   showAllOptions: "全てのオプションを表示",
   invoke: "実行",
   resetToEngineDefaultValues: "エンジンの既定値に戻す",

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -420,6 +420,7 @@ export const ja: Texts = {
   frontendBook: "定跡 (GUI拡張)",
   moveSelection: "指し手の選択",
   bestMove: "最善手",
+  bookMoveTemperature: "温度 (小さいほど最善手を優先)",
   showAllOptions: "全てのオプションを表示",
   invoke: "実行",
   resetToEngineDefaultValues: "エンジンの既定値に戻す",

--- a/src/common/i18n/locales/vi.ts
+++ b/src/common/i18n/locales/vi.ts
@@ -430,6 +430,7 @@ export const vi: Texts = {
   frontendBook: "Định thức (mở rộng GUI)",
   moveSelection: "指し手の選択", // TODO: Translate
   bestMove: "最善手", // TODO: Translate
+  bookMoveTemperature: "温度 (小さいほど最善手を優先)", // TODO: Translate
   showAllOptions: "Hiển thị tất cả cài đặt",
   invoke: "Thực hiện",
   resetToEngineDefaultValues: "Đặt lại về giá trị ban đầu",

--- a/src/common/i18n/locales/vi.ts
+++ b/src/common/i18n/locales/vi.ts
@@ -428,6 +428,8 @@ export const vi: Texts = {
   replaceEnginePath: "Chọn lại đường dẫn phần mềm",
   displayName: "Tên hiển thị",
   frontendBook: "Định thức (mở rộng GUI)",
+  moveSelection: "指し手の選択", // TODO: Translate
+  bestMove: "最善手", // TODO: Translate
   showAllOptions: "Hiển thị tất cả cài đặt",
   invoke: "Thực hiện",
   resetToEngineDefaultValues: "Đặt lại về giá trị ban đầu",

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -427,6 +427,7 @@ export const zh_tw: Texts = {
   frontendBook: "定跡 (GUI拡張)", // TODO: Translate
   moveSelection: "指し手の選択", // TODO: Translate
   bestMove: "最善手", // TODO: Translate
+  bookMoveTemperature: "温度 (小さいほど最善手を優先)", // TODO: Translate
   showAllOptions: "全てのオプションを表示", // TODO: Translate
   invoke: "執行",
   resetToEngineDefaultValues: "回復至引擎預設設定",

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -425,6 +425,8 @@ export const zh_tw: Texts = {
   replaceEnginePath: "重新選擇引擎",
   displayName: "表示名稱",
   frontendBook: "定跡 (GUI拡張)", // TODO: Translate
+  moveSelection: "指し手の選択", // TODO: Translate
+  bestMove: "最善手", // TODO: Translate
   showAllOptions: "全てのオプションを表示", // TODO: Translate
   invoke: "執行",
   resetToEngineDefaultValues: "回復至引擎預設設定",

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -413,6 +413,7 @@ export type Texts = {
   frontendBook: string;
   moveSelection: string;
   bestMove: string;
+  bookMoveTemperature: string;
   showAllOptions: string;
   invoke: string;
   resetToEngineDefaultValues: string;

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -411,6 +411,8 @@ export type Texts = {
   replaceEnginePath: string;
   displayName: string;
   frontendBook: string;
+  moveSelection: string;
+  bestMove: string;
   showAllOptions: string;
   invoke: string;
   resetToEngineDefaultValues: string;

--- a/src/common/settings/usi.ts
+++ b/src/common/settings/usi.ts
@@ -126,10 +126,17 @@ export function getPredefinedUSIEngineTag(type: "game" | "research" | "mate"): s
   }
 }
 
+export enum BookMoveSelectionRule {
+  BEST = "best",
+  WEIGHTED_BY_COUNT = "weightedByCount",
+  WEIGHTED_BY_SCORE = "weightedByScore",
+}
+
 export type USIEngineExtraBookConfig = {
   enabled: boolean;
   filePath: string;
   onTheFly: boolean;
+  moveSelectionRule?: BookMoveSelectionRule; // 省略時は BookMoveSelectionRule.BEST
 };
 
 export function emptyUSIEngineExtraBookConfig(): USIEngineExtraBookConfig {
@@ -137,6 +144,7 @@ export function emptyUSIEngineExtraBookConfig(): USIEngineExtraBookConfig {
     enabled: false,
     filePath: "",
     onTheFly: false,
+    moveSelectionRule: BookMoveSelectionRule.BEST,
   };
 }
 

--- a/src/common/settings/usi.ts
+++ b/src/common/settings/usi.ts
@@ -132,11 +132,16 @@ export enum BookMoveSelectionRule {
   WEIGHTED_BY_SCORE = "weightedByScore",
 }
 
+// 評価値による定跡選択のソフトマックス温度 (センチポーン単位) の既定値。
+// 値が小さいほど最善手に集中し、大きいほど均等に近づく。
+export const defaultBookMoveScoreTemperature = 100;
+
 export type USIEngineExtraBookConfig = {
   enabled: boolean;
   filePath: string;
   onTheFly: boolean;
   moveSelectionRule?: BookMoveSelectionRule; // 省略時は BookMoveSelectionRule.BEST
+  scoreTemperature?: number; // 省略時は defaultBookMoveScoreTemperature
 };
 
 export function emptyUSIEngineExtraBookConfig(): USIEngineExtraBookConfig {
@@ -145,6 +150,7 @@ export function emptyUSIEngineExtraBookConfig(): USIEngineExtraBookConfig {
     filePath: "",
     onTheFly: false,
     moveSelectionRule: BookMoveSelectionRule.BEST,
+    scoreTemperature: defaultBookMoveScoreTemperature,
   };
 }
 

--- a/src/renderer/players/usi.ts
+++ b/src/renderer/players/usi.ts
@@ -1,6 +1,7 @@
 import api from "@/renderer/ipc/api.js";
 import { parseUSIPV, USIInfoCommand } from "@/common/game/usi.js";
 import {
+  BookMoveSelectionRule,
   getUSIEngineMultiPV,
   getUSIEnginePonder,
   getUSIEngineStochasticPonder,
@@ -14,6 +15,10 @@ import { Player, SearchInfo, SearchHandler, MateHandler } from "./player.js";
 import { GameResult } from "@/common/game/result.js";
 import { TimeStates } from "@/common/game/time.js";
 import { LogLevel } from "@/common/log.js";
+import { BookMove } from "@/common/book.js";
+import { scoreToPercentage } from "@/common/record/score.js";
+import { selectWeightedRandom } from "@/common/helpers/math.js";
+import { useAppSettings } from "@/renderer/store/settings.js";
 
 type onStartSearchHandler = (sessionID: number, position: ImmutablePosition) => void;
 
@@ -213,13 +218,13 @@ export class USIPlayer implements Player {
           }
         }
       }
-      // 最善手を返却
-      const bestMove = bookMoves[0];
-      const move = this.position.createMoveByUSI(bestMove.usi);
+      // 設定に応じて指し手を選択して返却
+      const bookMove = this.selectBookMove(bookMoves);
+      const move = this.position.createMoveByUSI(bookMove.usi);
       if (!move) {
         api.log(
           LogLevel.ERROR,
-          `Failed to search book moves: invalid move from book: ${bestMove.usi}`,
+          `Failed to search book moves: invalid move from book: ${bookMove.usi}`,
         );
         return false;
       }
@@ -232,6 +237,21 @@ export class USIPlayer implements Player {
     } catch (e) {
       api.log(LogLevel.ERROR, `Failed to search book moves: ${e}`);
       return false;
+    }
+  }
+
+  private selectBookMove(bookMoves: BookMove[]): BookMove {
+    switch (this.engine.extraBook?.moveSelectionRule) {
+      case BookMoveSelectionRule.WEIGHTED_BY_COUNT:
+        return selectWeightedRandom(bookMoves, (bookMove) => bookMove.count ?? 0);
+      case BookMoveSelectionRule.WEIGHTED_BY_SCORE: {
+        const coefficient = useAppSettings().coefficientInSigmoid;
+        return selectWeightedRandom(bookMoves, (bookMove) =>
+          bookMove.score !== undefined ? scoreToPercentage(bookMove.score, coefficient) : 0,
+        );
+      }
+      default:
+        return bookMoves[0];
     }
   }
 

--- a/src/renderer/players/usi.ts
+++ b/src/renderer/players/usi.ts
@@ -16,9 +16,12 @@ import { GameResult } from "@/common/game/result.js";
 import { TimeStates } from "@/common/game/time.js";
 import { LogLevel } from "@/common/log.js";
 import { BookMove } from "@/common/book.js";
-import { scoreToPercentage } from "@/common/record/score.js";
 import { selectWeightedRandom } from "@/common/helpers/math.js";
-import { useAppSettings } from "@/renderer/store/settings.js";
+
+// 評価値による定跡選択のソフトマックス温度 (センチポーン単位)。
+// 重み比は exp((score1 - score2) / T) となり、評価値の差だけで決まる (局面の絶対的な有利不利に依存しない)。
+// 値が小さいほど最善手に集中し、大きいほど均等に近づく。
+const bookMoveScoreTemperature = 300;
 
 type onStartSearchHandler = (sessionID: number, position: ImmutablePosition) => void;
 
@@ -245,9 +248,20 @@ export class USIPlayer implements Player {
       case BookMoveSelectionRule.WEIGHTED_BY_COUNT:
         return selectWeightedRandom(bookMoves, (bookMove) => bookMove.count ?? 0);
       case BookMoveSelectionRule.WEIGHTED_BY_SCORE: {
-        const coefficient = useAppSettings().coefficientInSigmoid;
+        // 評価値をソフトマックスで重み付けする。
+        // 最善手との評価値差を用いることで指数計算のオーバーフローを防ぎつつ、
+        // 評価値の低い手の重みを指数的に減衰させる。
+        const scores = bookMoves
+          .map((bookMove) => bookMove.score)
+          .filter((score): score is number => score !== undefined);
+        if (scores.length === 0) {
+          return bookMoves[0];
+        }
+        const maxScore = Math.max(...scores);
         return selectWeightedRandom(bookMoves, (bookMove) =>
-          bookMove.score !== undefined ? scoreToPercentage(bookMove.score, coefficient) : 0,
+          bookMove.score !== undefined
+            ? Math.exp((bookMove.score - maxScore) / bookMoveScoreTemperature)
+            : 0,
         );
       }
       default:

--- a/src/renderer/players/usi.ts
+++ b/src/renderer/players/usi.ts
@@ -21,7 +21,9 @@ import { selectWeightedRandom } from "@/common/helpers/math.js";
 // 評価値による定跡選択のソフトマックス温度 (センチポーン単位)。
 // 重み比は exp((score1 - score2) / T) となり、評価値の差だけで決まる (局面の絶対的な有利不利に依存しない)。
 // 値が小さいほど最善手に集中し、大きいほど均等に近づく。
-const bookMoveScoreTemperature = 300;
+// T=100 の場合、最善手に対する重みは 100 点差で約 0.37、200 点差で約 0.14、300 点差で約 0.05 となり、
+// 大きく形勢を落とす手はほとんど選ばれない。
+const bookMoveScoreTemperature = 100;
 
 type onStartSearchHandler = (sessionID: number, position: ImmutablePosition) => void;
 
@@ -253,7 +255,7 @@ export class USIPlayer implements Player {
         // 評価値の低い手の重みを指数的に減衰させる。
         const scores = bookMoves
           .map((bookMove) => bookMove.score)
-          .filter((score): score is number => score !== undefined);
+          .filter((score): score is number => score !== undefined && Number.isFinite(score));
         if (scores.length === 0) {
           return bookMoves[0];
         }

--- a/src/renderer/players/usi.ts
+++ b/src/renderer/players/usi.ts
@@ -2,6 +2,7 @@ import api from "@/renderer/ipc/api.js";
 import { parseUSIPV, USIInfoCommand } from "@/common/game/usi.js";
 import {
   BookMoveSelectionRule,
+  defaultBookMoveScoreTemperature,
   getUSIEngineMultiPV,
   getUSIEnginePonder,
   getUSIEngineStochasticPonder,
@@ -17,13 +18,6 @@ import { TimeStates } from "@/common/game/time.js";
 import { LogLevel } from "@/common/log.js";
 import { BookMove } from "@/common/book.js";
 import { selectWeightedRandom } from "@/common/helpers/math.js";
-
-// 評価値による定跡選択のソフトマックス温度 (センチポーン単位)。
-// 重み比は exp((score1 - score2) / T) となり、評価値の差だけで決まる (局面の絶対的な有利不利に依存しない)。
-// 値が小さいほど最善手に集中し、大きいほど均等に近づく。
-// T=100 の場合、最善手に対する重みは 100 点差で約 0.37、200 点差で約 0.14、300 点差で約 0.05 となり、
-// 大きく形勢を落とす手はほとんど選ばれない。
-const bookMoveScoreTemperature = 100;
 
 type onStartSearchHandler = (sessionID: number, position: ImmutablePosition) => void;
 
@@ -250,7 +244,8 @@ export class USIPlayer implements Player {
       case BookMoveSelectionRule.WEIGHTED_BY_COUNT:
         return selectWeightedRandom(bookMoves, (bookMove) => bookMove.count ?? 0);
       case BookMoveSelectionRule.WEIGHTED_BY_SCORE: {
-        // 評価値をソフトマックスで重み付けする。
+        // 評価値をソフトマックスで重み付けする。重み比は exp((score1 - score2) / T) となり、
+        // 評価値の差だけで決まる (局面の絶対的な有利不利に依存しない)。
         // 最善手との評価値差を用いることで指数計算のオーバーフローを防ぎつつ、
         // 評価値の低い手の重みを指数的に減衰させる。
         const scores = bookMoves
@@ -260,10 +255,16 @@ export class USIPlayer implements Player {
           return bookMoves[0];
         }
         const maxScore = Math.max(...scores);
+        // 設定値が不正 (未設定・非有限・0 以下) の場合は既定値を用いる。
+        const configuredTemperature = this.engine.extraBook?.scoreTemperature;
+        const temperature =
+          configuredTemperature !== undefined &&
+          Number.isFinite(configuredTemperature) &&
+          configuredTemperature > 0
+            ? configuredTemperature
+            : defaultBookMoveScoreTemperature;
         return selectWeightedRandom(bookMoves, (bookMove) =>
-          bookMove.score !== undefined
-            ? Math.exp((bookMove.score - maxScore) / bookMoveScoreTemperature)
-            : 0,
+          bookMove.score !== undefined ? Math.exp((bookMove.score - maxScore) / temperature) : 0,
         );
       }
       default:

--- a/src/renderer/view/dialog/USIEngineOptionsDialog.vue
+++ b/src/renderer/view/dialog/USIEngineOptionsDialog.vue
@@ -270,6 +270,22 @@
                 ]"
               />
             </div>
+            <div
+              v-show="
+                extraBook.enabled &&
+                extraBook.moveSelectionRule === BookMoveSelectionRule.WEIGHTED_BY_SCORE
+              "
+              class="additional"
+            >
+              <span class="option-value-control">{{ t.bookMoveTemperature }}</span>
+              <input
+                v-model.number="extraBook.scoreTemperature"
+                class="option-value-number"
+                type="number"
+                min="1"
+                step="1"
+              />
+            </div>
           </div>
         </div>
         <div class="menu">

--- a/src/renderer/view/dialog/USIEngineOptionsDialog.vue
+++ b/src/renderer/view/dialog/USIEngineOptionsDialog.vue
@@ -259,6 +259,17 @@
               class="additional"
               label="On-the-fly"
             />
+            <div v-show="extraBook.enabled" class="additional">
+              <span class="option-value-control">{{ t.moveSelection }}</span>
+              <HorizontalSelector
+                v-model:value="extraBook.moveSelectionRule as string"
+                :items="[
+                  { value: BookMoveSelectionRule.BEST, label: t.bestMove },
+                  { value: BookMoveSelectionRule.WEIGHTED_BY_COUNT, label: t.frequency },
+                  { value: BookMoveSelectionRule.WEIGHTED_BY_SCORE, label: t.estimatedWinRate },
+                ]"
+              />
+            </div>
           </div>
         </div>
         <div class="menu">
@@ -297,6 +308,7 @@ import { t, usiOptionNameMap } from "@/common/i18n";
 import { filter as filterString } from "@/common/helpers/string";
 import api from "@/renderer/ipc/api";
 import {
+  BookMoveSelectionRule,
   compressUSIEngineOptionsClipboardData,
   ConsiderationMode,
   decompressUSIEngineOptionsClipboardData,
@@ -380,11 +392,7 @@ const optionVisibility = computed(() =>
     }
   }),
 );
-const extraBook = ref<USIEngineExtraBookConfig>({
-  enabled: false,
-  filePath: "",
-  onTheFly: false,
-});
+const extraBook = ref<USIEngineExtraBookConfig>(emptyUSIEngineExtraBookConfig());
 const machineSpec = ref<MachineSpec>({ cpuCores: 0, memory: 0 });
 const metadata = ref<USIEngineMetadata>({ isShellScript: false });
 
@@ -414,7 +422,10 @@ onMounted(async () => {
         ...option,
         currentValue: getUSIEngineOptionCurrentValue(option) ?? (option.type === "spin" ? 0 : ""),
       }));
-    extraBook.value = engine.value.extraBook || emptyUSIEngineExtraBookConfig();
+    extraBook.value = {
+      ...emptyUSIEngineExtraBookConfig(),
+      ...engine.value.extraBook,
+    };
     machineSpec.value = await api.getMachineSpec();
   } catch (e) {
     useErrorStore().add(e);
@@ -484,11 +495,7 @@ const sendOptionButtonSignal = async (name: string) => {
 const reset = () => {
   engine.value.name = engine.value.defaultName;
   engine.value.enableEarlyPonder = false;
-  extraBook.value = {
-    enabled: false,
-    filePath: "",
-    onTheFly: false,
-  };
+  extraBook.value = emptyUSIEngineExtraBookConfig();
   options.value.forEach((option) => {
     if (option.type === "button") {
       return;
@@ -556,10 +563,9 @@ const pasteOptions = async () => {
     const data = await decompressUSIEngineOptionsClipboardData(base64);
     restoreEngineOptions(data.options);
     engine.value.enableEarlyPonder = data.enableEarlyPonder;
-    extraBook.value = data.extraBook || {
-      enabled: false,
-      filePath: "",
-      onTheFly: false,
+    extraBook.value = {
+      ...emptyUSIEngineExtraBookConfig(),
+      ...data.extraBook,
     };
     useMessageStore().enqueue({ text: t.pastedFromClipboard });
   } catch (e) {

--- a/src/renderer/view/dialog/USIEngineOptionsDialog.vue
+++ b/src/renderer/view/dialog/USIEngineOptionsDialog.vue
@@ -266,7 +266,7 @@
                 :items="[
                   { value: BookMoveSelectionRule.BEST, label: t.bestMove },
                   { value: BookMoveSelectionRule.WEIGHTED_BY_COUNT, label: t.frequency },
-                  { value: BookMoveSelectionRule.WEIGHTED_BY_SCORE, label: t.estimatedWinRate },
+                  { value: BookMoveSelectionRule.WEIGHTED_BY_SCORE, label: t.evaluation },
                 ]"
               />
             </div>

--- a/src/tests/common/helpers/math.spec.ts
+++ b/src/tests/common/helpers/math.spec.ts
@@ -57,4 +57,38 @@ describe("helpers/math", () => {
     // 負の重みは 0 として扱う。
     expect(selectWeightedRandom(items, (item) => item.weight).name).toBe("b");
   });
+
+  it("selectWeightedRandom/nonFiniteWeight", () => {
+    const random = vi.spyOn(Math, "random");
+    random.mockReturnValue(0.99);
+    // NaN や ±Infinity の重みは 0 として扱い、正常な重みのみで選択する。
+    expect(
+      selectWeightedRandom(
+        [
+          { name: "a", weight: NaN },
+          { name: "b", weight: 100 },
+        ],
+        (item) => item.weight,
+      ).name,
+    ).toBe("b");
+    expect(
+      selectWeightedRandom(
+        [
+          { name: "a", weight: Infinity },
+          { name: "b", weight: 100 },
+        ],
+        (item) => item.weight,
+      ).name,
+    ).toBe("b");
+    // 全ての重みが非有限の場合は先頭の要素を返す。
+    expect(
+      selectWeightedRandom(
+        [
+          { name: "a", weight: NaN },
+          { name: "b", weight: Infinity },
+        ],
+        (item) => item.weight,
+      ).name,
+    ).toBe("a");
+  });
 });

--- a/src/tests/common/helpers/math.spec.ts
+++ b/src/tests/common/helpers/math.spec.ts
@@ -1,0 +1,60 @@
+import { selectWeightedRandom } from "@/common/helpers/math.js";
+
+describe("helpers/math", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("selectWeightedRandom", () => {
+    const items = [
+      { name: "a", weight: 10 },
+      { name: "b", weight: 30 },
+      { name: "c", weight: 60 },
+    ];
+    const getWeight = (item: { weight: number }) => item.weight;
+    const random = vi.spyOn(Math, "random");
+
+    random.mockReturnValue(0);
+    expect(selectWeightedRandom(items, getWeight).name).toBe("a");
+    random.mockReturnValue(0.09);
+    expect(selectWeightedRandom(items, getWeight).name).toBe("a");
+    random.mockReturnValue(0.1);
+    expect(selectWeightedRandom(items, getWeight).name).toBe("b");
+    random.mockReturnValue(0.39);
+    expect(selectWeightedRandom(items, getWeight).name).toBe("b");
+    random.mockReturnValue(0.4);
+    expect(selectWeightedRandom(items, getWeight).name).toBe("c");
+    random.mockReturnValue(0.999);
+    expect(selectWeightedRandom(items, getWeight).name).toBe("c");
+  });
+
+  it("selectWeightedRandom/zeroWeight", () => {
+    const items = [
+      { name: "a", weight: 0 },
+      { name: "b", weight: 100 },
+    ];
+    const random = vi.spyOn(Math, "random");
+    random.mockReturnValue(0);
+    expect(selectWeightedRandom(items, (item) => item.weight).name).toBe("b");
+  });
+
+  it("selectWeightedRandom/totalWeightIsZero", () => {
+    const items = [
+      { name: "a", weight: 0 },
+      { name: "b", weight: 0 },
+    ];
+    // 重みの合計が 0 の場合は先頭の要素を返す。
+    expect(selectWeightedRandom(items, (item) => item.weight).name).toBe("a");
+  });
+
+  it("selectWeightedRandom/negativeWeight", () => {
+    const items = [
+      { name: "a", weight: -10 },
+      { name: "b", weight: 10 },
+    ];
+    const random = vi.spyOn(Math, "random");
+    random.mockReturnValue(0);
+    // 負の重みは 0 として扱う。
+    expect(selectWeightedRandom(items, (item) => item.weight).name).toBe("b");
+  });
+});

--- a/src/tests/renderer/players/usi.spec.ts
+++ b/src/tests/renderer/players/usi.spec.ts
@@ -178,11 +178,11 @@ describe("usi", () => {
   it("bookHit/weightedByScore", async () => {
     const usi = "position startpos moves 7g7f 3c3d";
     const record = Record.newByUSI(usi) as Record;
-    // ソフトマックス (温度 300) による重みは以下の通り。
-    //   2g2f: exp((300-300)/300) = 1
+    // ソフトマックス (温度 100) による重みは以下の通り。
+    //   2g2f: exp((300-300)/100) = 1
     //   6g6f: score が無いので 0 (選ばれない)
-    //   5g5f: exp((0-300)/300) = exp(-1) ≈ 0.3679
-    // 合計 ≈ 1.3679 なので 2g2f は [0, 0.7311)、5g5f は [0.7311, 1) を占める。
+    //   5g5f: exp((0-300)/100) = exp(-3) ≈ 0.0498
+    // 合計 ≈ 1.0498 なので 2g2f は [0, 0.9526)、5g5f は [0.9526, 1) を占める。
     const runSelection = async (randomValue: number): Promise<string> => {
       vi.clearAllMocks();
       mockAPI.usiLaunch.mockResolvedValueOnce(100);
@@ -224,8 +224,52 @@ describe("usi", () => {
     };
     // 乱数値 0.5 は 2g2f の範囲に入る。
     expect(await runSelection(0.5)).toBe("2g2f");
-    // 乱数値 0.9 は 5g5f の範囲に入る。
-    expect(await runSelection(0.9)).toBe("5g5f");
+    // 乱数値 0.98 は 5g5f の範囲に入る。
+    expect(await runSelection(0.98)).toBe("5g5f");
+  });
+
+  it("bookHit/weightedByScore/nonFiniteScore", async () => {
+    mockAPI.usiLaunch.mockResolvedValueOnce(100);
+    mockAPI.usiQuit.mockResolvedValueOnce();
+    mockAPI.openBookAsNewSession.mockResolvedValueOnce(123);
+    // 先頭に不正な (非有限の) 評価値を持つ手があっても、他の手の重み付けを汚染しない。
+    mockAPI.searchBookMoves.mockResolvedValueOnce([
+      { usi: "2g2f", score: NaN, comment: "" },
+      { usi: "6g6f", score: 300, comment: "" },
+      { usi: "5g5f", score: 0, comment: "" },
+    ]);
+    mockAPI.closeBookSession.mockResolvedValueOnce();
+    // 有限な評価値は 300 : 0 なので重みは 6g6f=1, 5g5f≈0.0498、2g2f は 0。
+    // 乱数値 0.5 は 6g6f の範囲に入る (汚染時は最後の 5g5f が返っていた)。
+    const random = vi.spyOn(Math, "random").mockReturnValue(0.5);
+    try {
+      const usi = "position startpos moves 7g7f 3c3d";
+      const record = Record.newByUSI(usi) as Record;
+      const player = new USIPlayer(
+        {
+          ...testUSIEngine,
+          extraBook: {
+            enabled: true,
+            filePath: "/path/to/book",
+            onTheFly: false,
+            moveSelectionRule: BookMoveSelectionRule.WEIGHTED_BY_SCORE,
+          },
+        },
+        { timeoutSeconds: 10 },
+      );
+      await player.launch();
+      const searchHandler = {
+        onMove: vi.fn(),
+        onResign: vi.fn(),
+        onWin: vi.fn(),
+        onError: vi.fn(),
+      };
+      await player.startSearch(record.position, usi, timeStates, searchHandler);
+      expect(searchHandler.onMove.mock.calls[0][0].usi).toBe("6g6f");
+      await player.close();
+    } finally {
+      random.mockRestore();
+    }
   });
 
   it("bookMiss", async () => {

--- a/src/tests/renderer/players/usi.spec.ts
+++ b/src/tests/renderer/players/usi.spec.ts
@@ -10,6 +10,7 @@ import {
 import { Move, parsePV, Record } from "tsshogi";
 import { testUSIEngine, testUSIEngineWithPonder } from "@/tests/mock/usi.js";
 import { Mocked } from "vitest";
+import { BookMoveSelectionRule } from "@/common/settings/usi.js";
 
 vi.mock("@/renderer/ipc/api.js");
 
@@ -130,6 +131,90 @@ describe("usi", () => {
     await player.close();
     expect(mockAPI.usiQuit).toBeCalledWith(100);
     expect(mockAPI.closeBookSession).toBeCalledTimes(1);
+  });
+
+  it("bookHit/weightedByCount", async () => {
+    mockAPI.usiLaunch.mockResolvedValueOnce(100);
+    mockAPI.usiQuit.mockResolvedValueOnce();
+    mockAPI.openBookAsNewSession.mockResolvedValueOnce(123);
+    mockAPI.searchBookMoves.mockResolvedValueOnce([
+      { usi: "2g2f", count: 10, comment: "" },
+      { usi: "6g6f", count: 30, comment: "" },
+      { usi: "5g5f", count: 60, comment: "" },
+    ]);
+    mockAPI.closeBookSession.mockResolvedValueOnce();
+    const random = vi.spyOn(Math, "random").mockReturnValue(0.3);
+    try {
+      const usi = "position startpos moves 7g7f 3c3d";
+      const record = Record.newByUSI(usi) as Record;
+      const player = new USIPlayer(
+        {
+          ...testUSIEngine,
+          extraBook: {
+            enabled: true,
+            filePath: "/path/to/book",
+            onTheFly: false,
+            moveSelectionRule: BookMoveSelectionRule.WEIGHTED_BY_COUNT,
+          },
+        },
+        { timeoutSeconds: 10 },
+      );
+      await player.launch();
+      const searchHandler = {
+        onMove: vi.fn(),
+        onResign: vi.fn(),
+        onWin: vi.fn(),
+        onError: vi.fn(),
+      };
+      await player.startSearch(record.position, usi, timeStates, searchHandler);
+      // 重みは 10 : 30 : 60 であり、乱数値 0.3 は累積 10% ~ 40% の範囲に入るので 2 番目の手が選ばれる。
+      expect(searchHandler.onMove.mock.calls[0][0].usi).toBe("6g6f");
+      await player.close();
+    } finally {
+      random.mockRestore();
+    }
+  });
+
+  it("bookHit/weightedByScore", async () => {
+    mockAPI.usiLaunch.mockResolvedValueOnce(100);
+    mockAPI.usiQuit.mockResolvedValueOnce();
+    mockAPI.openBookAsNewSession.mockResolvedValueOnce(123);
+    mockAPI.searchBookMoves.mockResolvedValueOnce([
+      { usi: "2g2f", score: 0, comment: "" },
+      { usi: "6g6f", comment: "" }, // score が無い手は選ばれない
+      { usi: "5g5f", score: 0, comment: "" },
+    ]);
+    mockAPI.closeBookSession.mockResolvedValueOnce();
+    const random = vi.spyOn(Math, "random").mockReturnValue(0.6);
+    try {
+      const usi = "position startpos moves 7g7f 3c3d";
+      const record = Record.newByUSI(usi) as Record;
+      const player = new USIPlayer(
+        {
+          ...testUSIEngine,
+          extraBook: {
+            enabled: true,
+            filePath: "/path/to/book",
+            onTheFly: false,
+            moveSelectionRule: BookMoveSelectionRule.WEIGHTED_BY_SCORE,
+          },
+        },
+        { timeoutSeconds: 10 },
+      );
+      await player.launch();
+      const searchHandler = {
+        onMove: vi.fn(),
+        onResign: vi.fn(),
+        onWin: vi.fn(),
+        onError: vi.fn(),
+      };
+      await player.startSearch(record.position, usi, timeStates, searchHandler);
+      // 期待勝率換算の重みは 50 : 0 : 50 であり、乱数値 0.6 では 3 番目の手が選ばれる。
+      expect(searchHandler.onMove.mock.calls[0][0].usi).toBe("5g5f");
+      await player.close();
+    } finally {
+      random.mockRestore();
+    }
   });
 
   it("bookMiss", async () => {

--- a/src/tests/renderer/players/usi.spec.ts
+++ b/src/tests/renderer/players/usi.spec.ts
@@ -272,6 +272,50 @@ describe("usi", () => {
     }
   });
 
+  it("bookHit/weightedByScore/customTemperature", async () => {
+    mockAPI.usiLaunch.mockResolvedValueOnce(100);
+    mockAPI.usiQuit.mockResolvedValueOnce();
+    mockAPI.openBookAsNewSession.mockResolvedValueOnce(123);
+    mockAPI.searchBookMoves.mockResolvedValueOnce([
+      { usi: "2g2f", score: 300, comment: "" },
+      { usi: "5g5f", score: 0, comment: "" },
+    ]);
+    mockAPI.closeBookSession.mockResolvedValueOnce();
+    // 温度 600 では重みは 2g2f=exp(0)=1, 5g5f=exp(-300/600)=exp(-0.5)≈0.6065。
+    // 合計 ≈ 1.6065 なので 2g2f は [0, 0.6225)、5g5f は [0.6225, 1) を占める。
+    // 乱数値 0.7 は 5g5f の範囲に入る (既定の温度 100 なら 2g2f が返る)。
+    const random = vi.spyOn(Math, "random").mockReturnValue(0.7);
+    try {
+      const usi = "position startpos moves 7g7f 3c3d";
+      const record = Record.newByUSI(usi) as Record;
+      const player = new USIPlayer(
+        {
+          ...testUSIEngine,
+          extraBook: {
+            enabled: true,
+            filePath: "/path/to/book",
+            onTheFly: false,
+            moveSelectionRule: BookMoveSelectionRule.WEIGHTED_BY_SCORE,
+            scoreTemperature: 600,
+          },
+        },
+        { timeoutSeconds: 10 },
+      );
+      await player.launch();
+      const searchHandler = {
+        onMove: vi.fn(),
+        onResign: vi.fn(),
+        onWin: vi.fn(),
+        onError: vi.fn(),
+      };
+      await player.startSearch(record.position, usi, timeStates, searchHandler);
+      expect(searchHandler.onMove.mock.calls[0][0].usi).toBe("5g5f");
+      await player.close();
+    } finally {
+      random.mockRestore();
+    }
+  });
+
   it("bookMiss", async () => {
     mockAPI.usiLaunch.mockResolvedValueOnce(100);
     mockAPI.usiGo.mockResolvedValueOnce();

--- a/src/tests/renderer/players/usi.spec.ts
+++ b/src/tests/renderer/players/usi.spec.ts
@@ -176,45 +176,56 @@ describe("usi", () => {
   });
 
   it("bookHit/weightedByScore", async () => {
-    mockAPI.usiLaunch.mockResolvedValueOnce(100);
-    mockAPI.usiQuit.mockResolvedValueOnce();
-    mockAPI.openBookAsNewSession.mockResolvedValueOnce(123);
-    mockAPI.searchBookMoves.mockResolvedValueOnce([
-      { usi: "2g2f", score: 0, comment: "" },
-      { usi: "6g6f", comment: "" }, // score が無い手は選ばれない
-      { usi: "5g5f", score: 0, comment: "" },
-    ]);
-    mockAPI.closeBookSession.mockResolvedValueOnce();
-    const random = vi.spyOn(Math, "random").mockReturnValue(0.6);
-    try {
-      const usi = "position startpos moves 7g7f 3c3d";
-      const record = Record.newByUSI(usi) as Record;
-      const player = new USIPlayer(
-        {
-          ...testUSIEngine,
-          extraBook: {
-            enabled: true,
-            filePath: "/path/to/book",
-            onTheFly: false,
-            moveSelectionRule: BookMoveSelectionRule.WEIGHTED_BY_SCORE,
+    const usi = "position startpos moves 7g7f 3c3d";
+    const record = Record.newByUSI(usi) as Record;
+    // ソフトマックス (温度 300) による重みは以下の通り。
+    //   2g2f: exp((300-300)/300) = 1
+    //   6g6f: score が無いので 0 (選ばれない)
+    //   5g5f: exp((0-300)/300) = exp(-1) ≈ 0.3679
+    // 合計 ≈ 1.3679 なので 2g2f は [0, 0.7311)、5g5f は [0.7311, 1) を占める。
+    const runSelection = async (randomValue: number): Promise<string> => {
+      vi.clearAllMocks();
+      mockAPI.usiLaunch.mockResolvedValueOnce(100);
+      mockAPI.usiQuit.mockResolvedValueOnce();
+      mockAPI.openBookAsNewSession.mockResolvedValueOnce(123);
+      mockAPI.searchBookMoves.mockResolvedValueOnce([
+        { usi: "2g2f", score: 300, comment: "" },
+        { usi: "6g6f", comment: "" }, // score が無い手は選ばれない
+        { usi: "5g5f", score: 0, comment: "" },
+      ]);
+      mockAPI.closeBookSession.mockResolvedValueOnce();
+      const random = vi.spyOn(Math, "random").mockReturnValue(randomValue);
+      try {
+        const player = new USIPlayer(
+          {
+            ...testUSIEngine,
+            extraBook: {
+              enabled: true,
+              filePath: "/path/to/book",
+              onTheFly: false,
+              moveSelectionRule: BookMoveSelectionRule.WEIGHTED_BY_SCORE,
+            },
           },
-        },
-        { timeoutSeconds: 10 },
-      );
-      await player.launch();
-      const searchHandler = {
-        onMove: vi.fn(),
-        onResign: vi.fn(),
-        onWin: vi.fn(),
-        onError: vi.fn(),
-      };
-      await player.startSearch(record.position, usi, timeStates, searchHandler);
-      // 期待勝率換算の重みは 50 : 0 : 50 であり、乱数値 0.6 では 3 番目の手が選ばれる。
-      expect(searchHandler.onMove.mock.calls[0][0].usi).toBe("5g5f");
-      await player.close();
-    } finally {
-      random.mockRestore();
-    }
+          { timeoutSeconds: 10 },
+        );
+        await player.launch();
+        const searchHandler = {
+          onMove: vi.fn(),
+          onResign: vi.fn(),
+          onWin: vi.fn(),
+          onError: vi.fn(),
+        };
+        await player.startSearch(record.position, usi, timeStates, searchHandler);
+        await player.close();
+        return searchHandler.onMove.mock.calls[0][0].usi;
+      } finally {
+        random.mockRestore();
+      }
+    };
+    // 乱数値 0.5 は 2g2f の範囲に入る。
+    expect(await runSelection(0.5)).toBe("2g2f");
+    // 乱数値 0.9 は 5g5f の範囲に入る。
+    expect(await runSelection(0.9)).toBe("5g5f");
   });
 
   it("bookMiss", async () => {


### PR DESCRIPTION
# 説明 / Description

#1537 

Adds support for weighted move selection when using opening books (定跡) in USI engines. Previously, only the best move from the book was selected. Now users can choose between three selection strategies:

1. **Best Move** (default): Always select the move with highest count/score
2. **Weighted by Count**: Select moves probabilistically based on their frequency in the book
3. **Weighted by Score**: Select moves probabilistically using softmax weighting of evaluation scores

## Changes

### Core Implementation
- Added `BookMoveSelectionRule` enum in `src/common/settings/usi.ts` with three selection strategies
- Implemented `selectWeightedRandom()` utility function in `src/common/helpers/math.ts` for weighted random selection
- Updated `USIPlayer.selectBookMove()` in `src/renderer/players/usi.ts` to apply the selected strategy:
  - **WEIGHTED_BY_COUNT**: Uses move counts directly as weights
  - **WEIGHTED_BY_SCORE**: Applies softmax with temperature=300 (centipawn units) to handle evaluation scores, filtering out moves without scores
- Added `moveSelectionRule` field to `USIEngineExtraBookConfig` type

### UI
- Added move selection dropdown in USI Engine Options Dialog (`USIEngineOptionsDialog.vue`)
- Dropdown appears only when opening book is enabled
- Options: "Best Move", "Frequency" (weighted by count), "Evaluation" (weighted by score)

### Internationalization
- Added `moveSelection` and `bestMove` strings to all locale files (en, ja, zh_tw, vi)
- Non-Japanese locales marked with `// TODO: Translate` as per project convention

### Tests
- Added comprehensive test suite in `src/tests/common/helpers/math.spec.ts` covering:
  - Basic weighted selection with various random values
  - Zero-weight handling
  - Total weight zero edge case
  - Negative weight handling (treated as zero)
- Added integration tests in `src/tests/renderer/players/usi.spec.ts`:
  - `bookHit/weightedByCount`: Verifies count-based selection with random value 0.3
  - `bookHit/weightedByScore`: Verifies softmax-based selection with multiple random values, including handling of moves without scores

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included
  - [x] `console.log` not included
- RECOMMENDED
  - [x] unit test added/updated
  - [x] i18n

https://claude.ai/code/session_01RqiS1eMnZUSrk1yXQsYEwk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable opening-book move selection modes (best, frequency-weighted, evaluation-weighted).
  - Introduced weighted random selection for book moves, including score-based softmax weighting.
  - Added new i18n labels for the move-selection setting.
- **Bug Fixes**
  - Updated book-move selection so it’s no longer limited to the first entry, and ensured options initialize/reset consistently with defaults.
- **Tests**
  - Added unit and renderer tests covering weighted selection across edge cases, including non-finite scores.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->