### PR TITLE
Use dedicated tsconfig and caching for lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "bench": "npm run install:esbuild && npm run install:electron && vitest bench",
     "coverage": "npm test -- --coverage",
     "test:ui": "npm run install:esbuild && npm run install:electron && vitest --ui --coverage",
-    "lint": "vue-tsc --noEmit -p tsconfig.lint.json && eslint --cache --cache-location node_modules/.cache/eslint/ --fix --max-warnings 0 . && prettier --cache --cache-location node_modules/.cache/prettier/ --write .",
+    "lint": "vue-tsc --noEmit -p tsconfig.lint.json && eslint --cache --cache-location node_modules/.cache/eslint/ --fix --max-warnings 0 . && prettier --cache --cache-location node_modules/.cache/prettier/.prettier-cache --write .",
     "electron:compile": "npm run install:electron && tsc --project ./tsconfig.bg.json && tsc-alias && webpack --config-name preload",
     "electron:compile:serve": "npm run install:electron && tsc --project ./tsconfig.bg.json && tsc-alias && webpack --config-name preload --env dev",
     "electron:compile-all": "npm run compile && npm run electron:compile",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "bench": "npm run install:esbuild && npm run install:electron && vitest bench",
     "coverage": "npm test -- --coverage",
     "test:ui": "npm run install:esbuild && npm run install:electron && vitest --ui --coverage",
-    "lint": "vue-tsc --noEmit && eslint --fix --max-warnings 0 . && prettier --write .",
+    "lint": "vue-tsc --noEmit -p tsconfig.lint.json && eslint --cache --cache-location node_modules/.cache/eslint/ --fix --max-warnings 0 . && prettier --cache --cache-location node_modules/.cache/prettier/ --write .",
     "electron:compile": "npm run install:electron && tsc --project ./tsconfig.bg.json && tsc-alias && webpack --config-name preload",
     "electron:compile:serve": "npm run install:electron && tsc --project ./tsconfig.bg.json && tsc-alias && webpack --config-name preload --env dev",
     "electron:compile-all": "npm run compile && npm run electron:compile",

--- a/tsconfig.lint.json
+++ b/tsconfig.lint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "incremental": true,
+    "tsBuildInfoFile": "./node_modules/.cache/vue-tsc/tsconfig.lint.tsbuildinfo"
+  }
+}


### PR DESCRIPTION
### Motivation
- Improve lint performance and avoid full type-check by using a dedicated lint tsconfig and enabling caching for ESLint and Prettier.

### Description
- Updated the `lint` script in `package.json` to run `vue-tsc --noEmit -p tsconfig.lint.json` and added cache options for `eslint` and `prettier`, and added `tsconfig.lint.json` which extends `tsconfig.json` and sets `incremental` and `tsBuildInfoFile` to `./node_modules/.cache/vue-tsc/tsconfig.lint.tsbuildinfo`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a534107695883218b771f4e73220d5c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved linting and formatting workflows with caching to speed up repeat runs.
  * Updated the lint TypeScript validation to use a dedicated lint configuration.
  * Enabled incremental type-checking with cached build information to reduce processing time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->