### PR TITLE
連続棋譜解析の進捗を棋譜ペインに表示する

### DIFF
--- a/src/renderer/store/batch_analysis.ts
+++ b/src/renderer/store/batch_analysis.ts
@@ -18,7 +18,7 @@ export type BatchAnalysisResult = {
   skippedTotal: number;
 };
 
-export type BatchAnalysisProgress = {
+export type BatchAnalysisProgress = BatchAnalysisResult & {
   current: number; // 1 から始まる処理中ファイルの番号
   total: number;
   path: string;
@@ -143,6 +143,7 @@ export class BatchAnalysisManager {
       current: this.index + 1,
       total: this.files.length,
       path,
+      ...this.result,
     };
     this.onProgress(this._progress);
     this.openCurrentFile()

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -178,10 +178,13 @@ class Store {
   private _gameSettings: GameSettings = defaultGameSettings();
   private csaGameManager = new CSAGameManager(this.recordManager, this.blackClock, this.whiteClock);
   private analysisManager = new AnalysisManager(this.recordManager);
-  // reactive(this) の後に、reactive proxy 経由の recordManager を渡して構築する。
-  // これにより、連続解析のファイル間遷移が生の this に束縛されたコールバック経由で進んでも、
-  // this.recordManager が reactive proxy のままなので棋譜の置換・移動が Vue に伝わる。
-  private batchAnalysisManager!: BatchAnalysisManager;
+  // 連続解析で次のファイルを開くと棋譜が差し替わるが、生の RecordManager を渡すと
+  // この変更が Vue に伝わらず、盤面や棋譜の表示が前のファイルのまま更新されない。
+  // 変更を伝えるには reactive proxy 経由でメソッドを呼ぶ必要があるため、
+  // ストアが公開するものと同じプロキシを渡す。
+  private batchAnalysisManager = new BatchAnalysisManager(
+    reactive(this.recordManager) as RecordManager,
+  );
   private _batchAnalysisProgress?: BatchAnalysisProgress;
   private _analysisDialogTarget: AnalysisDialogTarget = "record";
   private mateSearchManager = new MateSearchManager();
@@ -199,12 +202,6 @@ class Store {
   constructor() {
     const refs = reactive(this);
     this._reactive = refs;
-    // 連続解析では reactive proxy 経由の recordManager を渡す。詳細はフィールド定義のコメント参照。
-    // reactive() は生オブジェクトをキーにプロキシをキャッシュするため、これはストアが公開する
-    // reactive proxy と同一のインスタンスになる。
-    this.batchAnalysisManager = new BatchAnalysisManager(
-      reactive(this.recordManager) as RecordManager,
-    );
     this.recordManager
       .on("changePosition", () => {
         this.onChangePositionHandlers.forEach((handler) => handler());

--- a/src/renderer/view/main/BatchAnalysisProgress.vue
+++ b/src/renderer/view/main/BatchAnalysisProgress.vue
@@ -2,12 +2,15 @@
   <div class="batch-analysis-progress">
     <div class="progress-header">
       <span>{{ t.batchAnalysis }}</span>
-      <span>{{ t.files }}: {{ progress?.current || 0 }} / {{ progress?.total || 0 }}</span>
+      <span>{{ t.success }}: {{ progress?.successTotal }}</span>
+      <span>{{ t.failed }}: {{ progress?.failedTotal }}</span>
+      <span>{{ t.skipped }}: {{ progress?.skippedTotal }}</span>
     </div>
-    <div class="progress-bar">
-      <div class="progress-bar-value" :style="{ width: completedPercentage }"></div>
-    </div>
-    <div class="current-file" :title="progress?.path">{{ currentFileName }}</div>
+    <PercentageBarChart
+      class="progress-bar"
+      :value="progress ? progress.current - 1 : 0"
+      :max="progress?.total ?? 1"
+    />
   </div>
 </template>
 
@@ -15,56 +18,28 @@
 import { t } from "@/common/i18n";
 import { computed } from "vue";
 import { useStore } from "@/renderer/store";
-import { basename } from "@/renderer/helpers/path";
+import PercentageBarChart from "@/renderer/view/primitive/PercentageBarChart.vue";
 
 const store = useStore();
-
 const progress = computed(() => store.batchAnalysisProgress);
-
-const currentFileName = computed(() => {
-  const path = progress.value?.path;
-  return path ? basename(path) : "";
-});
-
-// 処理中のファイルは未完了として扱う。
-const completedPercentage = computed(() => {
-  const value = progress.value;
-  if (!value || value.total <= 0) {
-    return "0%";
-  }
-  return `${((value.current - 1) / value.total) * 100}%`;
-});
 </script>
 
 <style scoped>
 .batch-analysis-progress {
-  padding: 4px;
+  padding: 4px 8px;
   margin-top: 4px;
   background-color: var(--text-bg-color);
   color: var(--text-color);
 }
 .progress-header {
   display: flex;
-  justify-content: space-between;
+  align-items: center;
   gap: 8px;
   font-size: 0.85em;
 }
 .progress-bar {
-  width: 100%;
-  height: 6px;
   margin: 4px 0;
-  background-color: var(--text-bg-color-disabled);
-}
-.progress-bar-value {
-  height: 100%;
-  background-color: var(--control-button-bg-color);
-}
-.current-file {
   width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  text-align: left;
-  font-size: 0.85em;
+  border: 1px solid var(--dialog-border-color);
 }
 </style>

--- a/src/renderer/view/main/BatchAnalysisProgress.vue
+++ b/src/renderer/view/main/BatchAnalysisProgress.vue
@@ -1,0 +1,70 @@
+<template>
+  <div class="batch-analysis-progress">
+    <div class="progress-header">
+      <span>{{ t.batchAnalysis }}</span>
+      <span>{{ t.files }}: {{ progress?.current || 0 }} / {{ progress?.total || 0 }}</span>
+    </div>
+    <div class="progress-bar">
+      <div class="progress-bar-value" :style="{ width: completedPercentage }"></div>
+    </div>
+    <div class="current-file" :title="progress?.path">{{ currentFileName }}</div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { t } from "@/common/i18n";
+import { computed } from "vue";
+import { useStore } from "@/renderer/store";
+import { basename } from "@/renderer/helpers/path";
+
+const store = useStore();
+
+const progress = computed(() => store.batchAnalysisProgress);
+
+const currentFileName = computed(() => {
+  const path = progress.value?.path;
+  return path ? basename(path) : "";
+});
+
+// 処理中のファイルは未完了として扱う。
+const completedPercentage = computed(() => {
+  const value = progress.value;
+  if (!value || value.total <= 0) {
+    return "0%";
+  }
+  return `${((value.current - 1) / value.total) * 100}%`;
+});
+</script>
+
+<style scoped>
+.batch-analysis-progress {
+  padding: 4px;
+  margin-top: 4px;
+  background-color: var(--text-bg-color);
+  color: var(--text-color);
+}
+.progress-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 0.85em;
+}
+.progress-bar {
+  width: 100%;
+  height: 6px;
+  margin: 4px 0;
+  background-color: var(--text-bg-color-disabled);
+}
+.progress-bar-value {
+  height: 100%;
+  background-color: var(--control-button-bg-color);
+}
+.current-file {
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: left;
+  font-size: 0.85em;
+}
+</style>

--- a/src/renderer/view/main/ControlPane.vue
+++ b/src/renderer/view/main/ControlPane.vue
@@ -108,14 +108,7 @@
           @click="onEndBatchAnalysis"
         >
           <Icon :icon="IconType.STOP" />
-          <span :class="{ tooltip: compact }"
-            >{{ t.stopAnalysis
-            }}{{
-              store.batchAnalysisProgress
-                ? ` (${store.batchAnalysisProgress.current}/${store.batchAnalysisProgress.total})`
-                : ""
-            }}</span
-          >
+          <span :class="{ tooltip: compact }">{{ t.stopAnalysis }}</span>
         </button>
         <!-- 詰み探索 -->
         <button

--- a/src/renderer/view/main/StandardLayout.vue
+++ b/src/renderer/view/main/StandardLayout.vue
@@ -30,11 +30,12 @@
                 :show-comment="appSettings.showCommentInRecordView"
                 :show-elapsed-time="appSettings.showElapsedTimeInRecordView"
                 :show-branch-tree="appSettings.showBranchTreeInRecordView"
-                :show-top-control="!isConsecutiveGame"
-                :show-bottom-control="!isConsecutiveGame"
-                :show-branches="!isConsecutiveGame"
+                :show-top-control="!isConsecutiveGame && !isBatchAnalysis"
+                :show-bottom-control="!isConsecutiveGame && !isBatchAnalysis"
+                :show-branches="!isConsecutiveGame && !isBatchAnalysis"
               />
               <ConsecutiveGameProgress v-if="isConsecutiveGame" />
+              <BatchAnalysisProgress v-if="isBatchAnalysis" />
             </div>
           </div>
           <button
@@ -120,6 +121,7 @@ import { reactive, onMounted, onUnmounted, computed, ref } from "vue";
 import BoardPane from "./BoardPane.vue";
 import RecordPane, { minWidth as minRecordWidth } from "./RecordPane.vue";
 import ConsecutiveGameProgress from "./ConsecutiveGameProgress.vue";
+import BatchAnalysisProgress from "./BatchAnalysisProgress.vue";
 import { useStore } from "@/renderer/store";
 import { AppState } from "@/common/control/state.js";
 import TabPane, { headerHeight as tabHeaderHeight } from "./TabPane.vue";
@@ -148,6 +150,7 @@ const appSettings = useAppSettings();
 const isConsecutiveGame = computed(
   () => store.appState === AppState.GAME && store.gameSettings.repeat >= 2,
 );
+const isBatchAnalysis = computed(() => store.appState === AppState.BATCH_ANALYSIS);
 const windowSize = reactive(new RectSize(window.innerWidth, window.innerHeight));
 const topPaneHeightPercentage = ref(appSettings.topPaneHeightPercentage);
 const bottomLeftPaneWidthPercentage = ref(appSettings.bottomLeftPaneWidthPercentage);

--- a/src/renderer/view/main/StandardLayout.vue
+++ b/src/renderer/view/main/StandardLayout.vue
@@ -31,7 +31,6 @@
                 :show-elapsed-time="appSettings.showElapsedTimeInRecordView"
                 :show-branch-tree="appSettings.showBranchTreeInRecordView"
                 :show-top-control="!isConsecutiveGame && !isBatchAnalysis"
-                :show-bottom-control="!isConsecutiveGame && !isBatchAnalysis"
                 :show-branches="!isConsecutiveGame && !isBatchAnalysis"
               />
               <ConsecutiveGameProgress v-if="isConsecutiveGame" />


### PR DESCRIPTION
# 説明 / Description

連続棋譜解析の進捗を、中断ボタンのラベルから棋譜ペインへ移動します。

## 進捗表示の移動

進捗は中断ボタンのラベル末尾に `(3/120)` として付加されていましたが、ボタンの表示幅では収まりませんでした。`ConsecutiveGameProgress` と同じ方式で、棋譜ペインの下にスペースを借りて表示します。

- `BatchAnalysisProgress.vue` を新規追加し、`StandardLayout.vue` の `RecordPane` 直下に配置
- 連続対局と同様に、実行中は棋譜ペインの上下コントロールと分岐表示を隠してスペースを確保
- ファイル数のカウンタ、進捗バー、解析中のファイル名を表示
- ファイル名は既存の `basename()` ヘルパーを使用 (`NextMoveGenerationProgressDialog` と同じパターン)。パスが長いと末尾が切れて肝心のファイル名が見えなくなるため、フルパスは `title` 属性のツールチップに回しています
- 進捗バーは処理中のファイルを未完了として扱うため `(current - 1) / total`。最後のファイルを処理中に 100% と表示してしまうのを避けています
- 色は既存のテーマ変数 (`--text-bg-color-disabled` / `--control-button-bg-color`) を使用し、全テーマに追従します
- i18n は既存キー (`t.batchAnalysis` / `t.files`) のみで賄えたため、新規追加はありません

## BatchAnalysisManager の構築方法の整理

`BatchAnalysisManager` をフィールド初期化子で構築するようにし、コンストラクタでの代入と `!` (definite assignment assertion) をやめました。

コンストラクタで代入していたのは「reactive proxy は `reactive(this)` の後に取得する必要がある」というコメントの主張によるものでしたが、この順序制約は実在しません。`reactive()` は生オブジェクトをキーにプロキシをキャッシュするため、`reactive(this)` の前後どちらで包んでも同一のプロキシが返ります (両順序で確認済み)。

あわせてコメントを、実際に防いでいる症状 (連続解析で次のファイルを開いた際に、盤面や棋譜の表示が前のファイルのまま更新されない) を先頭に置く形へ書き直しました。`reactive()` でラップする方針自体は変更していません。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/shogihome/blob/main/CONTRIBUTING.md)
  - [ ] I am human
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n

## 補足 / Notes

- 本 PR は Claude Code によって作成されたため "I am human" はチェックしていません。
- 検証は `npx vitest run` (625 件成功)、`npx vue-tsc --noEmit -p tsconfig.lint.json`、`npx eslint src --max-warnings 0`、`npx prettier --check src` で実施しました。
- ユニットテストは追加していません。表示のみの変更であり、既存の描画テストの枠組みがないためです。
- **実際の描画は未確認です。** 連続解析の起動にはエンジンとフォルダが必要で実行環境では再現できませんでした。幅の詰まり具合など実機でのご確認をお願いします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RX6F9TkSWinRsFAjoXHpSm

---
_Generated by [Claude Code](https://claude.ai/code/session_01RX6F9TkSWinRsFAjoXHpSm)_