### PR TITLE
Refactor release workflow to use workflow_dispatch with CI automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,82 @@ permissions:
   contents: write
 
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: "Release type (see specs/release-workflow.md)"
+        required: true
+        type: choice
+        options:
+          - minor # x.y.z -> x.(y+1).0
+          - patch # x.y.z -> x.y.(z+1)
+          - major # x.y.z -> (x+1).0.0
+          - preminor-alpha # x.y.z -> x.(y+1).0-alpha.0
+          - preminor-beta # x.y.z -> x.(y+1).0-beta.0
+          - prerelease # x.y.z-alpha.n -> x.y.z-alpha.(n+1)
+          - prerelease-beta # x.y.z-alpha.n -> x.y.z-beta.0
+          - finalize # x.y.z-pre.n -> x.y.z
+      dry_run:
+        description: "Validate and bump without pushing (no tag/branch push, no build)"
+        type: boolean
+        default: false
 
 jobs:
+  # Phase 1: run the quality gate and a build (compile) check, then create the
+  # release commit and tag. Nothing is pushed until every check above passes.
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.release.outputs.tag }}
+      version: ${{ steps.release.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7.0.0
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - uses: actions/setup-node@v6.4.0
+        with:
+          # Do not use Node.js v24.16.0 or later
+          # See: https://github.com/electron/electron/issues/51619
+          node-version: v24.15.0
+          cache: "npm"
+      - run: npm install -g npm@latest
+      - run: npm version
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      # Quality gate (mirrors test.yml)
+      - name: Verify package-lock.json integrity
+        run: node scripts/verify-lockfile.mjs
+      - run: npm ci --no-audit --no-fund
+      - run: npm run lint
+      - run: npm run docs
+      - run: git diff --exit-code
+      - run: npm run license
+      - run: npm run coverage
+
+      # Build gate: compile web + electron main/preload/background.
+      - run: npm run electron:pack
+
+      # Bump the version, update the website assets (final versions only),
+      # and create the release commit and tag locally.
+      - name: Prepare release
+        id: release
+        run: npm run release:ci -- ${{ inputs.release_type }}
+
+      # Push the branch and tag only after the gate and build succeeded.
+      - name: Push branch and tag
+        if: ${{ !inputs.dry_run }}
+        run: |
+          git push origin HEAD:${{ github.ref_name }}
+          git push origin "${{ steps.release.outputs.tag }}"
+
+  # Phase 2: build platform installers from the pushed tag.
   build:
+    needs: prepare
+    if: ${{ !inputs.dry_run }}
     strategy:
       matrix:
         include:
@@ -30,6 +100,8 @@ jobs:
       - run: git config --global core.autocrlf false
         if: matrix.os == 'windows'
       - uses: actions/checkout@v7.0.0
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
       - uses: actions/setup-node@v6.4.0
         with:
           node-version: lts/*
@@ -41,16 +113,21 @@ jobs:
         if: matrix.variant != 'portable'
       - run: npm run electron:portable
         if: matrix.variant == 'portable'
-      - run: node scripts/archive.mjs ${{ matrix.os_short }} ${{ github.ref_name }} ${{ matrix.variant }}
+      - run: node scripts/archive.mjs ${{ matrix.os_short }} ${{ needs.prepare.outputs.tag }} ${{ matrix.variant }}
       - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.os }}${{ matrix.variant == 'portable' && '-portable' || '' }}-release
           path: dist/release-*.zip
+
+  # Phase 3: gather the installers into a draft GitHub Release.
   release:
-    needs: build
+    needs: [prepare, build]
+    if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7.0.0
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
       - uses: actions/download-artifact@v8
         with:
           path: dist
@@ -63,4 +140,4 @@ jobs:
             dist/release-*.zip
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ github.ref_name }}
+          TAG_NAME: ${{ needs.prepare.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,6 @@ jobs:
         with:
           name: ${{ matrix.os }}${{ matrix.variant == 'portable' && '-portable' || '' }}-release
           path: dist/release-*.zip
-          persist-credentials: false
 
   # Phase 3: gather the installers into a draft GitHub Release.
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,6 @@ jobs:
     outputs:
       tag: ${{ steps.release.outputs.tag }}
       version: ${{ steps.release.outputs.version }}
-      pr_number: ${{ steps.create-pr.outputs.pull-request-number }}
     steps:
       - uses: actions/checkout@v7.0.0
         with:
@@ -71,7 +70,9 @@ jobs:
         id: release
         run: npm run release:ci -- ${{ inputs.release_type }}
 
-      # Create a release branch and push the tag (not main) only after all checks pass.
+      # Create a release branch and push it together with the tag (atomically,
+      # so a partial failure cannot leave the branch without its tag).
+      # Nothing is pushed to main.
       - name: Push release branch and tag
         if: ${{ !inputs.dry_run }}
         env:
@@ -79,20 +80,20 @@ jobs:
         run: |
           RELEASE_BRANCH="release/${TAG}"
           git checkout -b "$RELEASE_BRANCH"
-          git push -u origin "$RELEASE_BRANCH"
-          git push origin "$TAG"
+          git push --atomic origin "refs/heads/${RELEASE_BRANCH}" "refs/tags/${TAG}"
 
       # Create a PR for review of the release assets.
       - name: Create release PR
         if: ${{ !inputs.dry_run }}
-        id: create-pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.release.outputs.tag }}
         run: |
-          RELEASE_BRANCH="release/${{ steps.release.outputs.tag }}"
           gh pr create \
             --base main \
-            --head "$RELEASE_BRANCH" \
-            --title "Release ${{ steps.release.outputs.tag }}" \
-            --body "Release candidate for ${{ steps.release.outputs.tag }}.
+            --head "release/${TAG}" \
+            --title "Release ${TAG}" \
+            --body "Release candidate for ${TAG}.
 
           Please review the generated assets:
           - \`docs/release.json\` (for final versions)
@@ -100,10 +101,9 @@ jobs:
           - \`docs/webapp/\` (built web app bundle)
 
           Merge this PR to finalize the release."
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # Phase 2: build platform installers from the release branch (not tag, to include all assets).
+  # Phase 2: build platform installers from the tag, which points at the final
+  # release commit (all assets included), so the build input is deterministic.
   build:
     needs: prepare
     if: ${{ !inputs.dry_run }}
@@ -128,7 +128,7 @@ jobs:
         if: matrix.os == 'windows'
       - uses: actions/checkout@v7.0.0
         with:
-          ref: release/${{ needs.prepare.outputs.tag }}
+          ref: ${{ needs.prepare.outputs.tag }}
           persist-credentials: false
       - uses: actions/setup-node@v6.4.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: Release
 
 permissions:
   contents: write
+  pull-requests: write
 
 on:
   workflow_dispatch:
@@ -73,11 +74,13 @@ jobs:
       # Create a release branch and push the tag (not main) only after all checks pass.
       - name: Push release branch and tag
         if: ${{ !inputs.dry_run }}
+        env:
+          TAG: ${{ steps.release.outputs.tag }}
         run: |
-          RELEASE_BRANCH="release/${{ steps.release.outputs.tag }}"
+          RELEASE_BRANCH="release/${TAG}"
           git checkout -b "$RELEASE_BRANCH"
           git push -u origin "$RELEASE_BRANCH"
-          git push origin "${{ steps.release.outputs.tag }}"
+          git push origin "$TAG"
 
       # Create a PR for review of the release assets.
       - name: Create release PR
@@ -100,7 +103,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # Phase 2: build platform installers from the pushed tag.
+  # Phase 2: build platform installers from the release branch (not tag, to include all assets).
   build:
     needs: prepare
     if: ${{ !inputs.dry_run }}
@@ -125,7 +128,8 @@ jobs:
         if: matrix.os == 'windows'
       - uses: actions/checkout@v7.0.0
         with:
-          ref: ${{ needs.prepare.outputs.tag }}
+          ref: release/${{ needs.prepare.outputs.tag }}
+          persist-credentials: false
       - uses: actions/setup-node@v6.4.0
         with:
           node-version: lts/*
@@ -137,11 +141,17 @@ jobs:
         if: matrix.variant != 'portable'
       - run: npm run electron:portable
         if: matrix.variant == 'portable'
-      - run: node scripts/archive.mjs ${{ matrix.os_short }} ${{ needs.prepare.outputs.tag }} ${{ matrix.variant }}
+      - name: Archive and upload
+        env:
+          OS_SHORT: ${{ matrix.os_short }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+          VARIANT: ${{ matrix.variant }}
+        run: node scripts/archive.mjs "$OS_SHORT" "$TAG" "$VARIANT"
       - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.os }}${{ matrix.variant == 'portable' && '-portable' || '' }}-release
           path: dist/release-*.zip
+          persist-credentials: false
 
   # Phase 3: gather the installers into a draft GitHub Release.
   release:
@@ -152,16 +162,17 @@ jobs:
       - uses: actions/checkout@v7.0.0
         with:
           ref: ${{ needs.prepare.outputs.tag }}
+          persist-credentials: false
       - uses: actions/download-artifact@v8
         with:
           path: dist
           merge-multiple: true
       - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ needs.prepare.outputs.tag }}
         run: |
           gh release create "$TAG_NAME" \
             --title "ShogiHome $TAG_NAME" \
             --draft \
             dist/release-*.zip
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ needs.prepare.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,12 +26,13 @@ on:
 
 jobs:
   # Phase 1: run the quality gate and a build (compile) check, then create the
-  # release commit and tag. Nothing is pushed until every check above passes.
+  # release commit and tag on a release branch. Create a PR for review.
   prepare:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.release.outputs.tag }}
       version: ${{ steps.release.outputs.version }}
+      pr_number: ${{ steps.create-pr.outputs.pull-request-number }}
     steps:
       - uses: actions/checkout@v7.0.0
         with:
@@ -69,12 +70,35 @@ jobs:
         id: release
         run: npm run release:ci -- ${{ inputs.release_type }}
 
-      # Push the branch and tag only after the gate and build succeeded.
-      - name: Push branch and tag
+      # Create a release branch and push the tag (not main) only after all checks pass.
+      - name: Push release branch and tag
         if: ${{ !inputs.dry_run }}
         run: |
-          git push origin HEAD:${{ github.ref_name }}
+          RELEASE_BRANCH="release/${{ steps.release.outputs.tag }}"
+          git checkout -b "$RELEASE_BRANCH"
+          git push -u origin "$RELEASE_BRANCH"
           git push origin "${{ steps.release.outputs.tag }}"
+
+      # Create a PR for review of the release assets.
+      - name: Create release PR
+        if: ${{ !inputs.dry_run }}
+        id: create-pr
+        run: |
+          RELEASE_BRANCH="release/${{ steps.release.outputs.tag }}"
+          gh pr create \
+            --base main \
+            --head "$RELEASE_BRANCH" \
+            --title "Release ${{ steps.release.outputs.tag }}" \
+            --body "Release candidate for ${{ steps.release.outputs.tag }}.
+
+          Please review the generated assets:
+          - \`docs/release.json\` (for final versions)
+          - \`docs/release-*.json\` (platform-specific)
+          - \`docs/webapp/\` (built web app bundle)
+
+          Merge this PR to finalize the release."
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Phase 2: build platform installers from the pushed tag.
   build:

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "release:beta": "npm run license:commit && npm version preminor --preid beta",
     "release:pre": "npm run license:commit && npm version prerelease",
     "release:stable": "tsx scripts/publish-release.ts stable && npm run docs && git add . && git commit -m \"update stable version\"",
+    "release:ci": "tsx scripts/ci-release.ts",
     "usi-csa-bridge:build": "webpack --config-name command:usi-csa-bridge && node scripts/distribute-command.mjs usi-csa-bridge",
     "usi-csa-bridge:install": "npm run usi-csa-bridge:build && npm install -g ./dist/command/usi-csa-bridge",
     "gen-proto": "node scripts/gen-proto.mjs"

--- a/scripts/ci-release.ts
+++ b/scripts/ci-release.ts
@@ -40,6 +40,18 @@ function readVersion(): string {
   return JSON.parse(fs.readFileSync("package.json", "utf-8")).version;
 }
 
+function validateReleaseType(releaseType: string, currentVersion: string) {
+  const currentIsPrerelease = semver.prerelease(currentVersion) !== null;
+
+  // prerelease / prerelease-beta / finalize require the current version to be a prerelease
+  if (["prerelease", "prerelease-beta", "finalize"].includes(releaseType) && !currentIsPrerelease) {
+    throw new Error(
+      `Release type '${releaseType}' requires the current version to be a prerelease. ` +
+        `Current version: ${currentVersion}`,
+    );
+  }
+}
+
 function main() {
   const releaseType = process.argv[2];
   const versionArgs = releaseTypeToVersionArgs[releaseType];
@@ -49,6 +61,9 @@ function main() {
         `Valid types: ${Object.keys(releaseTypeToVersionArgs).join(", ")}`,
     );
   }
+
+  const currentVersion = readVersion();
+  validateReleaseType(releaseType, currentVersion);
 
   // 1. Commit the third-party license report if it changed.
   run("npm", ["run", "license:commit"]);

--- a/scripts/ci-release.ts
+++ b/scripts/ci-release.ts
@@ -68,12 +68,17 @@ function main() {
   // 1. Commit the third-party license report if it changed.
   run("npm", ["run", "license:commit"]);
 
-  // 2. Bump the version. This creates a commit and a `v<version>` tag.
-  run("npm", ["version", ...versionArgs]);
+  // 2. Bump the version without committing or tagging, so the tag can be
+  //    placed on the final commit after all release assets are generated.
+  run("npm", ["version", ...versionArgs, "--no-git-tag-version"]);
 
   const version = readVersion();
   const isPrerelease = semver.prerelease(version) !== null;
   console.log(`New version: ${version} (prerelease: ${isPrerelease})`);
+
+  // Commit the bump with the same message format as `npm version`.
+  run("git", ["add", "package.json", "package-lock.json"]);
+  run("git", ["commit", "-m", version]);
 
   // 3. For final (non-pre-release) versions, update the website assets that
   //    advertise the latest/stable versions and produce the release commit.
@@ -92,8 +97,9 @@ function main() {
     run("npm", ["run", "release"]);
   }
 
-  // Expose the tag name to the workflow via the step summary output file.
+  // 4. Tag the final commit so the tag includes every release asset.
   const tag = `v${version}`;
+  run("git", ["tag", "-a", tag, "-m", version]);
   const outputPath = process.env.GITHUB_OUTPUT;
   if (outputPath) {
     fs.appendFileSync(outputPath, `tag=${tag}\nversion=${version}\nprerelease=${isPrerelease}\n`);

--- a/scripts/ci-release.ts
+++ b/scripts/ci-release.ts
@@ -1,0 +1,89 @@
+/* eslint-disable no-console */
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import * as semver from "semver";
+
+/**
+ * Release types accepted by the CI release workflow.
+ *
+ * Each type maps to a set of `npm version` arguments. Whether the resulting
+ * version is a pre-release is detected afterwards from package.json, and the
+ * website (docs/release.json, docs HTML, webapp bundle) is only updated for
+ * non-pre-release versions.
+ *
+ *   minor            1.1.0        -> 1.2.0
+ *   patch            1.1.0        -> 1.1.1
+ *   major            1.1.0        -> 2.0.0
+ *   preminor-alpha   1.1.0        -> 1.2.0-alpha.0
+ *   preminor-beta    1.1.0        -> 1.2.0-beta.0
+ *   prerelease       1.1.0-alpha.0 -> 1.1.0-alpha.1
+ *   prerelease-beta  1.1.0-alpha.0 -> 1.1.0-beta.0
+ *   finalize         1.1.0-alpha.0 -> 1.1.0
+ */
+const releaseTypeToVersionArgs: Record<string, string[]> = {
+  minor: ["minor"],
+  patch: ["patch"],
+  major: ["major"],
+  "preminor-alpha": ["preminor", "--preid", "alpha"],
+  "preminor-beta": ["preminor", "--preid", "beta"],
+  prerelease: ["prerelease"],
+  "prerelease-beta": ["prerelease", "--preid", "beta"],
+  finalize: ["patch"],
+};
+
+function run(command: string, args: string[]) {
+  console.log(`$ ${command} ${args.join(" ")}`);
+  execFileSync(command, args, { stdio: "inherit" });
+}
+
+function readVersion(): string {
+  return JSON.parse(fs.readFileSync("package.json", "utf-8")).version;
+}
+
+function main() {
+  const releaseType = process.argv[2];
+  const versionArgs = releaseTypeToVersionArgs[releaseType];
+  if (!versionArgs) {
+    throw new Error(
+      `Invalid release type: ${releaseType}. ` +
+        `Valid types: ${Object.keys(releaseTypeToVersionArgs).join(", ")}`,
+    );
+  }
+
+  // 1. Commit the third-party license report if it changed.
+  run("npm", ["run", "license:commit"]);
+
+  // 2. Bump the version. This creates a commit and a `v<version>` tag.
+  run("npm", ["version", ...versionArgs]);
+
+  const version = readVersion();
+  const isPrerelease = semver.prerelease(version) !== null;
+  console.log(`New version: ${version} (prerelease: ${isPrerelease})`);
+
+  // 3. For final (non-pre-release) versions, update the website assets that
+  //    advertise the latest/stable versions and produce the release commit.
+  //    Pre-releases only publish a tag, matching the previous local behavior.
+  if (!isPrerelease) {
+    run("npm", [
+      "exec",
+      "--",
+      "tsx",
+      "scripts/publish-release.ts",
+      "latest",
+      "--yes",
+      "--platforms=all",
+    ]);
+    run("npm", ["run", "docs"]);
+    run("npm", ["run", "release"]);
+  }
+
+  // Expose the tag name to the workflow via the step summary output file.
+  const tag = `v${version}`;
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (outputPath) {
+    fs.appendFileSync(outputPath, `tag=${tag}\nversion=${version}\nprerelease=${isPrerelease}\n`);
+  }
+  console.log(`Prepared release ${tag}.`);
+}
+
+main();

--- a/scripts/publish-release.ts
+++ b/scripts/publish-release.ts
@@ -9,39 +9,74 @@ const releaseWinJSON = "docs/release-win.json";
 const releaseMacJSON = "docs/release-mac.json";
 const releaseLinuxJSON = "docs/release-linux.json";
 
-const stdio = createInterface({
-  input: process.stdin,
-  output: process.stdout,
-});
+const platformJSONs: Record<string, string> = {
+  win: releaseWinJSON,
+  mac: releaseMacJSON,
+  linux: releaseLinuxJSON,
+};
 
 type Target = "stable" | "latest";
 
-async function getTarget(): Promise<Target> {
-  const value = process.argv[2];
-  switch (value) {
-    case "":
-    case undefined:
-      return "latest";
-    case "stable":
-    case "latest":
-      return value as Target;
-    default:
-      throw new Error("Invalid target");
+type Args = {
+  target: Target;
+  /** Skip interactive prompts (for CI). */
+  yes: boolean;
+  /** Comma-separated platform list or "all". Only used with --yes. */
+  platforms?: string;
+};
+
+function parseArgs(): Args {
+  let target: Target = "latest";
+  let yes = false;
+  let platforms: string | undefined;
+  for (const arg of process.argv.slice(2)) {
+    if (arg === "--yes" || arg === "-y") {
+      yes = true;
+    } else if (arg.startsWith("--platforms=")) {
+      platforms = arg.slice("--platforms=".length);
+    } else if (arg === "stable" || arg === "latest") {
+      target = arg;
+    } else if (arg === "" || arg === undefined) {
+      // ignore
+    } else {
+      throw new Error(`Invalid argument: ${arg}`);
+    }
   }
+  return { target, yes, platforms };
+}
+
+function resolvePlatformPaths(platforms?: string): string[] {
+  const keys =
+    !platforms || platforms === "all" ? Object.keys(platformJSONs) : platforms.split(",");
+  return keys.map((key) => {
+    const path = platformJSONs[key.trim()];
+    if (!path) {
+      throw new Error(`Invalid platform: ${key}`);
+    }
+    return path;
+  });
 }
 
 async function inputPlatforms(): Promise<string[]> {
-  const paths = [] as string[];
-  if (!/^n/i.test(await stdio.question(`Do you want to update ${releaseWinJSON}? [Y/n]:`))) {
-    paths.push(releaseWinJSON);
+  const stdio = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  try {
+    const paths = [] as string[];
+    if (!/^n/i.test(await stdio.question(`Do you want to update ${releaseWinJSON}? [Y/n]:`))) {
+      paths.push(releaseWinJSON);
+    }
+    if (!/^n/i.test(await stdio.question(`Do you want to update ${releaseMacJSON}? [Y/n]:`))) {
+      paths.push(releaseMacJSON);
+    }
+    if (!/^n/i.test(await stdio.question(`Do you want to update ${releaseLinuxJSON}? [Y/n]:`))) {
+      paths.push(releaseLinuxJSON);
+    }
+    return paths;
+  } finally {
+    stdio.close();
   }
-  if (!/^n/i.test(await stdio.question(`Do you want to update ${releaseMacJSON}? [Y/n]:`))) {
-    paths.push(releaseMacJSON);
-  }
-  if (!/^n/i.test(await stdio.question(`Do you want to update ${releaseLinuxJSON}? [Y/n]:`))) {
-    paths.push(releaseLinuxJSON);
-  }
-  return paths;
 }
 
 async function updateReleaseJSON(target: Target) {
@@ -89,20 +124,16 @@ async function updateReleaseJSON(target: Target) {
 }
 
 async function main() {
-  const target = await getTarget();
-  const paths = await inputPlatforms();
-  await updateReleaseJSON(target);
+  const args = parseArgs();
+  const paths = args.yes ? resolvePlatformPaths(args.platforms) : await inputPlatforms();
+  await updateReleaseJSON(args.target);
   for (const path of paths) {
     fs.copyFileSync(releaseJSON, path);
   }
   console.log("updated.");
 }
 
-main()
-  .catch((err) => {
-    console.error(err);
-    process.exit(1);
-  })
-  .finally(() => {
-    stdio.close();
-  });
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/specs/release-workflow.md
+++ b/specs/release-workflow.md
@@ -1,0 +1,89 @@
+# Release Workflow
+
+ShogiHome releases are driven entirely by the `Release`
+GitHub Actions workflow (`.github/workflows/release.yml`). A maintainer no
+longer runs `npm run release:*` locally to create the release commit and tag;
+instead the workflow runs the quality gate and a build check first, and only
+then pushes the branch and tag.
+
+## Triggering a release
+
+Run the **Release** workflow from the Actions tab
+(`workflow_dispatch`) on the branch you want to release from (usually `main`,
+or a `support-*` branch). Two inputs are available:
+
+- `release_type` — the kind of version bump (see the table below).
+- `dry_run` — when `true`, the workflow runs the quality gate, the build check
+  and the version bump, but does **not** push anything and does **not** build
+  installers. Use it to validate a release candidate.
+
+## Release types
+
+`release_type` maps to `npm version` arguments. Whether the new version is a
+pre-release is detected from `package.json` afterwards, and the website assets
+(`docs/release.json`, the generated docs HTML, and the webapp bundle) are only
+updated for final (non-pre-release) versions. Pre-releases publish a tag only,
+matching the previous local behavior of `release:alpha` / `release:beta` /
+`release:pre`.
+
+| `release_type`    | Example                           | `npm version`             | Website update |
+| ----------------- | --------------------------------- | ------------------------- | -------------- |
+| `minor`           | `1.1.0` → `1.2.0`                 | `minor`                   | yes            |
+| `patch`           | `1.1.0` → `1.1.1`                 | `patch`                   | yes            |
+| `major`           | `1.1.0` → `2.0.0`                 | `major`                   | yes            |
+| `preminor-alpha`  | `1.1.0` → `1.2.0-alpha.0`         | `preminor --preid alpha`  | no (tag only)  |
+| `preminor-beta`   | `1.1.0` → `1.2.0-beta.0`          | `preminor --preid beta`   | no (tag only)  |
+| `prerelease`      | `1.1.0-alpha.0` → `1.1.0-alpha.1` | `prerelease`              | no (tag only)  |
+| `prerelease-beta` | `1.1.0-alpha.0` → `1.1.0-beta.0`  | `prerelease --preid beta` | no (tag only)  |
+| `finalize`        | `1.1.0-alpha.0` → `1.1.0`         | `patch`                   | yes            |
+
+The mapping lives in `scripts/ci-release.ts`
+(`releaseTypeToVersionArgs`).
+
+## Workflow phases
+
+The workflow runs three jobs in sequence:
+
+1. **prepare** (`ubuntu-latest`)
+   1. Quality gate mirroring `test.yml`: `verify-lockfile`, `npm ci`, `lint`,
+      `docs` + `git diff --exit-code`, `license`, `coverage`.
+   2. Build gate: `npm run electron:pack` (compiles web + electron
+      main/preload/background).
+   3. `npm run release:ci -- <release_type>` — runs `scripts/ci-release.ts`,
+      which commits the license report, runs `npm version` (creating the bump
+      commit and the `v<version>` tag), and for final versions runs
+      `publish-release`, `docs`, and `release` to update the website assets and
+      create the `release` commit.
+   4. Unless `dry_run`, pushes the current branch and the new tag. **Nothing is
+      pushed before this point**, so a failing test or build aborts the release
+      with no tag created.
+
+2. **build** (matrix: win/mac/linux installers + win portable) — checks out the
+   pushed tag and produces the platform installers as artifacts. Same as before.
+
+3. **release** — downloads the artifacts and creates a **draft** GitHub Release
+   for the tag. Same as before.
+
+`build` and `release` are skipped on `dry_run`.
+
+## Why one workflow instead of a tag-push trigger
+
+A tag pushed with the default `GITHUB_TOKEN` does **not** trigger other
+workflows (GitHub's protection against recursive Actions runs). Keeping the
+installer build in a separate `on: push: tags` workflow would therefore never
+fire for CI-created tags. Consolidating everything into a single
+`workflow_dispatch` run with job dependencies (`needs`) avoids this and keeps
+the whole release in one place.
+
+## Prerequisites / notes
+
+- The `prepare` job pushes directly to the release branch. Branch protection
+  rules must allow the `github-actions[bot]` (via the `contents: write`
+  permission) to push to that branch, or the push step will fail.
+- The tag points at the `npm version` bump commit; the `release` commit (webapp
+  bundle + `release.json`) sits on top on the branch. Installer builds check out
+  the tag, which carries the correct `package.json` version — this matches the
+  previous behavior.
+- The local `npm run release:*` scripts are retained for manual/offline use.
+  `scripts/publish-release.ts` now also accepts `--yes` and
+  `--platforms=all|win,mac,linux` for non-interactive runs.

--- a/specs/release-workflow.md
+++ b/specs/release-workflow.md
@@ -51,13 +51,16 @@ The workflow runs three jobs in sequence:
    2. Build gate: `npm run electron:pack` (compiles web + electron
       main/preload/background).
    3. `npm run release:ci -- <release_type>` — runs `scripts/ci-release.ts`,
-      which commits the license report, runs `npm version` (creating the bump
-      commit and the `v<version>` tag), and for final versions runs
-      `publish-release`, `docs`, and `release` to update the website assets and
-      create the `release` commit.
+      which validates the release type against the current version, commits the
+      license report, bumps the version with `npm version --no-git-tag-version`
+      and commits it, for final versions runs `publish-release`, `docs`, and
+      `release` to update the website assets and create the `release` commit,
+      and finally creates the annotated `v<version>` tag on the last commit so
+      the tag includes every release asset.
    4. Unless `dry_run`:
-      - Creates and pushes a `release/v<version>` branch (isolated from `main`)
-      - Pushes the version tag
+      - Creates a `release/v<version>` branch (isolated from `main`) and pushes
+        it together with the tag in a single atomic push (`git push --atomic`),
+        so a partial failure cannot leave the branch without its tag
       - **Creates a PR** against `main` for review of the generated assets
    5. **Nothing is pushed to `main` before this point**, so a failing test or
       build aborts the release with no branch/tag created.
@@ -93,10 +96,10 @@ the whole release in one place.
 - The `prepare` job creates and pushes a `release/v<version>` branch and
   creates a PR. The branch protection rules for `main` are **not** bypassed —
   the PR merge still requires branch protection checks to pass.
-- The tag points at the `npm version` bump commit; the `release` commit (webapp
-  bundle + `release.json`) sits on top of the branch. Installer builds check out
-  the tag, which carries the correct `package.json` version — this matches the
-  previous behavior.
+- The tag points at the final commit of the release branch: the `release`
+  commit (webapp bundle + `release.json`) for final versions, or the version
+  bump commit for pre-releases. Installer builds check out the tag, so they
+  always build from the complete release state.
 - The draft release is created pointing at this tag, but is not automatically
   published. The maintainer can review and publish it from GitHub, or keep it
   as a draft.

--- a/specs/release-workflow.md
+++ b/specs/release-workflow.md
@@ -3,8 +3,9 @@
 ShogiHome releases are driven entirely by the `Release`
 GitHub Actions workflow (`.github/workflows/release.yml`). A maintainer no
 longer runs `npm run release:*` locally to create the release commit and tag;
-instead the workflow runs the quality gate and a build check first, and only
-then pushes the branch and tag.
+instead the workflow runs the quality gate and a build check first, creates a
+release PR, and only after the maintainer reviews and merges the PR are
+installers built and the draft release published.
 
 ## Triggering a release
 
@@ -14,8 +15,8 @@ or a `support-*` branch). Two inputs are available:
 
 - `release_type` — the kind of version bump (see the table below).
 - `dry_run` — when `true`, the workflow runs the quality gate, the build check
-  and the version bump, but does **not** push anything and does **not** build
-  installers. Use it to validate a release candidate.
+  and the version bump, but does **not** push anything and does **not** create
+  a PR or build installers. Use it to validate a release candidate.
 
 ## Release types
 
@@ -54,17 +55,29 @@ The workflow runs three jobs in sequence:
       commit and the `v<version>` tag), and for final versions runs
       `publish-release`, `docs`, and `release` to update the website assets and
       create the `release` commit.
-   4. Unless `dry_run`, pushes the current branch and the new tag. **Nothing is
-      pushed before this point**, so a failing test or build aborts the release
-      with no tag created.
+   4. Unless `dry_run`:
+      - Creates and pushes a `release/v<version>` branch (isolated from `main`)
+      - Pushes the version tag
+      - **Creates a PR** against `main` for review of the generated assets
+   5. **Nothing is pushed to `main` before this point**, so a failing test or
+      build aborts the release with no branch/tag created.
 
 2. **build** (matrix: win/mac/linux installers + win portable) — checks out the
-   pushed tag and produces the platform installers as artifacts. Same as before.
+   tag and produces the platform installers as artifacts. Runs even before the
+   PR is merged (on the tag, which is stable).
 
 3. **release** — downloads the artifacts and creates a **draft** GitHub Release
-   for the tag. Same as before.
+   for the tag. The draft is left for manual review/publishing.
 
 `build` and `release` are skipped on `dry_run`.
+
+## After the workflow completes
+
+1. Review the release PR: check the generated assets (`docs/release.json`,
+   webapp build, etc.)
+2. Merge the PR into `main` when satisfied.
+3. If desired, publish the draft release from the GitHub Releases page (or let
+   it sit as a draft for further review).
 
 ## Why one workflow instead of a tag-push trigger
 
@@ -77,13 +90,16 @@ the whole release in one place.
 
 ## Prerequisites / notes
 
-- The `prepare` job pushes directly to the release branch. Branch protection
-  rules must allow the `github-actions[bot]` (via the `contents: write`
-  permission) to push to that branch, or the push step will fail.
+- The `prepare` job creates and pushes a `release/v<version>` branch and
+  creates a PR. The branch protection rules for `main` are **not** bypassed —
+  the PR merge still requires branch protection checks to pass.
 - The tag points at the `npm version` bump commit; the `release` commit (webapp
-  bundle + `release.json`) sits on top on the branch. Installer builds check out
+  bundle + `release.json`) sits on top of the branch. Installer builds check out
   the tag, which carries the correct `package.json` version — this matches the
   previous behavior.
+- The draft release is created pointing at this tag, but is not automatically
+  published. The maintainer can review and publish it from GitHub, or keep it
+  as a draft.
 - The local `npm run release:*` scripts are retained for manual/offline use.
   `scripts/publish-release.ts` now also accepts `--yes` and
   `--platforms=all|win,mac,linux` for non-interactive runs.


### PR DESCRIPTION
# 説明 / Description

This PR refactors the release process from a tag-push trigger to a `workflow_dispatch`-driven workflow with automated CI checks and multi-phase job orchestration.

## Key Changes

### Workflow Architecture (`release.yml`)
- Changed trigger from `on: push: tags` to `on: workflow_dispatch` with inputs for `release_type` and `dry_run`
- Split into three sequential jobs:
  1. **prepare**: Runs quality gate (lint, tests, coverage), build check, version bump, and website asset updates (for final releases only)
  2. **build**: Builds platform installers from the prepared tag (skipped on dry_run)
  3. **release**: Creates draft GitHub Release (skipped on dry_run)
- All jobs use `needs` dependencies to ensure sequential execution and pass outputs (tag, version) between phases
- Nothing is pushed until all quality/build checks pass, preventing failed releases from creating tags

### CI Release Script (`scripts/ci-release.ts` - new)
- Implements the version bump logic with support for 8 release types (minor, patch, major, preminor-alpha, preminor-beta, prerelease, prerelease-beta, finalize)
- Detects whether the new version is a pre-release and conditionally updates website assets only for final releases
- Outputs tag and version to `GITHUB_OUTPUT` for workflow consumption
- Replaces manual `npm run release:*` invocations with a single parameterized script

### Publish Release Script (`scripts/publish-release.ts`)
- Refactored to support non-interactive mode with `--yes` and `--platforms=all|win,mac,linux` flags
- Extracted platform path resolution into `resolvePlatformPaths()` function
- Improved argument parsing with `parseArgs()` to handle multiple CLI options
- Moved `readline` interface creation into `inputPlatforms()` with proper cleanup in try/finally
- Removed global stdio interface to avoid resource leaks

### Documentation (`specs/release-workflow.md` - new)
- Comprehensive guide explaining the new workflow, release types, and three-phase job structure
- Clarifies why `workflow_dispatch` is used instead of tag-push triggers (GitHub's recursive Actions protection)
- Documents prerequisites for branch protection rules and tag/commit structure

## Rationale

The previous tag-push trigger could not trigger dependent workflows due to GitHub's protection against recursive Actions runs. This consolidates the entire release into a single `workflow_dispatch` workflow with job dependencies, ensuring:
- Quality gate runs before any tag is created
- Build check validates compilation before installers are built
- Website assets are only updated for final (non-pre-release) versions
- All phases are visible in one workflow run with clear dependencies
- Dry-run capability for validation without pushing

## チェックリスト / Checklist

- MUST
  - [ ] `npm test` passed
  - [ ] `npm run lint` was applied without warnings
  - [ ] changes of `/docs/webapp` not included (except release branch)
  - [ ] `console.log` not included (except script file)

https://claude.ai/code/session_019RY8qkM9psUCv6TtZSRnu8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manual GitHub Actions release workflow with `release_type` selection and a `dry_run` option.
  * The workflow computes the release tag/version, runs a quality/build gate, builds installer artifacts across supported platforms, and (when not a dry run) pushes a release branch, opens a PR to the default branch, and drafts a GitHub Release.

* **Automation / Tooling**
  * Added CI-driven version/tag handling with prerelease rules and automated website/docs updates for final releases.
  * Updated the release publishing CLI for non-interactive platform selection.

* **Documentation**
  * Updated the end-to-end release process guide to reflect the new workflow and behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->