### PR TITLE
Update button layout of PositionEditingDialog

### DIFF
--- a/src/renderer/view/dialog/PositionEditingDialog.vue
+++ b/src/renderer/view/dialog/PositionEditingDialog.vue
@@ -70,42 +70,51 @@
           </button>
           <button class="bulk thin" @click="setAllZero">{{ t.setAllPiecesToZero }}</button>
         </div>
-        <div class="form-group">
-          <div class="row">
-            <button class="wide" data-hotkey="Mod+z" :disabled="!canUndo" @click="undo">
+        <div class="form-group icon-buttons">
+          <div class="icon-button-row">
+            <button class="icon-button" data-hotkey="Mod+z" :disabled="!canUndo" @click="undo">
               <Icon :icon="IconType.UNDO" />
-              <span>{{ t.undo }}</span>
+              <div class="label">{{ t.undo }}</div>
             </button>
-            <button class="wide" data-hotkey="Mod+Shift+z" :disabled="!canRedo" @click="redo">
+            <button
+              class="icon-button"
+              data-hotkey="Mod+Shift+z"
+              :disabled="!canRedo"
+              @click="redo"
+            >
               <Icon :icon="IconType.REDO" />
-              <span>{{ t.redo }}</span>
+              <div class="label">{{ t.redo }}</div>
             </button>
           </div>
-          <button class="wide" @click="isInitialPositionMenuVisible = true">
-            <Icon :icon="IconType.REFRESH" />
-            <span>{{ t.initializePosition }}</span>
-          </button>
+          <div class="icon-button-row">
+            <button class="icon-button" @click="isInitialPositionMenuVisible = true">
+              <Icon :icon="IconType.REFRESH" />
+              <div class="label">{{ t.initializePosition }}</div>
+            </button>
+            <button class="icon-button" @click="onChangeTurn">
+              <Icon :icon="IconType.SWAP" />
+              <div class="label">{{ t.changeTurn }}</div>
+            </button>
+          </div>
           <InitialPositionMenu
             v-if="isInitialPositionMenuVisible"
             @select="onSelectPreset"
             @close="isInitialPositionMenuVisible = false"
           />
-          <button class="wide" @click="onChangeTurn">
-            <Icon :icon="IconType.SWAP" />
-            <span>{{ t.changeTurn }}</span>
-          </button>
-          <button class="wide" @click="onCopySFEN">
-            <Icon :icon="IconType.COPY" />
-            <span>{{ t.copy }}(SFEN)</span>
-          </button>
-          <button class="wide" @click="onCopyBOD">
-            <Icon :icon="IconType.COPY" />
-            <span>{{ t.copy }}(BOD)</span>
-          </button>
-          <button class="wide" @click="onPaste">
-            <Icon :icon="IconType.PASTE" />
-            <span>{{ t.paste }}</span>
-          </button>
+          <div class="icon-button-row">
+            <button class="icon-button" @click="onCopySFEN">
+              <Icon :icon="IconType.COPY" />
+              <div class="label">{{ t.copy }}(SFEN)</div>
+            </button>
+            <button class="icon-button" @click="onCopyBOD">
+              <Icon :icon="IconType.COPY" />
+              <div class="label">{{ t.copy }}(BOD)</div>
+            </button>
+            <button class="icon-button" @click="onPaste">
+              <Icon :icon="IconType.PASTE" />
+              <div class="label">{{ t.paste }}</div>
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -353,8 +362,32 @@ const onCancel = () => {
 .number {
   width: 3em;
 }
-button.wide {
-  width: 100%;
+.icon-button-row {
+  display: flex;
+  flex-direction: row;
+  margin-bottom: 0.5em;
+}
+.icon-button-row:last-child {
+  margin-bottom: 0;
+}
+button.icon-button {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 0;
+  padding: 6px 4px;
+}
+button.icon-button .icon {
+  height: 28px;
+  width: 28px;
+  display: block;
+}
+button.icon-button .label {
+  display: block;
+  font-size: 0.8em;
+  margin-top: 0.5em;
+  white-space: nowrap;
 }
 button.bulk {
   width: 100%;

--- a/src/renderer/view/dialog/PositionEditingDialog.vue
+++ b/src/renderer/view/dialog/PositionEditingDialog.vue
@@ -385,9 +385,8 @@ button.icon-button .icon {
 }
 button.icon-button .label {
   display: block;
-  font-size: 0.8em;
+  font-size: 0.9em;
   margin-top: 0.5em;
-  white-space: nowrap;
 }
 button.bulk {
   width: 100%;


### PR DESCRIPTION
# 説明 / Description

局面編集ダイアログのボタンの見せ方を変更

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/shogihome/blob/main/CONTRIBUTING.md)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Redesigned position-editing controls using compact icon-only buttons with clear labels.
  * Organized related actions (undo/redo, initialize position, change turn, copy/paste) into neatly spaced icon-button rows.
  * Updated styling for consistent sizing, alignment, and icon/label presentation across the new layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->