### PR TITLE
Fix webpack TypeScript resolution breaking jimp dependency

### DIFF
--- a/webpack.config.mjs
+++ b/webpack.config.mjs
@@ -65,6 +65,14 @@ export default (env = {}) => {
       externals: ["electron"],
       experiments: {
         outputModule: true,
+        // This entry is already compiled to JavaScript by `tsc`, so webpack's built-in
+        // TypeScript support is unnecessary. Leaving it on "auto" (the default since
+        // webpack 5.109) turns it on for this config because no ts-loader is registered
+        // here, which in turn enables `resolve.tsconfig` and makes the resolver read the
+        // `tsconfig.json` files bundled in dependencies. jimp ships one that extends
+        // `@jimp/config-typescript`, a devDependency that is not installed for consumers,
+        // and the unresolvable `extends` breaks every module resolution from jimp.
+        typescript: false,
       },
       optimization,
       cache,


### PR DESCRIPTION
# 説明 / Description

Disable webpack's automatic TypeScript support in the Electron main process configuration to prevent module resolution failures when bundling dependencies like `jimp`.

## Problem

Webpack 5.109+ enables TypeScript support by default when no `ts-loader` is registered. This causes webpack's resolver to read `tsconfig.json` files from bundled dependencies. The `jimp` package ships a `tsconfig.json` that extends `@jimp/config-typescript` (a devDependency not installed for consumers), making the `extends` field unresolvable and breaking all module resolution from jimp.

## Solution

Explicitly set `experiments.typescript: false` in the webpack config for the Electron main process, since this entry is already compiled to JavaScript by `tsc` and doesn't need webpack's TypeScript support.

# チェックリスト / Checklist

- MUST
  - [ ] `npm test` passed
  - [ ] `npm run lint` was applied without warnings
  - [ ] changes of `/docs/webapp` not included (except release branch)
  - [ ] `console.log` not included (except script file)

https://claude.ai/code/session_01P87JKhWGRmM6baH7RzhGYs