### PR TITLE
分岐が多い場合に「本譜へ戻る」ボタンの表示位置がおかしくなる問題を修正

### DIFF
--- a/src/renderer/view/primitive/RecordView.vue
+++ b/src/renderer/view/primitive/RecordView.vue
@@ -50,7 +50,7 @@
     <div v-else-if="showBranches" class="row branch-list-area">
       <!-- NOTE: 背景だけを透過させるために背景専用の要素を作る。 -->
       <div class="move-list-background" :style="{ opacity }"></div>
-      <div class="auto column regular-interval branch-list-main">
+      <div class="auto column branch-list-main">
         <div ref="branchList" class="auto full branch-list">
           <div
             v-for="(branch, index) in branches"
@@ -380,6 +380,7 @@ onUpdated(() => {
   overflow-y: auto;
 }
 .branch-list {
+  min-height: 0;
   color: var(--text-color);
 }
 .branch-bottom-control {


### PR DESCRIPTION
# 説明 / Description

分岐が多い場合に「本譜へ戻る」ボタンの表示位置がおかしくなる問題を修正

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/shogihome/blob/main/CONTRIBUTING.md)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated
  - [x] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved branch list layout and scrolling behavior.
  * Updated branch list styling for more consistent sizing, including refined container sizing and improved overflow handling.
  * Adjusted branch list styling to prevent layout issues when space is constrained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->