### PR TITLE
Refactor update check notification to use dedicated function

### DIFF
--- a/src/background/window/ipc.ts
+++ b/src/background/window/ipc.ts
@@ -1150,7 +1150,7 @@ ipcMain.handle(Background.GET_VERSION_STATUS, async (event) => {
 
 ipcMain.handle(Background.CHECK_UPDATES, async (event) => {
   validateIPCSender(event.senderFrame);
-  await checkUpdatesManually(sendNotification);
+  await checkUpdatesManually(sendUpdateCheckResult);
 });
 
 ipcMain.on(Background.OPEN_LOG_FILE, (event, logType: LogType) => {
@@ -1206,6 +1206,13 @@ export function sendMessage(message: Message): void {
 
 export function sendNotification(message: string, url?: string): void {
   mainWindow.webContents.send(Renderer.SEND_NOTIFICATION, message, url);
+}
+
+export function sendUpdateCheckResult(message: string, url?: string): void {
+  sendMessage({
+    text: message,
+    attachments: url ? [{ type: "link", text: "Release Page", url }] : undefined,
+  });
 }
 
 export function onMenuEvent(event: MenuEvent): void {

--- a/src/background/window/menu.ts
+++ b/src/background/window/menu.ts
@@ -26,6 +26,7 @@ import {
   sendError,
   sendMessage,
   sendNotification,
+  sendUpdateCheckResult,
   updateAppSettings,
 } from "@/background/window/ipc.js";
 import { MenuEvent } from "@/common/control/menu.js";
@@ -695,7 +696,7 @@ function createMenuTemplate(window: BrowserWindow) {
         {
           label: t.checkForUpdates,
           click: () => {
-            checkUpdatesManually(sendNotification).catch((e) => {
+            checkUpdatesManually(sendUpdateCheckResult).catch((e) => {
               sendError(new Error(`${t.failedToCheckUpdates}: ${e}`));
             });
           },


### PR DESCRIPTION
# 説明 / Description

This PR refactors the update check notification flow by introducing a dedicated `sendUpdateCheckResult()` function instead of reusing the generic `sendNotification()` function.

## Changes

- Added new `sendUpdateCheckResult()` function in `src/background/window/ipc.ts` that formats update check results with a "Release Page" link attachment
- Updated `CHECK_UPDATES` IPC handler to use `sendUpdateCheckResult()` instead of `sendNotification()`
- Updated menu "Check for Updates" click handler to use `sendUpdateCheckResult()` instead of `sendNotification()`
- Exported `sendUpdateCheckResult()` from ipc module and imported it in `src/background/window/menu.ts`

## Rationale

This change improves separation of concerns by using a specialized notification function for update check results. The new function formats the message with a structured link attachment (using `sendMessage()` internally) rather than a simple text notification, providing better UX for update notifications.

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED
  - [ ] unit test added/updated (if applicable to notification flow)

https://claude.ai/code/session_019AtTUvjAkgqsjpoYpMCq2H