### PR TITLE
Fix Safari hand markers in position image

### DIFF
--- a/src/renderer/view/primitive/SimpleBoardView.vue
+++ b/src/renderer/view/primitive/SimpleBoardView.vue
@@ -65,14 +65,20 @@
         </text>
       </svg>
       <div class="column reverse" :style="layout.blackHand.style">
-        <span class="hand black" :class="layout.typefaceClass" :style="layout.blackHand.textStyle"
-          >☗{{ layout.blackHand.text }}</span
-        >
+        <span class="hand black" :class="layout.typefaceClass" :style="layout.blackHand.textStyle">
+          <svg class="hand-marker black" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M12 1 22 5 19 23H5L2 5Z" />
+          </svg>
+          <span>{{ layout.blackHand.text }}</span>
+        </span>
       </div>
       <div v-if="!hideWhiteHand" class="column reverse" :style="layout.whiteHand.style">
-        <span class="hand white" :class="layout.typefaceClass" :style="layout.whiteHand.textStyle"
-          >☖{{ layout.whiteHand.text }}</span
-        >
+        <span class="hand white" :class="layout.typefaceClass" :style="layout.whiteHand.textStyle">
+          <svg class="hand-marker white" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M12 1 22 5 19 23H5L2 5Z" />
+          </svg>
+          <span>{{ layout.whiteHand.text }}</span>
+        </span>
       </div>
     </div>
   </div>
@@ -358,5 +364,21 @@ const layout = computed(() => {
   display: inline-block;
   text-orientation: upright;
   letter-spacing: 0px;
+}
+.hand-marker {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  writing-mode: horizontal-tb;
+  overflow: visible;
+}
+.hand-marker.black {
+  fill: black;
+}
+.hand-marker.white {
+  fill: white;
+  stroke: black;
+  stroke-width: 1.5px;
+  stroke-linejoin: round;
 }
 </style>

--- a/src/tests/renderer/view/primitive/simple-board.spec.ts
+++ b/src/tests/renderer/view/primitive/simple-board.spec.ts
@@ -81,4 +81,17 @@ describe("SimpleBoardView", () => {
     }
     expect(parseDy(blackPiece.attributes("dy"))).toBe(0);
   });
+
+  it("renders hand markers separately from vertical hand text", () => {
+    const wrapper = mountSimpleBoard();
+    const hands = wrapper.findAll(".hand");
+
+    expect(hands).toHaveLength(2);
+    expect(hands[0].find(".hand-marker.black").exists()).toBeTruthy();
+    expect(hands[1].find(".hand-marker.white").exists()).toBeTruthy();
+    expect(hands[0].text()).not.toContain("☗");
+    expect(hands[1].text()).not.toContain("☖");
+    expect(hands[0].text()).toContain("なし");
+    expect(hands[1].text()).toContain("なし");
+  });
 });


### PR DESCRIPTION
## 説明

Fixes #1489 のうち、書籍風局面図の持ち駒表示が Safari / WebKit で崩れる問題を修正します。

コントロールメニューの問題はすでに 26aaeff7 (Fix control pane for safari) で対応済みのため、この PR は未解決の局面図表示だけを対象にしています。

原因は、縦書きのテキスト内で Unicode の ☗ / ☖ を使用していることでした。WebKit ではフォントフォールバックと文字方向の組み合わせによって字形が崩れます。

黒・白の駒印をインライン SVG として明示的に描画し、縦書きのテキストから分離しました。これにより、フォントの Unicode 字形に依存せず、盤面反転時も親要素の回転に合わせて表示されます。

## 確認

- Safari 26.5 で現行のコントロールメニューがすでに修正済みであることを確認
- WebKit と Chromium で、書籍風局面図の持ち駒表示を確認
- WebKit で再現していた白い駒印の崩れがなくなることを確認
- ゴシック体 / 明朝体、盤面反転、持ち駒ラベルの表示を確認
- `npm test` (85 files, 552 tests)
- `npm run lint`
- `npm run compile`

## チェックリスト

- [x] `npm test` passed
- [x] `npm run lint` was applied without warnings
- [x] changes of `/docs/webapp` not included
- [x] `console.log` not included
- [x] understand `CONTRIBUTING.md`
- [x] unit test added/updated
- [x] i18n not required (no user-facing text added)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Replaced text-based hand indicators with clear inline markers for black and white pieces.
  * Improved marker styling and visual separation from the hand text.

* **Bug Fixes**
  * Prevented hand text from displaying unnecessary symbol characters while preserving the hand status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->