### PR TITLE
Enforce npm alias ban in lockfile verification

### DIFF
--- a/scripts/verify-lockfile.mjs
+++ b/scripts/verify-lockfile.mjs
@@ -9,6 +9,21 @@
 // malicious tarball. A prefix-only check on the registry host would pass in that case, and
 // `npm ci` would happily extract the attacker's package into the original dependency's path.
 //
+// It also enforces this project's ban on npm aliases (`"foo": "npm:bar@1.2.3"`):
+//
+//   - The root package.json must not declare any alias, in any dependency field or in
+//     "overrides".
+//   - An aliased lockfile entry (one whose "name" differs from its install path) is rejected
+//     unless it appears in ALLOWED_TRANSITIVE_ALIASES below and is genuinely requested by a
+//     third-party package.
+//
+// The alias syntax is what makes "install package X at the path of package Y" a legitimate
+// lockfile state, so an unrestricted alias is exactly the escape hatch the name/version check
+// above is meant to close: adding `"name": "evil"` to the "node_modules/vue" entry would
+// otherwise turn a malicious substitution into a "correctly aliased" dependency. Aliases buy
+// this project nothing, so they are banned outright and the few transitive ones that our
+// dependencies force upon us are pinned in an explicit allowlist.
+//
 // This script only uses Node.js built-ins so it can run before `npm ci`/`npm install`.
 
 import fs from "node:fs";
@@ -16,6 +31,24 @@ import fs from "node:fs";
 const TRUSTED_RESOLVED_PREFIX = "https://registry.npmjs.org/";
 const INTEGRITY_PATTERN = /^sha(1|256|512)-[A-Za-z0-9+/]+={0,2}$/;
 const RESOLVED_URL_PATTERN = /^https:\/\/registry\.npmjs\.org\/(.+)\/-\/([^/]+)\.tgz$/;
+const ALIAS_SPEC_PREFIX = "npm:";
+
+const DEPENDENCY_FIELDS = [
+  "dependencies",
+  "devDependencies",
+  "optionalDependencies",
+  "peerDependencies",
+];
+
+// Aliases this project cannot avoid because a third-party package declares them. Each entry
+// maps the alias (the name it is installed under) to the real package it must resolve to.
+// Do not add entries here for our own dependencies: aliases are banned in package.json.
+const ALLOWED_TRANSITIVE_ALIASES = new Map([
+  // Requested by @isaacs/cliui to load the CommonJS builds alongside the ESM ones.
+  ["string-width-cjs", "string-width"],
+  ["strip-ansi-cjs", "strip-ansi"],
+  ["wrap-ansi-cjs", "wrap-ansi"],
+]);
 
 // Packages bundled inside their parent's tarball (bundleDependencies) have no tarball of
 // their own, so npm records them without a "resolved"/"integrity" field.
@@ -24,18 +57,155 @@ function isBundledOrLinked(pkg) {
 }
 
 // The lockfile key is the install path, e.g. "node_modules/@scope/foo" or
-// "node_modules/a/node_modules/foo". The package name is whatever follows the last
-// "node_modules/" segment, unless overridden by an explicit "name" field (used for
-// aliased dependencies, e.g. `"bar": "npm:foo@1.2.3"`).
-function expectedNameForKey(key, pkg) {
-  if (pkg.name) {
-    return pkg.name;
-  }
+// "node_modules/a/node_modules/foo". The name a package is installed under is whatever
+// follows the last "node_modules/" segment.
+function installedNameForKey(key) {
   const marker = "node_modules/";
-  return key.slice(key.lastIndexOf(marker) + marker.length);
+  const index = key.lastIndexOf(marker);
+  // Workspace entries are keyed by their directory instead; they are linked, not installed.
+  return index < 0 ? key : key.slice(index + marker.length);
 }
 
-function verifyResolvedIdentity(key, pkg, errors) {
+function aliasTarget(spec) {
+  // "npm:foo@^1.2.3" / "npm:@scope/foo@^1.2.3" / "npm:foo" (version omitted)
+  const rest = spec.slice(ALIAS_SPEC_PREFIX.length);
+  const separator = rest.lastIndexOf("@");
+  return separator > 0 ? rest.slice(0, separator) : rest;
+}
+
+// Yields every alias spec in an "overrides" map. A nested value is another overrides map,
+// scoped to the package named by its key, where "." overrides the package itself.
+function* aliasSpecsOfOverrides(overrides, path) {
+  if (!overrides || typeof overrides !== "object") {
+    return;
+  }
+  for (const [name, value] of Object.entries(overrides)) {
+    if (typeof value === "string") {
+      if (value.startsWith(ALIAS_SPEC_PREFIX)) {
+        // "." overrides the package named by the enclosing key.
+        const target = name === "." && path.length > 1 ? path[path.length - 1] : name;
+        yield { field: path.join("."), name: target, spec: value };
+      }
+    } else {
+      yield* aliasSpecsOfOverrides(value, [...path, name]);
+    }
+  }
+}
+
+// Yields every alias spec declared by a manifest-like object, including nested "overrides".
+function* aliasSpecsOf(manifest) {
+  if (!manifest || typeof manifest !== "object") {
+    return;
+  }
+  for (const field of DEPENDENCY_FIELDS) {
+    const deps = manifest[field];
+    if (!deps || typeof deps !== "object") {
+      continue;
+    }
+    for (const [name, spec] of Object.entries(deps)) {
+      if (typeof spec === "string" && spec.startsWith(ALIAS_SPEC_PREFIX)) {
+        yield { field, name, spec };
+      }
+    }
+  }
+  yield* aliasSpecsOfOverrides(manifest.overrides, ["overrides"]);
+}
+
+// Collects the aliases requested by third-party packages, keyed by the alias name, so that an
+// aliased lockfile entry can be traced back to the package that asked for it.
+function collectRequestedAliases(packages) {
+  const requested = new Map();
+  for (const [key, pkg] of Object.entries(packages)) {
+    if (key === "") {
+      continue; // The root project is checked against package.json instead.
+    }
+    for (const { name, spec } of aliasSpecsOf(pkg)) {
+      let entry = requested.get(name);
+      if (!entry) {
+        entry = { targets: new Set(), requesters: new Set() };
+        requested.set(name, entry);
+      }
+      entry.targets.add(aliasTarget(spec));
+      entry.requesters.add(installedNameForKey(key));
+    }
+  }
+  return requested;
+}
+
+function verifyRootHasNoAliases(errors) {
+  const manifest = JSON.parse(fs.readFileSync("package.json", "utf-8"));
+  for (const { field, name, spec } of aliasSpecsOf(manifest)) {
+    errors.push(
+      `package.json declares the npm alias "${name}": "${spec}" in "${field}" — aliases are not allowed in this project`,
+    );
+  }
+}
+
+// Returns the real package name the entry must resolve to, or null if the entry is an alias
+// that this project does not allow.
+function resolveDeclaredName(key, pkg, requestedAliases, errors) {
+  const installedName = installedNameForKey(key);
+  if (!pkg.name || pkg.name === installedName) {
+    return installedName;
+  }
+
+  // From here on the entry is an alias: it installs pkg.name under a different name.
+  const allowedTarget = ALLOWED_TRANSITIVE_ALIASES.get(installedName);
+  if (allowedTarget === undefined) {
+    errors.push(
+      `"${key}" is an npm alias for "${pkg.name}" — aliases are not allowed in this project` +
+        ` (add it to ALLOWED_TRANSITIVE_ALIASES only if a third-party package requires it)`,
+    );
+    return null;
+  }
+  if (allowedTarget !== pkg.name) {
+    errors.push(
+      `"${key}" is allowed to alias "${allowedTarget}" but the lockfile entry aliases "${pkg.name}"`,
+    );
+    return null;
+  }
+
+  const requested = requestedAliases.get(installedName);
+  if (!requested) {
+    errors.push(
+      `"${key}" is an npm alias that no package in the lockfile requests — remove it or fix the lockfile`,
+    );
+    return null;
+  }
+  if (!requested.targets.has(allowedTarget)) {
+    errors.push(
+      `"${key}" aliases "${allowedTarget}" but its requester(s) ${[...requested.requesters]
+        .map((name) => `"${name}"`)
+        .join(", ")} ask for "${[...requested.targets].join('", "')}"`,
+    );
+    return null;
+  }
+  return allowedTarget;
+}
+
+function verifyRequestedAliases(requestedAliases, errors) {
+  for (const [name, { targets, requesters }] of requestedAliases) {
+    const allowedTarget = ALLOWED_TRANSITIVE_ALIASES.get(name);
+    if (allowedTarget === undefined) {
+      errors.push(
+        `${[...requesters].map((r) => `"${r}"`).join(", ")} request the npm alias "${name}"` +
+          ` (for "${[...targets].join('", "')}") — aliases are not allowed in this project`,
+      );
+      continue;
+    }
+    for (const target of targets) {
+      if (target !== allowedTarget) {
+        errors.push(
+          `the npm alias "${name}" is allowed to point at "${allowedTarget}" but ${[...requesters]
+            .map((r) => `"${r}"`)
+            .join(", ")} request "${target}"`,
+        );
+      }
+    }
+  }
+}
+
+function verifyResolvedIdentity(key, pkg, expectedName, errors) {
   const match = pkg.resolved.match(RESOLVED_URL_PATTERN);
   if (!match) {
     errors.push(
@@ -54,7 +224,6 @@ function verifyResolvedIdentity(key, pkg, errors) {
     return;
   }
 
-  const expectedName = expectedNameForKey(key, pkg);
   if (resolvedName !== expectedName) {
     errors.push(
       `"${key}" resolves to package "${resolvedName}" but the lockfile entry is for "${expectedName}"`,
@@ -94,11 +263,25 @@ function main() {
 
   const errors = [];
   let checked = 0;
+  let aliases = 0;
+
+  verifyRootHasNoAliases(errors);
+
+  const requestedAliases = collectRequestedAliases(packages);
+  verifyRequestedAliases(requestedAliases, errors);
 
   for (const [key, pkg] of Object.entries(packages)) {
     // The root project itself has no "resolved" URL.
     if (key === "" || isBundledOrLinked(pkg)) {
       continue;
+    }
+
+    const expectedName = resolveDeclaredName(key, pkg, requestedAliases, errors);
+    if (expectedName === null) {
+      continue;
+    }
+    if (expectedName !== installedNameForKey(key)) {
+      aliases++;
     }
 
     if (!pkg.resolved) {
@@ -116,7 +299,7 @@ function main() {
       continue;
     }
 
-    verifyResolvedIdentity(key, pkg, errors);
+    verifyResolvedIdentity(key, pkg, expectedName, errors);
     checked++;
   }
 
@@ -127,7 +310,8 @@ function main() {
   }
 
   console.log(
-    `OK: ${checked} package(s) in package-lock.json resolve to ${TRUSTED_RESOLVED_PREFIX} with matching name/version`,
+    `OK: ${checked} package(s) in package-lock.json resolve to ${TRUSTED_RESOLVED_PREFIX} with matching name/version` +
+      ` (${aliases} allow-listed transitive alias(es), no other npm aliases)`,
   );
 }
 

--- a/scripts/verify-lockfile.mjs
+++ b/scripts/verify-lockfile.mjs
@@ -240,6 +240,65 @@ function verifyRequestedAliases(requestedAliases, errors) {
   }
 }
 
+// Indexes installable entries by the name they are installed under, so an alias request can be
+// followed to the entry (or entries) it would resolve to.
+function indexEntriesByInstalledName(packages) {
+  const index = new Map();
+  for (const [key, pkg] of Object.entries(packages)) {
+    if (key === "" || isBundledOrLinked(pkg)) {
+      continue;
+    }
+    const name = installedNameForKey(key);
+    let entries = index.get(name);
+    if (!entries) {
+      entries = [];
+      index.set(name, entries);
+    }
+    entries.push({ key, pkg });
+  }
+  return index;
+}
+
+// Checks the aliases from the requesting side. Verifying entries alone is not enough: dropping
+// the "name" field turns an alias entry into what looks like an ordinary package, and the
+// name/version check then only compares it against its own install name. An attacker who
+// publishes a package actually called "string-width-cjs" could therefore take the place of the
+// "string-width" that @isaacs/cliui asked for. So every alias request must land on an entry
+// that still declares the allow-listed target.
+function verifyAliasRequestsResolve(entriesByInstalledName, requestedAliases, errors) {
+  for (const [aliasName, records] of requestedAliases) {
+    const allowedTarget = ALLOWED_TRANSITIVE_ALIASES.get(aliasName);
+    if (allowedTarget === undefined) {
+      continue; // Already reported by verifyRequestedAliases().
+    }
+    const entries = entriesByInstalledName.get(aliasName) ?? [];
+    for (const { requesterKey, target } of records) {
+      if (target !== allowedTarget) {
+        continue; // Already reported by verifyRequestedAliases().
+      }
+      const requesterName = installedNameForKey(requesterKey);
+      const reachable = entries.filter(({ key }) =>
+        isReachableFrom(requesterKey, scopeOwnerForKey(key)),
+      );
+      if (reachable.length === 0) {
+        errors.push(
+          `"${requesterName}" requests the npm alias "${aliasName}" but no lockfile entry it can reach provides it`,
+        );
+        continue;
+      }
+      for (const { key, pkg } of reachable) {
+        if (pkg.name !== allowedTarget) {
+          errors.push(
+            `"${requesterName}" requests the npm alias "${aliasName}" for "${allowedTarget}",` +
+              ` but "${key}" declares "${pkg.name ?? installedNameForKey(key)}" — an entry an alias` +
+              ` request resolves to must declare "name": "${allowedTarget}"`,
+          );
+        }
+      }
+    }
+  }
+}
+
 function verifyResolvedIdentity(key, pkg, expectedName, errors) {
   const match = pkg.resolved.match(RESOLVED_URL_PATTERN);
   if (!match) {
@@ -304,6 +363,7 @@ function main() {
 
   const requestedAliases = collectRequestedAliases(packages);
   verifyRequestedAliases(requestedAliases, errors);
+  verifyAliasRequestsResolve(indexEntriesByInstalledName(packages), requestedAliases, errors);
 
   for (const [key, pkg] of Object.entries(packages)) {
     // The root project itself has no "resolved" URL.

--- a/scripts/verify-lockfile.mjs
+++ b/scripts/verify-lockfile.mjs
@@ -15,7 +15,7 @@
 //     "overrides".
 //   - An aliased lockfile entry (one whose "name" differs from its install path) is rejected
 //     unless it appears in ALLOWED_TRANSITIVE_ALIASES below and is genuinely requested by a
-//     third-party package.
+//     third-party package that can resolve to that entry's install path.
 //
 // The alias syntax is what makes "install package X at the path of package Y" a legitimate
 // lockfile state, so an unrestricted alias is exactly the escape hatch the name/version check
@@ -66,11 +66,41 @@ function installedNameForKey(key) {
   return index < 0 ? key : key.slice(index + marker.length);
 }
 
+// A nested entry ("<owner>/node_modules/foo") is only reachable from <owner> itself and from
+// packages installed inside it. A top-level entry is hoisted and reachable from anywhere, so
+// it has no owner. Used to check that an alias is requested where it is actually installed.
+function scopeOwnerForKey(key) {
+  const index = key.lastIndexOf("/node_modules/");
+  return index < 0 ? null : key.slice(0, index);
+}
+
+function isReachableFrom(requesterKey, owner) {
+  return (
+    owner === null || requesterKey === owner || requesterKey.startsWith(`${owner}/node_modules/`)
+  );
+}
+
+// npm matches the alias protocol case-insensitively (npm-package-arg does
+// `spec.toLowerCase().startsWith('npm:')`), so "NPM:foo@1.2.3" is an alias too. It does not
+// trim, so lowercasing is the whole normalization.
+function isAliasSpec(spec) {
+  return typeof spec === "string" && spec.toLowerCase().startsWith(ALIAS_SPEC_PREFIX);
+}
+
 function aliasTarget(spec) {
   // "npm:foo@^1.2.3" / "npm:@scope/foo@^1.2.3" / "npm:foo" (version omitted)
   const rest = spec.slice(ALIAS_SPEC_PREFIX.length);
   const separator = rest.lastIndexOf("@");
   return separator > 0 ? rest.slice(0, separator) : rest;
+}
+
+function formatRequesters(records) {
+  const names = new Set(records.map(({ requesterKey }) => installedNameForKey(requesterKey)));
+  return [...names].map((name) => `"${name}"`).join(", ");
+}
+
+function formatTargets(records) {
+  return [...new Set(records.map(({ target }) => target))].join('", "');
 }
 
 // Yields every alias spec in an "overrides" map. A nested value is another overrides map,
@@ -81,7 +111,7 @@ function* aliasSpecsOfOverrides(overrides, path) {
   }
   for (const [name, value] of Object.entries(overrides)) {
     if (typeof value === "string") {
-      if (value.startsWith(ALIAS_SPEC_PREFIX)) {
+      if (isAliasSpec(value)) {
         // "." overrides the package named by the enclosing key.
         const target = name === "." && path.length > 1 ? path[path.length - 1] : name;
         yield { field: path.join("."), name: target, spec: value };
@@ -103,7 +133,7 @@ function* aliasSpecsOf(manifest) {
       continue;
     }
     for (const [name, spec] of Object.entries(deps)) {
-      if (typeof spec === "string" && spec.startsWith(ALIAS_SPEC_PREFIX)) {
+      if (isAliasSpec(spec)) {
         yield { field, name, spec };
       }
     }
@@ -112,7 +142,8 @@ function* aliasSpecsOf(manifest) {
 }
 
 // Collects the aliases requested by third-party packages, keyed by the alias name, so that an
-// aliased lockfile entry can be traced back to the package that asked for it.
+// aliased lockfile entry can be traced back to the package that asked for it. The requester's
+// full lockfile key is kept because an alias only justifies entries that requester can reach.
 function collectRequestedAliases(packages) {
   const requested = new Map();
   for (const [key, pkg] of Object.entries(packages)) {
@@ -120,13 +151,12 @@ function collectRequestedAliases(packages) {
       continue; // The root project is checked against package.json instead.
     }
     for (const { name, spec } of aliasSpecsOf(pkg)) {
-      let entry = requested.get(name);
-      if (!entry) {
-        entry = { targets: new Set(), requesters: new Set() };
-        requested.set(name, entry);
+      let records = requested.get(name);
+      if (!records) {
+        records = [];
+        requested.set(name, records);
       }
-      entry.targets.add(aliasTarget(spec));
-      entry.requesters.add(installedNameForKey(key));
+      records.push({ requesterKey: key, target: aliasTarget(spec) });
     }
   }
   return requested;
@@ -165,18 +195,24 @@ function resolveDeclaredName(key, pkg, requestedAliases, errors) {
     return null;
   }
 
-  const requested = requestedAliases.get(installedName);
-  if (!requested) {
+  // The alias must be requested by a package that can actually resolve to this entry: a
+  // request elsewhere in the tree says nothing about why the alias sits at this path.
+  const records = requestedAliases.get(installedName) ?? [];
+  const owner = scopeOwnerForKey(key);
+  const inScope = records.filter(({ requesterKey }) => isReachableFrom(requesterKey, owner));
+  if (inScope.length === 0) {
     errors.push(
-      `"${key}" is an npm alias that no package in the lockfile requests — remove it or fix the lockfile`,
+      records.length === 0
+        ? `"${key}" is an npm alias that no package in the lockfile requests — remove it or fix the lockfile`
+        : `"${key}" is an npm alias that nothing able to reach it requests` +
+            ` (only ${formatRequesters(records)} request "${installedName}")`,
     );
     return null;
   }
-  if (!requested.targets.has(allowedTarget)) {
+  if (!inScope.some(({ target }) => target === allowedTarget)) {
     errors.push(
-      `"${key}" aliases "${allowedTarget}" but its requester(s) ${[...requested.requesters]
-        .map((name) => `"${name}"`)
-        .join(", ")} ask for "${[...requested.targets].join('", "')}"`,
+      `"${key}" aliases "${allowedTarget}" but its requester(s) ${formatRequesters(inScope)}` +
+        ` ask for "${formatTargets(inScope)}"`,
     );
     return null;
   }
@@ -184,21 +220,20 @@ function resolveDeclaredName(key, pkg, requestedAliases, errors) {
 }
 
 function verifyRequestedAliases(requestedAliases, errors) {
-  for (const [name, { targets, requesters }] of requestedAliases) {
+  for (const [name, records] of requestedAliases) {
     const allowedTarget = ALLOWED_TRANSITIVE_ALIASES.get(name);
     if (allowedTarget === undefined) {
       errors.push(
-        `${[...requesters].map((r) => `"${r}"`).join(", ")} request the npm alias "${name}"` +
-          ` (for "${[...targets].join('", "')}") — aliases are not allowed in this project`,
+        `${formatRequesters(records)} request the npm alias "${name}"` +
+          ` (for "${formatTargets(records)}") — aliases are not allowed in this project`,
       );
       continue;
     }
-    for (const target of targets) {
+    for (const { requesterKey, target } of records) {
       if (target !== allowedTarget) {
         errors.push(
-          `the npm alias "${name}" is allowed to point at "${allowedTarget}" but ${[...requesters]
-            .map((r) => `"${r}"`)
-            .join(", ")} request "${target}"`,
+          `the npm alias "${name}" is allowed to point at "${allowedTarget}"` +
+            ` but "${installedNameForKey(requesterKey)}" requests "${target}"`,
         );
       }
     }

--- a/scripts/verify-lockfile.mjs
+++ b/scripts/verify-lockfile.mjs
@@ -14,8 +14,8 @@
 //   - The root package.json must not declare any alias, in any dependency field or in
 //     "overrides".
 //   - An aliased lockfile entry (one whose "name" differs from its install path) is rejected
-//     unless it appears in ALLOWED_TRANSITIVE_ALIASES below and is genuinely requested by a
-//     third-party package that can resolve to that entry's install path.
+//     unless it appears in ALLOWED_TRANSITIVE_ALIASES below and some third-party package's
+//     alias request actually resolves to that entry (nearest-match, the way npm resolves).
 //
 // The alias syntax is what makes "install package X at the path of package Y" a legitimate
 // lockfile state, so an unrestricted alias is exactly the escape hatch the name/version check
@@ -66,18 +66,26 @@ function installedNameForKey(key) {
   return index < 0 ? key : key.slice(index + marker.length);
 }
 
-// A nested entry ("<owner>/node_modules/foo") is only reachable from <owner> itself and from
-// packages installed inside it. A top-level entry is hoisted and reachable from anywhere, so
-// it has no owner. Used to check that an alias is requested where it is actually installed.
+// A nested entry ("<owner>/node_modules/foo") is only visible to <owner> itself and to
+// packages installed inside it. A top-level entry is hoisted and has no owner (null).
 function scopeOwnerForKey(key) {
   const index = key.lastIndexOf("/node_modules/");
   return index < 0 ? null : key.slice(0, index);
 }
 
-function isReachableFrom(requesterKey, owner) {
-  return (
-    owner === null || requesterKey === owner || requesterKey.startsWith(`${owner}/node_modules/`)
-  );
+// npm resolves a dependency name by looking in the requester's own "node_modules", then in
+// each enclosing scope's, and takes the NEAREST match — entries farther up are shadowed.
+// Mirror that walk over the lockfile keys to find the one entry a request resolves to.
+function resolveRequestKey(packages, requesterKey, name) {
+  for (let scope = requesterKey; ; scope = scopeOwnerForKey(scope)) {
+    const candidate = scope === null ? `node_modules/${name}` : `${scope}/node_modules/${name}`;
+    if (Object.hasOwn(packages, candidate)) {
+      return candidate;
+    }
+    if (scope === null) {
+      return null;
+    }
+  }
 }
 
 // npm matches the alias protocol case-insensitively (npm-package-arg does
@@ -142,8 +150,9 @@ function* aliasSpecsOf(manifest) {
 }
 
 // Collects the aliases requested by third-party packages, keyed by the alias name, so that an
-// aliased lockfile entry can be traced back to the package that asked for it. The requester's
-// full lockfile key is kept because an alias only justifies entries that requester can reach.
+// aliased lockfile entry can be traced back to the package that asked for it. Each request is
+// resolved to its nearest matching entry up front, because that entry — and only that entry —
+// is what the request justifies.
 function collectRequestedAliases(packages) {
   const requested = new Map();
   for (const [key, pkg] of Object.entries(packages)) {
@@ -156,7 +165,11 @@ function collectRequestedAliases(packages) {
         records = [];
         requested.set(name, records);
       }
-      records.push({ requesterKey: key, target: aliasTarget(spec) });
+      records.push({
+        requesterKey: key,
+        target: aliasTarget(spec),
+        resolvedKey: resolveRequestKey(packages, key, name),
+      });
     }
   }
   return requested;
@@ -195,24 +208,24 @@ function resolveDeclaredName(key, pkg, requestedAliases, errors) {
     return null;
   }
 
-  // The alias must be requested by a package that can actually resolve to this entry: a
-  // request elsewhere in the tree says nothing about why the alias sits at this path.
+  // The alias must be justified by a request that actually resolves to this entry: a request
+  // that npm resolves to a nearer copy — or elsewhere in the tree — says nothing about why
+  // the alias sits at this path.
   const records = requestedAliases.get(installedName) ?? [];
-  const owner = scopeOwnerForKey(key);
-  const inScope = records.filter(({ requesterKey }) => isReachableFrom(requesterKey, owner));
-  if (inScope.length === 0) {
+  const resolvingHere = records.filter(({ resolvedKey }) => resolvedKey === key);
+  if (resolvingHere.length === 0) {
     errors.push(
       records.length === 0
         ? `"${key}" is an npm alias that no package in the lockfile requests — remove it or fix the lockfile`
-        : `"${key}" is an npm alias that nothing able to reach it requests` +
-            ` (only ${formatRequesters(records)} request "${installedName}")`,
+        : `"${key}" is an npm alias that no request resolves to` +
+            ` (${formatRequesters(records)} request "${installedName}", but npm resolves those requests elsewhere)`,
     );
     return null;
   }
-  if (!inScope.some(({ target }) => target === allowedTarget)) {
+  if (!resolvingHere.some(({ target }) => target === allowedTarget)) {
     errors.push(
-      `"${key}" aliases "${allowedTarget}" but its requester(s) ${formatRequesters(inScope)}` +
-        ` ask for "${formatTargets(inScope)}"`,
+      `"${key}" aliases "${allowedTarget}" but its requester(s) ${formatRequesters(resolvingHere)}` +
+        ` ask for "${formatTargets(resolvingHere)}"`,
     );
     return null;
   }
@@ -240,60 +253,38 @@ function verifyRequestedAliases(requestedAliases, errors) {
   }
 }
 
-// Indexes installable entries by the name they are installed under, so an alias request can be
-// followed to the entry (or entries) it would resolve to.
-function indexEntriesByInstalledName(packages) {
-  const index = new Map();
-  for (const [key, pkg] of Object.entries(packages)) {
-    if (key === "" || isBundledOrLinked(pkg)) {
-      continue;
-    }
-    const name = installedNameForKey(key);
-    let entries = index.get(name);
-    if (!entries) {
-      entries = [];
-      index.set(name, entries);
-    }
-    entries.push({ key, pkg });
-  }
-  return index;
-}
-
 // Checks the aliases from the requesting side. Verifying entries alone is not enough: dropping
 // the "name" field turns an alias entry into what looks like an ordinary package, and the
 // name/version check then only compares it against its own install name. An attacker who
 // publishes a package actually called "string-width-cjs" could therefore take the place of the
-// "string-width" that @isaacs/cliui asked for. So every alias request must land on an entry
-// that still declares the allow-listed target.
-function verifyAliasRequestsResolve(entriesByInstalledName, requestedAliases, errors) {
+// "string-width" that @isaacs/cliui asked for. So every allow-listed alias request must
+// resolve (nearest-match, as npm does) to an entry that still declares the allow-listed
+// target as its "name".
+function verifyAliasRequestsResolve(packages, requestedAliases, errors) {
   for (const [aliasName, records] of requestedAliases) {
     const allowedTarget = ALLOWED_TRANSITIVE_ALIASES.get(aliasName);
     if (allowedTarget === undefined) {
       continue; // Already reported by verifyRequestedAliases().
     }
-    const entries = entriesByInstalledName.get(aliasName) ?? [];
-    for (const { requesterKey, target } of records) {
+    for (const { requesterKey, target, resolvedKey } of records) {
       if (target !== allowedTarget) {
         continue; // Already reported by verifyRequestedAliases().
       }
       const requesterName = installedNameForKey(requesterKey);
-      const reachable = entries.filter(({ key }) =>
-        isReachableFrom(requesterKey, scopeOwnerForKey(key)),
-      );
-      if (reachable.length === 0) {
+      if (resolvedKey === null) {
         errors.push(
-          `"${requesterName}" requests the npm alias "${aliasName}" but no lockfile entry it can reach provides it`,
+          `"${requesterName}" requests the npm alias "${aliasName}" but no lockfile entry provides it`,
         );
         continue;
       }
-      for (const { key, pkg } of reachable) {
-        if (pkg.name !== allowedTarget) {
-          errors.push(
-            `"${requesterName}" requests the npm alias "${aliasName}" for "${allowedTarget}",` +
-              ` but "${key}" declares "${pkg.name ?? installedNameForKey(key)}" — an entry an alias` +
-              ` request resolves to must declare "name": "${allowedTarget}"`,
-          );
-        }
+      const resolved = packages[resolvedKey];
+      if (resolved.name !== allowedTarget) {
+        errors.push(
+          `"${requesterName}" requests the npm alias "${aliasName}" for "${allowedTarget}",` +
+            ` but it resolves to "${resolvedKey}" which declares` +
+            ` "${resolved.name ?? installedNameForKey(resolvedKey)}" — that entry must declare` +
+            ` "name": "${allowedTarget}"`,
+        );
       }
     }
   }
@@ -363,7 +354,7 @@ function main() {
 
   const requestedAliases = collectRequestedAliases(packages);
   verifyRequestedAliases(requestedAliases, errors);
-  verifyAliasRequestsResolve(indexEntriesByInstalledName(packages), requestedAliases, errors);
+  verifyAliasRequestsResolve(packages, requestedAliases, errors);
 
   for (const [key, pkg] of Object.entries(packages)) {
     // The root project itself has no "resolved" URL.


### PR DESCRIPTION
# 説明 / Description

This change extends the lockfile verification script (`scripts/verify-lockfile.mjs`) to enforce a project-wide ban on npm aliases (e.g., `"foo": "npm:bar@1.2.3"`), with an allowlist for unavoidable transitive aliases from third-party dependencies.

## Changes

- **Root package.json validation**: Rejects any npm alias declarations in dependency fields or "overrides"
- **Lockfile alias detection**: Identifies aliased entries (where `pkg.name` differs from the install path) and validates them against an allowlist
- **Transitive alias allowlist**: Pinned three aliases (`string-width-cjs`, `strip-ansi-cjs`, `wrap-ansi-cjs`) that `@isaacs/cliui` requires
- **Requester tracking**: Verifies that allowed aliases are actually requested by third-party packages and resolve to the expected targets
- **Refactored name resolution**: Separated install path parsing from name resolution to support alias validation

The alias syntax is a security concern because it allows installing one package under another's name/path, which could bypass the existing name/version integrity checks. By banning aliases outright (except for pinned transitive ones), this closes that escape hatch.

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/shogihome/blob/main/CONTRIBUTING.md)
  - [ ] I am human
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n

https://claude.ai/code/session_01B6At4Toy1UertVWyzQ8Ne4