### PR TITLE
Add GitHub Actions workflow for publishing CLI tools

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -18,6 +18,11 @@ on:
 jobs:
   usi-csa-bridge:
     runs-on: ubuntu-latest
+    # Must match the environment name registered in the npm Trusted Publisher
+    # settings. It narrows the OIDC subject to
+    # "repo:sunfish-shogi/shogihome:environment:npm", so the refs allowed to
+    # publish can be restricted by the environment protection rules.
+    environment: npm
     env:
       USI_CSA_BRIDGE_TMP: /tmp/usi-csa-bridge
       DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -32,8 +32,11 @@ jobs:
       # Note: "registry-url" is intentionally omitted. It makes setup-node write an
       # "_authToken" line into .npmrc, which stops npm from performing the OIDC token
       # exchange for Trusted Publishing. The default registry is registry.npmjs.org.
-      - uses: actions/checkout@v7.0.0
-      - uses: actions/setup-node@v6.4.0
+      #
+      # These actions are pinned to a commit SHA rather than a tag because they run
+      # in a job that holds the npm publishing identity via OIDC.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: lts/*
           cache: "npm"

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -45,7 +45,15 @@ jobs:
       - name: Verify package-lock.json integrity
         run: node scripts/verify-lockfile.mjs
       - run: npm ci --no-audit --no-fund
-      - run: npm -g i tsx
+      # The e2e runner calls "npx --no-install tsx" from outside the repository, so it
+      # resolves the global tsx. Take the version from package-lock.json instead of
+      # installing the latest, so this job never runs an unreviewed third-party release
+      # while the OIDC publishing identity is available to it.
+      - name: Install tsx
+        run: |
+          set -eux
+          TSX_VERSION=$(node -p "require('./package-lock.json').packages['node_modules/tsx'].version")
+          npm -g i "tsx@${TSX_VERSION}"
 
       # Build
       - run: npm run usi-csa-bridge:build

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -1,0 +1,99 @@
+name: Publish CLI tools
+
+permissions:
+  contents: read
+  id-token: write # required for npm Trusted Publishing (OIDC)
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Run npm publish with --dry-run"
+        type: boolean
+        default: true
+
+jobs:
+  usi-csa-bridge:
+    runs-on: ubuntu-latest
+    env:
+      USI_CSA_BRIDGE_TMP: /tmp/usi-csa-bridge
+      DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+    steps:
+      # Setup
+      #
+      # Note: "registry-url" is intentionally omitted. It makes setup-node write an
+      # "_authToken" line into .npmrc, which stops npm from performing the OIDC token
+      # exchange for Trusted Publishing. The default registry is registry.npmjs.org.
+      - uses: actions/checkout@v7.0.0
+      - uses: actions/setup-node@v6.4.0
+        with:
+          node-version: lts/*
+          cache: "npm"
+      - run: npm install -g npm@latest # npm >= 11.5.1 is required for Trusted Publishing
+      - run: npm version
+      - name: Verify package-lock.json integrity
+        run: node scripts/verify-lockfile.mjs
+      - run: npm ci --no-audit --no-fund
+      - run: npm -g i tsx
+
+      # Build
+      - run: npm run usi-csa-bridge:build
+      - run: mv ./dist/command/usi-csa-bridge ${USI_CSA_BRIDGE_TMP}
+
+      # Resolve what to publish
+      - name: Resolve version and dist-tag
+        run: |
+          set -eux
+          NAME=$(jq -r .name ${USI_CSA_BRIDGE_TMP}/package.json)
+          VERSION=$(jq -r .version ${USI_CSA_BRIDGE_TMP}/package.json)
+          echo "NAME=$NAME" >> $GITHUB_ENV
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          # On tag push, the tag must match the version in package.json.
+          if [ "${{ github.ref_type }}" = "tag" ] && [ "${{ github.ref_name }}" != "v$VERSION" ]; then
+            echo "::error::Tag ${{ github.ref_name }} does not match package version $VERSION"
+            exit 1
+          fi
+          # Prereleases must not be published as "latest".
+          case "$VERSION" in
+            *-alpha*) DIST_TAG=alpha ;;
+            *-beta*) DIST_TAG=beta ;;
+            *-*) DIST_TAG=next ;;
+            *) DIST_TAG=latest ;;
+          esac
+          echo "DIST_TAG=$DIST_TAG" >> $GITHUB_ENV
+      - name: Check if the version is already published
+        run: |
+          set -eu
+          if npm view "$NAME@$VERSION" version > /dev/null 2>&1; then
+            echo "::notice::$NAME@$VERSION is already published. Skipping."
+            echo "ALREADY_PUBLISHED=true" >> $GITHUB_ENV
+          else
+            echo "ALREADY_PUBLISHED=false" >> $GITHUB_ENV
+          fi
+
+      # Test before publishing
+      - name: Install dependencies for usi-csa-bridge
+        if: env.ALREADY_PUBLISHED == 'false'
+        run: |
+          set -eux
+          cd ${USI_CSA_BRIDGE_TMP}
+          npm i --no-audit --no-fund
+      - name: Test usi-csa-bridge
+        if: env.ALREADY_PUBLISHED == 'false'
+        timeout-minutes: 1
+        run: ${USI_CSA_BRIDGE_TMP}/e2e/run-all
+
+      # Publish
+      - name: Publish usi-csa-bridge
+        if: env.ALREADY_PUBLISHED == 'false'
+        run: |
+          set -eux
+          cd ${USI_CSA_BRIDGE_TMP}
+          if [ "$DRY_RUN" = "true" ]; then
+            npm publish --tag "$DIST_TAG" --dry-run
+          else
+            npm publish --tag "$DIST_TAG"
+          fi


### PR DESCRIPTION
# 説明 / Description

#1669 

This PR adds a new GitHub Actions workflow (`publish-cli.yml`) to automate the publishing of CLI tools (specifically `usi-csa-bridge`) to npm.

## What's Changed

- **New workflow file**: `.github/workflows/publish-cli.yml`
  - Triggers on git tags matching `v*` pattern (automatic release) or manual workflow dispatch (with optional dry-run mode)
  - Uses npm Trusted Publishing (OIDC) for secure, token-free authentication
  - Builds the `usi-csa-bridge` CLI tool from source
  - Validates that git tags match the package version
  - Automatically determines the appropriate npm dist-tag (latest, alpha, beta, or next) based on version string
  - Skips publishing if the version is already published to npm
  - Runs end-to-end tests before publishing to ensure quality
  - Supports dry-run mode for testing the publish process without actually publishing

## Key Features

- **Secure**: Uses OIDC-based Trusted Publishing instead of npm tokens
- **Smart versioning**: Automatically tags prerelease versions appropriately (alpha, beta, next)
- **Safety checks**: Validates tag/version match and prevents duplicate publishes
- **Quality gates**: Runs e2e tests before publishing
- **Flexible**: Supports both automatic tag-based releases and manual workflow dispatch with dry-run option

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed (no code changes to test)
  - [x] `npm run lint` was applied without warnings (no code changes to lint)
  - [x] changes of `/docs/webapp` not included
  - [x] `console.log` not included
- RECOMMENDED
  - [x] No unit tests needed (workflow configuration file)

https://claude.ai/code/session_01UuWfgKQ4zLvPBUTcij5ra5