### PR TITLE
連続解析で前のファイルの探索結果が次のファイルの棋譜に書き込まれる問題を修正

### DIFF
--- a/src/renderer/store/analysis.ts
+++ b/src/renderer/store/analysis.ts
@@ -273,6 +273,12 @@ export class AnalysisManager {
   }
 
   updateSearchInfo(info: SearchInfo): void {
+    // エンジンを再利用する連続解析では、前のファイル (前の局面) に対する探索結果が
+    // 探索停止後に遅れて届くことがある。現在の解析対象局面と一致しない情報は、
+    // 別の局面 (例: 次のファイルの初期局面) に誤って書き込まれてしまうため破棄する。
+    if (info.usi !== this.recordManager.record.usi) {
+      return;
+    }
     this.recordManager.updateSearchInfo(SearchInfoSenderType.RESEARCHER, info);
     this.searchInfo = info;
   }

--- a/src/renderer/store/analysis.ts
+++ b/src/renderer/store/analysis.ts
@@ -3,7 +3,7 @@ import { USIPlayer } from "@/renderer/players/usi.js";
 import { AnalysisSettings, defaultAnalysisSettings } from "@/common/settings/analysis.js";
 import { AppSettings } from "@/common/settings/app.js";
 import { USIEngine } from "@/common/settings/usi.js";
-import { Color, Move, reverseColor } from "tsshogi";
+import { Color, ImmutableNode, Move, reverseColor } from "tsshogi";
 import { SearchInfoSenderType } from "@/common/record/types.js";
 import { RecordManager } from "@/renderer/record/manager.js";
 import { scoreToPercentage } from "@/common/record/score.js";
@@ -18,6 +18,9 @@ export class AnalysisManager {
   private settings = defaultAnalysisSettings();
   private lastSearchInfo?: SearchInfo;
   private searchInfo?: SearchInfo;
+  // 探索中の局面。Record#usi は呼び出しのたびに指し手を辿って文字列を生成するため、
+  // 探索開始時に取得した値を保持し、探索結果の照合に使い回す。
+  private searching?: { usi: string; node: ImmutableNode };
   private timerHandle?: number;
   private closed = false;
   private onFinish: FinishCallback = () => {
@@ -67,6 +70,7 @@ export class AnalysisManager {
     this.settings = settings;
     this.lastSearchInfo = undefined;
     this.searchInfo = undefined;
+    this.searching = undefined;
     this.recordManager.changePly(this.firstPly());
     if (this.settings.descending && !(this.recordManager.record.current.move instanceof Move)) {
       // 降順の場合に「投了」や「中断」などの特殊な指し手はスキップする。
@@ -99,6 +103,7 @@ export class AnalysisManager {
 
   close(): void {
     this.closed = true;
+    this.searching = undefined;
     this.clearTimer();
     this.closeEngine().catch((e) => {
       this.onError(e);
@@ -191,15 +196,17 @@ export class AnalysisManager {
     // タイマーをセットする。
     this.setTimer();
     // 探索を開始する。
-    this.researcher
-      .startResearch(this.recordManager.record.position, this.recordManager.record.usi)
-      .catch((e) => {
-        this.onError(e);
-      });
+    const usi = record.usi;
+    this.searching = { usi, node: record.current };
+    this.researcher.startResearch(record.position, usi).catch((e) => {
+      this.onError(e);
+    });
   }
 
   private finish(): void {
     this.clearTimer();
+    // 解析終了後に遅れて届く探索結果を取り込まないようにする。
+    this.searching = undefined;
     this.onFinish();
     if (!this.option?.keepEngine) {
       this.close();
@@ -276,7 +283,15 @@ export class AnalysisManager {
     // エンジンを再利用する連続解析では、前のファイル (前の局面) に対する探索結果が
     // 探索停止後に遅れて届くことがある。現在の解析対象局面と一致しない情報は、
     // 別の局面 (例: 次のファイルの初期局面) に誤って書き込まれてしまうため破棄する。
-    if (info.usi !== this.recordManager.record.usi) {
+    // 局面の一致は探索開始時に保持した USI 文字列で判定し、棋譜自体が別のファイルへ
+    // 差し替わっていないことをノードの同一性で確認する。
+    // (次のファイルの初期局面は前のファイルの初期局面と USI 文字列が一致し得るため、
+    //  文字列の比較だけでは不十分。)
+    if (
+      !this.searching ||
+      info.usi !== this.searching.usi ||
+      this.recordManager.record.current !== this.searching.node
+    ) {
       return;
     }
     this.recordManager.updateSearchInfo(SearchInfoSenderType.RESEARCHER, info);

--- a/src/tests/renderer/store/analysis.spec.ts
+++ b/src/tests/renderer/store/analysis.spec.ts
@@ -10,6 +10,18 @@ vi.mock("@/renderer/players/usi.js");
 
 const mockUSIPlayer = USIPlayer as MockedClass<typeof USIPlayer>;
 
+// startResearch に渡された USI 文字列の一覧を返す。
+function startResearchUSIs(): string[] {
+  return mockUSIPlayer.prototype.startResearch.mock.calls.map((call) => call[1]);
+}
+
+// 実際のエンジンは startResearch に渡された USI 文字列をそのまま info.usi として
+// 返すため、テストでも探索開始時にキャプチャした値をコールバックに使用する。
+function lastStartResearchUSI(): string {
+  const calls = mockUSIPlayer.prototype.startResearch.mock.calls;
+  return calls[calls.length - 1][1];
+}
+
 describe("store/analysis", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -49,25 +61,25 @@ describe("store/analysis", () => {
     vi.runOnlyPendingTimers();
     expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(1);
     manager.updateSearchInfo({
-      usi: recordManager.record.usi,
+      usi: lastStartResearchUSI(),
       score: 10,
     });
     vi.runOnlyPendingTimers();
     expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(2);
     manager.updateSearchInfo({
-      usi: recordManager.record.usi,
+      usi: lastStartResearchUSI(),
       score: 20,
     });
     vi.runOnlyPendingTimers();
     expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(3);
     manager.updateSearchInfo({
-      usi: recordManager.record.usi,
+      usi: lastStartResearchUSI(),
       score: 30,
     });
     vi.runOnlyPendingTimers();
     expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(4);
     manager.updateSearchInfo({
-      usi: recordManager.record.usi,
+      usi: lastStartResearchUSI(),
       score: 40,
     });
     vi.runOnlyPendingTimers();
@@ -75,7 +87,7 @@ describe("store/analysis", () => {
     expect(mockUSIPlayer.prototype.close).not.toBeCalled();
     expect(onFinish).not.toBeCalled();
     manager.updateSearchInfo({
-      usi: recordManager.record.usi,
+      usi: lastStartResearchUSI(),
       score: 50,
     });
     vi.runOnlyPendingTimers();
@@ -84,6 +96,14 @@ describe("store/analysis", () => {
     expect(mockUSIPlayer.prototype.close).toBeCalledTimes(1);
     expect(onFinish).toBeCalledTimes(1);
     expect(onError).not.toBeCalled();
+    // 各局面で意図した USI 文字列により探索が開始されている。
+    expect(startResearchUSIs()).toEqual([
+      "position startpos",
+      "position startpos moves 7g7f",
+      "position startpos moves 7g7f 3c3d",
+      "position startpos moves 7g7f 3c3d 2g2f",
+      "position startpos moves 7g7f 3c3d 2g2f 8c8d",
+    ]);
     recordManager.changePly(0);
     expect(recordManager.record.current.comment).toBe("");
     recordManager.changePly(1);
@@ -124,6 +144,9 @@ describe("store/analysis", () => {
       endCriteria: { enableNumber: false, number: 0 },
     });
     vi.runOnlyPendingTimers();
+    // 初期局面 (ply 0) に対して意図した USI 文字列により探索が開始されている。
+    expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(1);
+    expect(lastStartResearchUSI()).toBe("position startpos");
     // 初期局面 (ply 0) を解析中に、別局面 (別ファイルの最終局面など) の結果が遅れて届く。
     manager.updateSearchInfo({
       usi: "position startpos moves 2g2f 8c8d 2f2e",
@@ -134,9 +157,9 @@ describe("store/analysis", () => {
     recordManager.changePly(0);
     const staleData = recordManager.record.current.customData as RecordCustomData | undefined;
     expect(staleData?.researchInfo).toBeUndefined();
-    // 現局面 (ply 0) 本来の結果は記録される。
+    // 現局面 (ply 0) 本来の結果は探索開始時の USI 文字列とともに届き、記録される。
     manager.updateSearchInfo({
-      usi: recordManager.record.usi,
+      usi: lastStartResearchUSI(),
       score: 10,
       depth: 20,
     });
@@ -175,25 +198,25 @@ describe("store/analysis", () => {
     vi.runOnlyPendingTimers();
     expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(1);
     manager.updateSearchInfo({
-      usi: recordManager.record.usi,
+      usi: lastStartResearchUSI(),
       score: 10,
     });
     vi.runOnlyPendingTimers();
     expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(2);
     manager.updateSearchInfo({
-      usi: recordManager.record.usi,
+      usi: lastStartResearchUSI(),
       score: 20,
     });
     vi.runOnlyPendingTimers();
     expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(3);
     manager.updateSearchInfo({
-      usi: recordManager.record.usi,
+      usi: lastStartResearchUSI(),
       score: 30,
     });
     vi.runOnlyPendingTimers();
     expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(4);
     manager.updateSearchInfo({
-      usi: recordManager.record.usi,
+      usi: lastStartResearchUSI(),
       score: 40,
     });
     vi.runOnlyPendingTimers();
@@ -202,6 +225,13 @@ describe("store/analysis", () => {
     expect(mockUSIPlayer.prototype.close).toBeCalledTimes(1);
     expect(onFinish).toBeCalledTimes(1);
     expect(onError).not.toBeCalled();
+    // 開始手数から終了手数までの各局面で意図した USI 文字列により探索が開始されている。
+    expect(startResearchUSIs()).toEqual([
+      "position startpos moves 7g7f",
+      "position startpos moves 7g7f 3c3d",
+      "position startpos moves 7g7f 3c3d 2g2f",
+      "position startpos moves 7g7f 3c3d 2g2f 8c8d",
+    ]);
     recordManager.changePly(1);
     expect(recordManager.record.current.comment).toBe("");
     recordManager.changePly(2);
@@ -252,31 +282,31 @@ describe("store/analysis", () => {
     vi.runOnlyPendingTimers();
     expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(1);
     manager.updateSearchInfo({
-      usi: recordManager.record.usi,
+      usi: lastStartResearchUSI(),
       score: 10,
     });
     vi.runOnlyPendingTimers();
     expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(2);
     manager.updateSearchInfo({
-      usi: recordManager.record.usi,
+      usi: lastStartResearchUSI(),
       score: 20,
     });
     vi.runOnlyPendingTimers();
     expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(3);
     manager.updateSearchInfo({
-      usi: recordManager.record.usi,
+      usi: lastStartResearchUSI(),
       score: 30,
     });
     vi.runOnlyPendingTimers();
     expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(4);
     manager.updateSearchInfo({
-      usi: recordManager.record.usi,
+      usi: lastStartResearchUSI(),
       score: 40,
     });
     vi.runOnlyPendingTimers();
     expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(5);
     manager.updateSearchInfo({
-      usi: recordManager.record.usi,
+      usi: lastStartResearchUSI(),
       score: 50,
     });
     vi.runOnlyPendingTimers();
@@ -285,6 +315,14 @@ describe("store/analysis", () => {
     expect(mockUSIPlayer.prototype.close).toBeCalledTimes(1);
     expect(onFinish).toBeCalledTimes(1);
     expect(onError).not.toBeCalled();
+    // 降順に各局面で意図した USI 文字列により探索が開始されている。
+    expect(startResearchUSIs()).toEqual([
+      "position startpos moves 7g7f 3c3d 2g2f 8c8d",
+      "position startpos moves 7g7f 3c3d 2g2f",
+      "position startpos moves 7g7f 3c3d",
+      "position startpos moves 7g7f",
+      "position startpos",
+    ]);
     recordManager.changePly(0);
     expect(recordManager.record.current.comment).toBe("");
     recordManager.changePly(1);
@@ -337,25 +375,25 @@ describe("store/analysis", () => {
     vi.runOnlyPendingTimers();
     expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(1);
     manager.updateSearchInfo({
-      usi: recordManager.record.usi,
+      usi: lastStartResearchUSI(),
       score: 10,
     });
     vi.runOnlyPendingTimers();
     expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(2);
     manager.updateSearchInfo({
-      usi: recordManager.record.usi,
+      usi: lastStartResearchUSI(),
       score: 20,
     });
     vi.runOnlyPendingTimers();
     expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(3);
     manager.updateSearchInfo({
-      usi: recordManager.record.usi,
+      usi: lastStartResearchUSI(),
       score: 30,
     });
     vi.runOnlyPendingTimers();
     expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(4);
     manager.updateSearchInfo({
-      usi: recordManager.record.usi,
+      usi: lastStartResearchUSI(),
       score: 40,
     });
     vi.runOnlyPendingTimers();
@@ -364,6 +402,13 @@ describe("store/analysis", () => {
     expect(mockUSIPlayer.prototype.close).toBeCalledTimes(1);
     expect(onFinish).toBeCalledTimes(1);
     expect(onError).not.toBeCalled();
+    // 降順に終了手数から開始手数までの各局面で意図した USI 文字列により探索が開始されている。
+    expect(startResearchUSIs()).toEqual([
+      "position startpos moves 7g7f 3c3d 2g2f 8c8d 2f2e",
+      "position startpos moves 7g7f 3c3d 2g2f 8c8d",
+      "position startpos moves 7g7f 3c3d 2g2f",
+      "position startpos moves 7g7f 3c3d",
+    ]);
     recordManager.changePly(0);
     expect(recordManager.record.current.comment).toBe("");
     recordManager.changePly(1);
@@ -487,37 +532,37 @@ describe("store/analysis", () => {
         vi.runOnlyPendingTimers();
         expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(1);
         manager.updateSearchInfo({
-          usi: recordManager.record.usi,
+          usi: lastStartResearchUSI(),
           score: 10,
         });
         vi.runOnlyPendingTimers();
         expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(2);
         manager.updateSearchInfo({
-          usi: recordManager.record.usi,
+          usi: lastStartResearchUSI(),
           score: -10,
         });
         vi.runOnlyPendingTimers();
         expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(3);
         manager.updateSearchInfo({
-          usi: recordManager.record.usi,
+          usi: lastStartResearchUSI(),
           score: 200,
         });
         vi.runOnlyPendingTimers();
         expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(4);
         manager.updateSearchInfo({
-          usi: recordManager.record.usi,
+          usi: lastStartResearchUSI(),
           score: -200,
         });
         vi.runOnlyPendingTimers();
         expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(5);
         manager.updateSearchInfo({
-          usi: recordManager.record.usi,
+          usi: lastStartResearchUSI(),
           score: 400,
         });
         vi.runOnlyPendingTimers();
         expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(6);
         manager.updateSearchInfo({
-          usi: recordManager.record.usi,
+          usi: lastStartResearchUSI(),
           score: -1000,
         });
         vi.runOnlyPendingTimers();
@@ -526,6 +571,15 @@ describe("store/analysis", () => {
         expect(mockUSIPlayer.prototype.close).toBeCalledTimes(1);
         expect(onFinish).toBeCalledTimes(1);
         expect(onError).not.toBeCalled();
+        // 各局面で意図した USI 文字列により探索が開始されている。
+        expect(startResearchUSIs()).toEqual([
+          "position startpos",
+          "position startpos moves 7g7f",
+          "position startpos moves 7g7f 3c3d",
+          "position startpos moves 7g7f 3c3d 2g2f",
+          "position startpos moves 7g7f 3c3d 2g2f 8c8d",
+          "position startpos moves 7g7f 3c3d 2g2f 8c8d 2f2e",
+        ]);
         recordManager.changePly(0);
         expect(recordManager.record.current.comment).toBe("");
         for (let i = 0; i < testCase.expectedComments.length; i++) {

--- a/src/tests/renderer/store/analysis.spec.ts
+++ b/src/tests/renderer/store/analysis.spec.ts
@@ -169,6 +169,44 @@ describe("store/analysis", () => {
     manager.close();
   });
 
+  it("does-not-write-comment-from-other-position", async () => {
+    // 別の局面の探索結果は評価値グラフ (customData) だけでなくコメントにも影響する。
+    // コメントは棋譜ファイルに保存されるため、取り込んでしまうと上書き保存によって
+    // 本来コメントを持たない初期局面に誤った評価値や着手評価が残ってしまう。
+    mockUSIPlayer.prototype.launch.mockResolvedValue();
+    mockUSIPlayer.prototype.readyNewGame.mockResolvedValue();
+    mockUSIPlayer.prototype.startResearch.mockResolvedValue();
+    mockUSIPlayer.prototype.close.mockResolvedValue();
+    const recordManager = new RecordManager();
+    recordManager.importRecord(
+      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f",
+    );
+    const manager = new AnalysisManager(recordManager, { keepEngine: true });
+    await manager.start({ ...baseAnalysisSettings });
+    // 最初の探索開始前に、前のファイル (別局面) の結果が遅れて届く。
+    const otherPositionUSI = "position startpos moves 2g2f 8c8d 2f2e 8d8e";
+    manager.updateSearchInfo({ usi: otherPositionUSI, score: -3000, depth: 30 });
+    vi.runOnlyPendingTimers();
+    // 初期局面 (ply 0) 本来の結果が届いた後にも、前のファイルの結果が遅れて届く。
+    expect(lastStartResearchUSI()).toBe("position startpos");
+    manager.updateSearchInfo({ usi: lastStartResearchUSI(), score: 0, depth: 20 });
+    manager.updateSearchInfo({ usi: otherPositionUSI, score: -3000, depth: 30 });
+    vi.runOnlyPendingTimers();
+    // 1 手目の結果が届く。
+    expect(lastStartResearchUSI()).toBe("position startpos moves 7g7f");
+    manager.updateSearchInfo({ usi: lastStartResearchUSI(), score: 20, depth: 20 });
+    vi.runOnlyPendingTimers();
+    // 初期局面にはコメントを書き込まない。
+    recordManager.changePly(0);
+    expect(recordManager.record.current.comment).toBe("");
+    // 1 手目には自分の局面の評価値のみを書き込む (別局面の評価値による着手評価も付かない)。
+    recordManager.changePly(1);
+    expect(recordManager.record.current.comment).toBe(
+      "互角\n#評価値=20\n#深さ=20\n#エンジン=my usi engine\n",
+    );
+    manager.close();
+  });
+
   it("with-limits", async () => {
     mockUSIPlayer.prototype.launch.mockResolvedValue();
     mockUSIPlayer.prototype.startResearch.mockResolvedValue();

--- a/src/tests/renderer/store/analysis.spec.ts
+++ b/src/tests/renderer/store/analysis.spec.ts
@@ -4,6 +4,7 @@ import { analysisSettings as baseAnalysisSettings } from "@/tests/mock/analysis.
 import { USIPlayer } from "@/renderer/players/usi.js";
 import { MockedClass } from "vitest";
 import { CommentBehavior } from "@/common/settings/comment.js";
+import { RecordCustomData } from "@/common/record/types.js";
 
 vi.mock("@/renderer/players/usi.js");
 
@@ -48,25 +49,25 @@ describe("store/analysis", () => {
     vi.runOnlyPendingTimers();
     expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(1);
     manager.updateSearchInfo({
-      usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1",
+      usi: recordManager.record.usi,
       score: 10,
     });
     vi.runOnlyPendingTimers();
     expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(2);
     manager.updateSearchInfo({
-      usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f",
+      usi: recordManager.record.usi,
       score: 20,
     });
     vi.runOnlyPendingTimers();
     expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(3);
     manager.updateSearchInfo({
-      usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d",
+      usi: recordManager.record.usi,
       score: 30,
     });
     vi.runOnlyPendingTimers();
     expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(4);
     manager.updateSearchInfo({
-      usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f",
+      usi: recordManager.record.usi,
       score: 40,
     });
     vi.runOnlyPendingTimers();
@@ -74,7 +75,7 @@ describe("store/analysis", () => {
     expect(mockUSIPlayer.prototype.close).not.toBeCalled();
     expect(onFinish).not.toBeCalled();
     manager.updateSearchInfo({
-      usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f 8c8d",
+      usi: recordManager.record.usi,
       score: 50,
     });
     vi.runOnlyPendingTimers();
@@ -103,6 +104,46 @@ describe("store/analysis", () => {
     );
     recordManager.changePly(5);
     expect(recordManager.record.current.comment).toBe("");
+  });
+
+  it("ignores-search-info-of-other-position", async () => {
+    // エンジン再利用時に前の局面 (前のファイル) の探索結果が遅れて届いても、
+    // 現在の解析対象局面と一致しない情報は無視され、別の局面に書き込まれない。
+    mockUSIPlayer.prototype.launch.mockResolvedValue();
+    mockUSIPlayer.prototype.startResearch.mockResolvedValue();
+    mockUSIPlayer.prototype.stop.mockResolvedValue();
+    mockUSIPlayer.prototype.close.mockResolvedValue();
+    const recordManager = new RecordManager();
+    recordManager.importRecord(
+      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d",
+    );
+    const manager = new AnalysisManager(recordManager);
+    await manager.start({
+      ...baseAnalysisSettings,
+      startCriteria: { enableNumber: false, number: 0 },
+      endCriteria: { enableNumber: false, number: 0 },
+    });
+    vi.runOnlyPendingTimers();
+    // 初期局面 (ply 0) を解析中に、別局面 (別ファイルの最終局面など) の結果が遅れて届く。
+    manager.updateSearchInfo({
+      usi: "position startpos moves 2g2f 8c8d 2f2e",
+      score: 9999,
+      depth: 20,
+    });
+    // 別局面の結果は現局面 (ply 0) に書き込まれない。
+    recordManager.changePly(0);
+    const staleData = recordManager.record.current.customData as RecordCustomData | undefined;
+    expect(staleData?.researchInfo).toBeUndefined();
+    // 現局面 (ply 0) 本来の結果は記録される。
+    manager.updateSearchInfo({
+      usi: recordManager.record.usi,
+      score: 10,
+      depth: 20,
+    });
+    recordManager.changePly(0);
+    const data = recordManager.record.current.customData as RecordCustomData;
+    expect(data.researchInfo?.score).toBe(10);
+    manager.close();
   });
 
   it("with-limits", async () => {
@@ -134,25 +175,25 @@ describe("store/analysis", () => {
     vi.runOnlyPendingTimers();
     expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(1);
     manager.updateSearchInfo({
-      usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f",
+      usi: recordManager.record.usi,
       score: 10,
     });
     vi.runOnlyPendingTimers();
     expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(2);
     manager.updateSearchInfo({
-      usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d",
+      usi: recordManager.record.usi,
       score: 20,
     });
     vi.runOnlyPendingTimers();
     expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(3);
     manager.updateSearchInfo({
-      usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f",
+      usi: recordManager.record.usi,
       score: 30,
     });
     vi.runOnlyPendingTimers();
     expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(4);
     manager.updateSearchInfo({
-      usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f 8c8d",
+      usi: recordManager.record.usi,
       score: 40,
     });
     vi.runOnlyPendingTimers();
@@ -211,31 +252,31 @@ describe("store/analysis", () => {
     vi.runOnlyPendingTimers();
     expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(1);
     manager.updateSearchInfo({
-      usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f 8c8d",
+      usi: recordManager.record.usi,
       score: 10,
     });
     vi.runOnlyPendingTimers();
     expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(2);
     manager.updateSearchInfo({
-      usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f",
+      usi: recordManager.record.usi,
       score: 20,
     });
     vi.runOnlyPendingTimers();
     expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(3);
     manager.updateSearchInfo({
-      usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d",
+      usi: recordManager.record.usi,
       score: 30,
     });
     vi.runOnlyPendingTimers();
     expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(4);
     manager.updateSearchInfo({
-      usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f",
+      usi: recordManager.record.usi,
       score: 40,
     });
     vi.runOnlyPendingTimers();
     expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(5);
     manager.updateSearchInfo({
-      usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1",
+      usi: recordManager.record.usi,
       score: 50,
     });
     vi.runOnlyPendingTimers();
@@ -296,25 +337,25 @@ describe("store/analysis", () => {
     vi.runOnlyPendingTimers();
     expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(1);
     manager.updateSearchInfo({
-      usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f 8c8d 2f2e",
+      usi: recordManager.record.usi,
       score: 10,
     });
     vi.runOnlyPendingTimers();
     expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(2);
     manager.updateSearchInfo({
-      usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f 8c8d",
+      usi: recordManager.record.usi,
       score: 20,
     });
     vi.runOnlyPendingTimers();
     expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(3);
     manager.updateSearchInfo({
-      usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f",
+      usi: recordManager.record.usi,
       score: 30,
     });
     vi.runOnlyPendingTimers();
     expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(4);
     manager.updateSearchInfo({
-      usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d",
+      usi: recordManager.record.usi,
       score: 40,
     });
     vi.runOnlyPendingTimers();
@@ -446,37 +487,37 @@ describe("store/analysis", () => {
         vi.runOnlyPendingTimers();
         expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(1);
         manager.updateSearchInfo({
-          usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1",
+          usi: recordManager.record.usi,
           score: 10,
         });
         vi.runOnlyPendingTimers();
         expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(2);
         manager.updateSearchInfo({
-          usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f",
+          usi: recordManager.record.usi,
           score: -10,
         });
         vi.runOnlyPendingTimers();
         expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(3);
         manager.updateSearchInfo({
-          usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d",
+          usi: recordManager.record.usi,
           score: 200,
         });
         vi.runOnlyPendingTimers();
         expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(4);
         manager.updateSearchInfo({
-          usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f",
+          usi: recordManager.record.usi,
           score: -200,
         });
         vi.runOnlyPendingTimers();
         expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(5);
         manager.updateSearchInfo({
-          usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f 8c8d",
+          usi: recordManager.record.usi,
           score: 400,
         });
         vi.runOnlyPendingTimers();
         expect(mockUSIPlayer.prototype.startResearch).toBeCalledTimes(6);
         manager.updateSearchInfo({
-          usi: "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f 8c8d 2f2e",
+          usi: recordManager.record.usi,
           score: -1000,
         });
         vi.runOnlyPendingTimers();

--- a/src/tests/renderer/store/analysis.spec.ts
+++ b/src/tests/renderer/store/analysis.spec.ts
@@ -169,6 +169,36 @@ describe("store/analysis", () => {
     manager.close();
   });
 
+  it("ignores-search-info-after-record-replaced", async () => {
+    // 降順の連続解析では前のファイルの最後の探索が初期局面になるため、次のファイルの
+    // 初期局面と USI 文字列が一致し得る。棋譜が差し替わっている場合は文字列が一致しても
+    // 前のファイルの結果として破棄する。
+    mockUSIPlayer.prototype.launch.mockResolvedValue();
+    mockUSIPlayer.prototype.readyNewGame.mockResolvedValue();
+    mockUSIPlayer.prototype.startResearch.mockResolvedValue();
+    mockUSIPlayer.prototype.close.mockResolvedValue();
+    const recordManager = new RecordManager();
+    recordManager.importRecord(
+      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d",
+    );
+    const manager = new AnalysisManager(recordManager, { keepEngine: true });
+    await manager.start({ ...baseAnalysisSettings });
+    vi.runOnlyPendingTimers();
+    expect(lastStartResearchUSI()).toBe("position startpos");
+    // 次のファイルを読み込み、初期局面へ移動する。USI 文字列は前のファイルと同一になる。
+    recordManager.importRecord(
+      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 2g2f 8c8d",
+    );
+    recordManager.changePly(0);
+    expect(recordManager.record.usi).toBe("position startpos");
+    // 前のファイルの結果が遅れて届いても取り込まない。
+    manager.updateSearchInfo({ usi: "position startpos", score: -3000, depth: 30 });
+    recordManager.changePly(0);
+    const data = recordManager.record.current.customData as RecordCustomData | undefined;
+    expect(data?.researchInfo).toBeUndefined();
+    manager.close();
+  });
+
   it("does-not-write-comment-from-other-position", async () => {
     // 別の局面の探索結果は評価値グラフ (customData) だけでなくコメントにも影響する。
     // コメントは棋譜ファイルに保存されるため、取り込んでしまうと上書き保存によって


### PR DESCRIPTION
# 説明 / Description

連続解析 (フォルダ指定の一括解析) で、前のファイルに対する探索結果が次のファイルに混入する問題を修正します。**表示上の不整合だけでなく、上書き保存されるファイルの内容にも影響します。**

## 原因

連続解析ではエンジンを再利用する (`keepEngine`) ため、あるファイルの探索停止後にも `info` が遅れて届きます (`USIPlayer` は 500ms ごとに `flushUSIInfo()` するため、ファイルの保存・次ファイルの読み込み・`readyNewGame()` の間にも届きます)。`AnalysisManager#updateSearchInfo` は届いた情報を無条件に取り込んでいたため、その時点で既に次のファイルへ移動していると次のファイル側に反映されていました。

`updateSearchInfo` は 2 つの状態を更新するので、影響も 2 つに分かれます。

1. `recordManager.updateSearchInfo()` → 現在ノードの `customData.researchInfo`
   - 評価値グラフの初期局面 (ply 0) に本来ないデータポイントが描画される。**保存はされない** (メモリ上のみ)。
2. `this.searchInfo = info` → **`AnalysisManager` 自身の状態**
   - この値は次の `search()` で `lastSearchInfo` にシフトされ、`onResult()` がコメントを組み立てる際に使われます。
   - その結果、最初の解析局面で `onResult()` の早期リターン (`if (!this.searchInfo || !this.lastSearchInfo) return;`) をすり抜け、**本来コメントを書き込まない初期局面 (ply 0) にコメントが書き込まれます。**
   - コメントは `exportRecordAsBuffer()` で棋譜ファイルに保存されるため、**上書き保存によってユーザーのファイルに残ります。**

## 保存ファイルへの影響 (修正前の実測)

修正前のコードで遅延情報を再現したところ、次のファイルの初期局面に以下のコメントが書き込まれました。

- 遅延情報が最初の探索開始前に届いた場合 (誤った着手評価が付く):

```
【悪手】
互角
#評価値=0
#深さ=20
#エンジン=my usi engine
```

- 本来の結果の後にも届いた場合 (前のファイルの評価値がそのまま残る):

```
後手勝勢
#評価値=-3000
#深さ=30
#エンジン=my usi engine
```

## 修正内容

`updateSearchInfo` で `info.usi` と現在の `record.usi` を比較し、一致しない局面の情報は破棄するようにしました。これにより `customData` と `searchInfo` の両方が汚染されなくなります。単一ファイルの解析ではエンジンを都度終了するため挙動は変わらず、連続解析でのみ遅延情報が捨てられます。

## テスト

- `ignores-search-info-of-other-position`: 別局面の情報が `customData` (評価値グラフ) に書き込まれないこと。
- `does-not-write-comment-from-other-position`: 別局面の情報がコメント (= 保存内容) に影響しないこと。初期局面にコメントが書き込まれず、1 手目にも誤った着手評価が付かないことを確認します。
- いずれも修正を外すと失敗することを確認済みです。
- あわせて、既存テストが `startResearch()` に渡された USI 文字列を検証し、その値をコールバックに使う形に修正しました (実エンジンは渡された USI 文字列をそのまま `info.usi` として返すため)。修正前は呼び出し時点の `recordManager.record.usi` を渡しており、局面一致の判定が常に成立してしまう状態でした。

# チェックリスト / Checklist

- MUST
  - [ ] I am human
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated
  - [ ] i18n

## 補足 / Notes

- 本 PR は Claude Code によって作成されたため "I am human" はチェックしていません。
- テストは `npx vitest run` で 619 件すべて成功しています。`src/tests/background/log.spec.ts` のみ、実行環境で Electron バイナリをダウンロードできず suite の読み込みに失敗しました (変更内容とは無関係)。
- `npx tsc --noEmit` / `npx eslint src --max-warnings 0` / `npx prettier --check` はいずれも警告なしです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RX6F9TkSWinRsFAjoXHpSm