### PR TITLE
Disable Git credentials persistence in GitHub Actions workflows

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: lts/*

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -36,6 +36,8 @@ jobs:
       # These actions are pinned to a commit SHA rather than a tag because they run
       # in a job that holds the npm publishing identity via OIDC.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: lts/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,8 @@ jobs:
       - run: git config --global core.autocrlf false
         if: matrix.os == 'windows'
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: lts/*
@@ -50,7 +52,12 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      # The checkout only provides the repository context that "gh" resolves from the
+      # remote URL. "gh release create" authenticates with GH_TOKEN, not with the
+      # credentials checkout would otherwise leave in .git/config.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       # Setup
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: lts/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           # Do not use Node.js v24.16.0 or later


### PR DESCRIPTION
# 説明 / Description

This PR adds `persist-credentials: false` to all `actions/checkout@v7.0.1` steps across the GitHub Actions workflows. This security hardening measure prevents Git credentials from being persisted in the `.git/config` file during workflow execution.

## Changes

- **release.yml**: Added `persist-credentials: false` to checkout steps in both `build` and `release` jobs. Includes explanatory comment for the `release` job clarifying that `gh release create` authenticates via `GH_TOKEN` environment variable, not Git credentials.
- **publish-cli.yml**: Added `persist-credentials: false` to the checkout step in the `publish` job (which holds npm publishing identity via OIDC).
- **test-cli.yml**: Added `persist-credentials: false` to the checkout step.
- **test.yml**: Added `persist-credentials: false` to the checkout step.
- **audit.yml**: Added `persist-credentials: false` to the existing checkout configuration.

## Rationale

This change improves security by ensuring that temporary credentials used during workflow execution are not left in the repository's Git configuration. This is particularly important for jobs that authenticate with sensitive tokens (OIDC, npm publishing, GitHub releases).

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED
  - [x] No code changes; workflow configuration only

https://claude.ai/code/session_012DTWJWTX3tkdVMcF17Dzru