### PR TITLE
Add "Tree" into mobile UI

### DIFF
--- a/specs/record-branch-tree.md
+++ b/specs/record-branch-tree.md
@@ -149,7 +149,7 @@ export function buildRecordTreeLayout(record: ImmutableRecord): RecordTreeLayout
 
 - `src/common/settings/app.ts`: `showBranchTreeInRecordView: boolean` を追加(既定 false、normalize 対応)。
 - `src/renderer/view/main/RecordPane.vue`: appSettings から prop を渡し、トグルの emit で `updateAppSettings` を呼ぶ(既存トグルと同じ経路)。StandardLayout / MobileLayout / CustomLayout は RecordPane 経由のため個別対応は不要。
-- i18n: `ja.ts` / `en.ts` に「分岐ツリー」(例: `branchTree`)を追加。`zh_tw.ts` / `vi.ts` は翻訳ポリシーに従い `// TODO: Translate` を付けて日本語のまま追加する。
+- i18n: `ja.ts` / `en.ts` に「ツリー」(例: `tree`)を追加。`zh_tw.ts` / `vi.ts` は翻訳ポリシーに従い `// TODO: Translate` を付けて日本語のまま追加する。
 
 ### 5. テスト
 

--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -323,7 +323,7 @@ export const en: Texts = {
   commentsAndBookmarks: "Comments & Bookmarks",
   branches: "Branches",
   branchListMode: "Branch List Mode",
-  branchTree: "Branch Tree",
+  tree: "Tree",
   previousMoveBranches: "Sibling Branches",
   nextMoveBranches: "Next Move Branches",
   bookmark: "Bookmark",

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -323,7 +323,7 @@ export const ja: Texts = {
   commentsAndBookmarks: "コメント・しおり",
   branches: "分岐",
   branchListMode: "分岐の表示",
-  branchTree: "分岐ツリー",
+  tree: "ツリー",
   previousMoveBranches: "着手した手",
   nextMoveBranches: "次の手",
   bookmark: "しおり",

--- a/src/common/i18n/locales/vi.ts
+++ b/src/common/i18n/locales/vi.ts
@@ -333,7 +333,7 @@ export const vi: Texts = {
   commentsAndBookmarks: "Bình luận & đánh dấu",
   branches: "Nhánh",
   branchListMode: "Hiển thị các nhánh",
-  branchTree: "分岐ツリー", // TODO: Translate
+  tree: "ツリー", // TODO: Translate
   previousMoveBranches: "Các nước đã đi",
   nextMoveBranches: "Nước tiếp theo",
   bookmark: "Đánh dấu",

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -330,7 +330,7 @@ export const zh_tw: Texts = {
   commentsAndBookmarks: "備註・書籤",
   branches: "分支",
   branchListMode: "分岐の表示", // TODO: Translate
-  branchTree: "分岐ツリー", // TODO: Translate
+  tree: "ツリー", // TODO: Translate
   previousMoveBranches: "着手した手", // TODO: Translate
   nextMoveBranches: "次の手", // TODO: Translate
   bookmark: "書籤",

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -315,7 +315,7 @@ export type Texts = {
   commentsAndBookmarks: string;
   branches: string;
   branchListMode: string;
-  branchTree: string;
+  tree: string;
   previousMoveBranches: string;
   nextMoveBranches: string;
   bookmark: string;

--- a/src/renderer/view/layout/LayoutManager.vue
+++ b/src/renderer/view/layout/LayoutManager.vue
@@ -240,7 +240,7 @@
               <span class="property">
                 <ToggleButton
                   :value="!!component.showBranchTree"
-                  :label="t.branchTree"
+                  :label="t.tree"
                   @update:value="
                     (value) => updateCustomProfileComponent(index, 'showBranchTree', value)
                   "

--- a/src/renderer/view/main/MobileLayout.vue
+++ b/src/renderer/view/main/MobileLayout.vue
@@ -13,7 +13,7 @@
         />
         <RecordPane
           v-if="showRecordViewOnBottom"
-          v-show="bottomUIType === BottomUIType.RECORD"
+          v-show="bottomUIType === BottomUIType.RECORD || bottomUIType === BottomUIType.BRANCH_TREE"
           :style="{
             width: `${windowSize.width}px`,
             height: `${bottomViewSize.height}px`,
@@ -22,7 +22,7 @@
           :show-bottom-control="false"
           :show-elapsed-time="true"
           :show-comment="true"
-          :show-branch-tree="appSettings.showBranchTreeInRecordView"
+          :show-branch-tree="bottomUIType === BottomUIType.BRANCH_TREE"
         />
         <RecordComment
           v-if="showRecordViewOnBottom"
@@ -42,6 +42,7 @@
           v-model:value="bottomUIType"
           :items="[
             { label: t.record, value: BottomUIType.RECORD },
+            { label: t.tree, value: BottomUIType.BRANCH_TREE },
             { label: t.comments, value: BottomUIType.COMMENT },
             { label: t.recordProperties, value: BottomUIType.INFO },
           ]"
@@ -55,13 +56,19 @@
       >
         <MobileControls :style="{ height: `${controlPaneHeight}px` }" />
         <RecordPane
-          v-show="sideUIType === SideUIType.RECORD"
-          :style="{ height: `${sideViewSize.height * 0.6}px` }"
+          v-show="sideUIType === SideUIType.RECORD || sideUIType === SideUIType.BRANCH_TREE"
+          :style="{
+            height: `${
+              sideUIType === SideUIType.BRANCH_TREE
+                ? sideViewSize.height
+                : sideViewSize.height * 0.6
+            }px`,
+          }"
           :show-top-control="false"
           :show-bottom-control="false"
           :show-elapsed-time="true"
           :show-comment="true"
-          :show-branch-tree="appSettings.showBranchTreeInRecordView"
+          :show-branch-tree="sideUIType === SideUIType.BRANCH_TREE"
         />
         <RecordComment
           v-show="sideUIType === SideUIType.RECORD"
@@ -75,6 +82,7 @@
           v-model:value="sideUIType"
           :items="[
             { label: t.record, value: SideUIType.RECORD },
+            { label: t.tree, value: SideUIType.BRANCH_TREE },
             { label: t.recordProperties, value: SideUIType.INFO },
           ]"
           :height="selectorHeight"
@@ -87,11 +95,13 @@
 <script lang="ts">
 enum BottomUIType {
   RECORD = "record",
+  BRANCH_TREE = "branchTree",
   COMMENT = "comment",
   INFO = "info",
 }
 enum SideUIType {
   RECORD = "record",
+  BRANCH_TREE = "branchTree",
   INFO = "info",
 }
 </script>
@@ -109,9 +119,6 @@ import HorizontalSelector from "@/renderer/view/primitive/HorizontalSelector.vue
 import { t } from "@/common/i18n";
 import RecordInfo from "@/renderer/view/tab/RecordInfo.vue";
 import { isIOS } from "@/renderer/helpers/env";
-import { useAppSettings } from "@/renderer/store/settings";
-
-const appSettings = useAppSettings();
 
 const lazyUpdateDelay = 80;
 const selectorHeight = 30;

--- a/src/renderer/view/primitive/RecordView.vue
+++ b/src/renderer/view/primitive/RecordView.vue
@@ -123,7 +123,7 @@
       </div>
       <div class="option">
         <ToggleButton
-          :label="t.branchTree"
+          :label="t.tree"
           :value="showBranchTree"
           @update:value="(enabled: boolean) => emit('toggleShowBranchTree', enabled)"
         />


### PR DESCRIPTION
# 説明 / Description

モバイル版でもツリーを選べるようにする。
またデスクトップ版も含めて「分岐ツリー」という文言がスペースを圧迫しているので「ツリー」に変更する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/shogihome/blob/main/CONTRIBUTING.md)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added selectable branch-tree views to mobile bottom and side layouts.
  * Branch-tree display can now be switched directly through layout selectors.

* **Improvements**
  * Updated interface labels and translations to use the simplified “Tree” terminology.
  * Branch-tree views now receive appropriate layout sizing in side panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->