### PR TITLE
カスタムレイアウトに自動でリサイズするオプションを追加

### DIFF
--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -617,6 +617,7 @@ export const en: Texts = {
   exportProfileToClipboard: "Export Profile to Clipboard",
   importProfileFromClipboard: "Import Profile from Clipboard",
   editLayoutWithDragAndDrop: "Edit with Drag and Drop",
+  stretchCustomLayout: "Scale to Fit Screen",
   profileExportedToClipboard: "Profile exported to clipboard.",
   profileImported: "Profile imported.",
   failedToImportProfile: "Failed to import profile.",

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -617,7 +617,7 @@ export const ja: Texts = {
   exportProfileToClipboard: "プロファイルをクリップボードに出力",
   importProfileFromClipboard: "クリップボードからプロファイルを取り込む",
   editLayoutWithDragAndDrop: "ドラッグで編集",
-  stretchCustomLayout: "画面サイズに合わせて伸縮",
+  stretchCustomLayout: "ウィンドウに合わせる",
   profileExportedToClipboard: "プロファイルをクリップボードに出力しました。",
   profileImported: "プロファイルを取り込みました。",
   failedToImportProfile: "プロファイルの取り込みに失敗しました。",

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -617,6 +617,7 @@ export const ja: Texts = {
   exportProfileToClipboard: "プロファイルをクリップボードに出力",
   importProfileFromClipboard: "クリップボードからプロファイルを取り込む",
   editLayoutWithDragAndDrop: "ドラッグで編集",
+  stretchCustomLayout: "画面サイズに合わせて伸縮",
   profileExportedToClipboard: "プロファイルをクリップボードに出力しました。",
   profileImported: "プロファイルを取り込みました。",
   failedToImportProfile: "プロファイルの取り込みに失敗しました。",

--- a/src/common/i18n/locales/vi.ts
+++ b/src/common/i18n/locales/vi.ts
@@ -627,7 +627,7 @@ export const vi: Texts = {
   exportProfileToClipboard: "Sao chép cài đặt",
   importProfileFromClipboard: "Dán cài đặt",
   editLayoutWithDragAndDrop: "ドラッグで編集", // TODO: Translate
-  stretchCustomLayout: "Co giãn vừa màn hình",
+  stretchCustomLayout: "ウィンドウに合わせる", // TODO: Translate
   profileExportedToClipboard: "Đã xuất cài đặt.",
   profileImported: "Đã nhập cài đặt.",
   failedToImportProfile: "Nhập cài đặt thất bại.",

--- a/src/common/i18n/locales/vi.ts
+++ b/src/common/i18n/locales/vi.ts
@@ -627,6 +627,7 @@ export const vi: Texts = {
   exportProfileToClipboard: "Sao chép cài đặt",
   importProfileFromClipboard: "Dán cài đặt",
   editLayoutWithDragAndDrop: "ドラッグで編集", // TODO: Translate
+  stretchCustomLayout: "Co giãn vừa màn hình",
   profileExportedToClipboard: "Đã xuất cài đặt.",
   profileImported: "Đã nhập cài đặt.",
   failedToImportProfile: "Nhập cài đặt thất bại.",

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -624,6 +624,7 @@ export const zh_tw: Texts = {
   exportProfileToClipboard: "將佈局設定複製至剪貼板",
   importProfileFromClipboard: "自剪貼板匯入佈局設定",
   editLayoutWithDragAndDrop: "ドラッグで編集", // TODO: Translate
+  stretchCustomLayout: "縮放以符合螢幕",
   profileExportedToClipboard: "該佈局已複製至剪貼板。",
   profileImported: "該佈局已成功匯入。",
   failedToImportProfile: "佈局匯入失敗。",

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -624,7 +624,7 @@ export const zh_tw: Texts = {
   exportProfileToClipboard: "將佈局設定複製至剪貼板",
   importProfileFromClipboard: "自剪貼板匯入佈局設定",
   editLayoutWithDragAndDrop: "ドラッグで編集", // TODO: Translate
-  stretchCustomLayout: "縮放以符合螢幕",
+  stretchCustomLayout: "ウィンドウに合わせる", // TODO: Translate
   profileExportedToClipboard: "該佈局已複製至剪貼板。",
   profileImported: "該佈局已成功匯入。",
   failedToImportProfile: "佈局匯入失敗。",

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -607,6 +607,7 @@ export type Texts = {
   exportProfileToClipboard: string;
   importProfileFromClipboard: string;
   editLayoutWithDragAndDrop: string;
+  stretchCustomLayout: string;
   profileExportedToClipboard: string;
   profileImported: string;
   failedToImportProfile: string;

--- a/src/common/settings/layout.ts
+++ b/src/common/settings/layout.ts
@@ -137,8 +137,11 @@ export function calculateLayoutScale(
   const y0 = Math.max(Math.min(...components.map((component) => component.top)), 0);
   const maxX = Math.max(...components.map((component) => component.left + component.width));
   const maxY = Math.max(...components.map((component) => component.top + component.height));
-  const horizontalScale = maxX > 0 ? (width - x0) / maxX : Number.POSITIVE_INFINITY;
-  const verticalScale = maxY > 0 ? (height - y0) / maxY : Number.POSITIVE_INFINITY;
+  const horizontalExtent = maxX + x0;
+  const verticalExtent = maxY + y0;
+  const horizontalScale =
+    horizontalExtent > 0 ? width / horizontalExtent : Number.POSITIVE_INFINITY;
+  const verticalScale = verticalExtent > 0 ? height / verticalExtent : Number.POSITIVE_INFINITY;
   return Math.max(Math.min(horizontalScale, verticalScale), 0);
 }
 

--- a/src/common/settings/layout.ts
+++ b/src/common/settings/layout.ts
@@ -118,11 +118,29 @@ export enum DialogPosition {
 export type LayoutProfile = {
   uri: string;
   name: string;
+  stretch?: boolean;
   backgroundColor?: string;
   dialogPosition?: DialogPosition;
   dialogBackdrop?: boolean;
   components: UIComponent[];
 };
+
+export function calculateLayoutScale(
+  components: UIComponent[],
+  width: number,
+  height: number,
+): number {
+  if (components.length === 0) {
+    return 1;
+  }
+  const x0 = Math.max(Math.min(...components.map((component) => component.left)), 0);
+  const y0 = Math.max(Math.min(...components.map((component) => component.top)), 0);
+  const maxX = Math.max(...components.map((component) => component.left + component.width));
+  const maxY = Math.max(...components.map((component) => component.top + component.height));
+  const horizontalScale = maxX > 0 ? (width - x0) / maxX : Number.POSITIVE_INFINITY;
+  const verticalScale = maxY > 0 ? (height - y0) / maxY : Number.POSITIVE_INFINITY;
+  return Math.max(Math.min(horizontalScale, verticalScale), 0);
+}
 
 export type LayoutProfileList = {
   profiles: LayoutProfile[];

--- a/src/renderer/view/layout/LayoutManager.vue
+++ b/src/renderer/view/layout/LayoutManager.vue
@@ -63,16 +63,8 @@
             @update:value="(value) => updateCustomProfileProp('dialogPosition', value)"
           />
         </div>
-        <div v-if="!draggingMode" class="row">
+        <div v-if="!draggingMode" class="row profile-toggles">
           <ToggleButton
-            :value="!!customProfile.stretch"
-            :label="t.stretchCustomLayout"
-            @update:value="(value) => updateCustomProfileProp('stretch', value)"
-          />
-        </div>
-        <div v-if="!draggingMode" class="row">
-          <ToggleButton
-            class="color-toggle"
             :value="!!customProfile.backgroundColor"
             :label="t.backgroundColor"
             @update:value="
@@ -87,10 +79,14 @@
             @input="(e) => updateCustomProfileProp('backgroundColor', inputEventToString(e))"
           />
           <ToggleButton
-            class="backdrop-toggle"
             :value="!!customProfile.dialogBackdrop"
             :label="t.dialogBackdrop"
             @update:value="(value) => updateCustomProfileProp('dialogBackdrop', value)"
+          />
+          <ToggleButton
+            :value="!!customProfile.stretch"
+            :label="t.stretchCustomLayout"
+            @update:value="(value) => updateCustomProfileProp('stretch', value)"
           />
         </div>
         <div class="row">
@@ -819,16 +815,11 @@ button {
   display: inline-block;
   width: 50px;
 }
-.color-toggle {
+.profile-toggles > * {
   display: inline-block;
   margin-right: 20px;
 }
 .color-selector {
-  display: inline-block;
   height: 24px;
-  margin-right: 20px;
-}
-.backdrop-toggle {
-  display: inline-block;
 }
 </style>

--- a/src/renderer/view/layout/LayoutManager.vue
+++ b/src/renderer/view/layout/LayoutManager.vue
@@ -65,6 +65,13 @@
         </div>
         <div v-if="!draggingMode" class="row">
           <ToggleButton
+            :value="!!customProfile.stretch"
+            :label="t.stretchCustomLayout"
+            @update:value="(value) => updateCustomProfileProp('stretch', value)"
+          />
+        </div>
+        <div v-if="!draggingMode" class="row">
+          <ToggleButton
             class="color-toggle"
             :value="!!customProfile.backgroundColor"
             :label="t.backgroundColor"

--- a/src/renderer/view/main/CustomLayout.vue
+++ b/src/renderer/view/main/CustomLayout.vue
@@ -1,95 +1,97 @@
 <template>
-  <div>
-    <div
-      v-for="c in components"
-      :key="`${c.type}.${c.index}`"
-      class="component"
-      :style="{ ...c.style, zIndex: 1e5 - c.index }"
-    >
-      <BoardPane
-        v-if="c.type === 'Board'"
-        :max-size="c.size"
-        :left-control-type="
-          c.leftControlBox ? LeftSideControlType.STANDARD : LeftSideControlType.NONE
-        "
-        :right-control-type="
-          c.rightControlBox ? RightSideControlType.STANDARD : RightSideControlType.NONE
-        "
-        :layout-type="c.layoutType || BoardLayoutType.STANDARD"
-      />
-      <RecordPane
-        v-else-if="c.type === 'Record'"
-        class="full"
-        :show-comment="!!c.showCommentColumn"
-        :show-elapsed-time="!!c.showElapsedTimeColumn"
-        :show-branch-tree="!!c.showBranchTree"
-        :show-top-control="!!c.topControlBox"
-        :show-bottom-control="false"
-        :show-branches="!!c.branches"
-      />
-      <BookPanel v-else-if="c.type === 'Book'" class="full" />
-      <div v-else-if="c.type === 'Analytics'" class="full tab-content">
-        <EngineAnalytics
+  <div ref="root" class="custom-layout full">
+    <div class="layout-content" :style="layoutStyle">
+      <div
+        v-for="c in components"
+        :key="`${c.type}.${c.index}`"
+        class="component"
+        :style="{ ...c.style, zIndex: 1e5 - c.index }"
+      >
+        <BoardPane
+          v-if="c.type === 'Board'"
+          :max-size="c.size"
+          :left-control-type="
+            c.leftControlBox ? LeftSideControlType.STANDARD : LeftSideControlType.NONE
+          "
+          :right-control-type="
+            c.rightControlBox ? RightSideControlType.STANDARD : RightSideControlType.NONE
+          "
+          :layout-type="c.layoutType || BoardLayoutType.STANDARD"
+        />
+        <RecordPane
+          v-else-if="c.type === 'Record'"
+          class="full"
+          :show-comment="!!c.showCommentColumn"
+          :show-elapsed-time="!!c.showElapsedTimeColumn"
+          :show-branch-tree="!!c.showBranchTree"
+          :show-top-control="!!c.topControlBox"
+          :show-bottom-control="false"
+          :show-branches="!!c.branches"
+        />
+        <BookPanel v-else-if="c.type === 'Book'" class="full" />
+        <div v-else-if="c.type === 'Analytics'" class="full tab-content">
+          <EngineAnalytics
+            :size="c.size"
+            :history-mode="!!c.historyMode"
+            :show-header="!!c.showHeader"
+            :show-time-column="!!c.showTimeColumn"
+            :show-multi-pv-column="!!c.showMultiPvColumn"
+            :show-depth-column="!!c.showDepthColumn"
+            :show-nodes-column="!!c.showNodesColumn"
+            :show-score-column="!!c.showScoreColumn"
+            :show-play-button="!!c.showPlayButton"
+            :show-suggestions-count="!!c.showSuggestionsCount"
+          />
+        </div>
+        <EvaluationChart
+          v-else-if="c.type === 'Chart'"
           :size="c.size"
-          :history-mode="!!c.historyMode"
-          :show-header="!!c.showHeader"
-          :show-time-column="!!c.showTimeColumn"
-          :show-multi-pv-column="!!c.showMultiPvColumn"
-          :show-depth-column="!!c.showDepthColumn"
-          :show-nodes-column="!!c.showNodesColumn"
-          :show-score-column="!!c.showScoreColumn"
-          :show-play-button="!!c.showPlayButton"
-          :show-suggestions-count="!!c.showSuggestionsCount"
+          :type="c.chartType"
+          :thema="appSettings.thema"
+          :coefficient-in-sigmoid="appSettings.coefficientInSigmoid"
+          :show-legend="!!c.showLegend"
+        />
+        <RecordComment
+          v-else-if="c.type === 'Comment'"
+          class="full"
+          :show-bookmark="!!c.showBookmark"
+        />
+        <RecordInfo v-else-if="c.type === 'RecordInfo'" class="full" :size="c.size" />
+        <ControlPane
+          v-else-if="c.type === 'ControlGroup1'"
+          class="full"
+          :group="ControlGroup.Group1"
+        />
+        <ControlPane
+          v-else-if="c.type === 'ControlGroup2'"
+          class="full"
+          :group="ControlGroup.Group2"
+        />
+        <ElapsedTimeChart
+          v-else-if="c.type === 'ElapsedTimeChart'"
+          :size="c.size"
+          :thema="appSettings.thema"
+          :record="store.record"
+          :show-legend="!!c.showLegend"
+          @click-ply="(ply) => store.changePly(ply)"
+        />
+        <SimpleBoardView
+          v-else-if="c.type === 'SimpleBoard'"
+          :max-size="c.size"
+          :position="store.record.position"
+          :black-name="getBlackPlayerNamePreferShort(store.record.metadata)"
+          :white-name="getWhitePlayerNamePreferShort(store.record.metadata)"
+          :header="c.bookmark ? store.record.current.bookmark : ''"
+          :footer="store.record.current.comment"
+          :last-move="
+            store.record.current.move instanceof Move ? store.record.current.move : undefined
+          "
+          typeface="mincho"
+          :font-weight="c.fontWeight === PositionImageFontWeight.W700X ? 700 : 400"
+          :text-shadow="c.fontWeight !== PositionImageFontWeight.W400"
+          :font-scale="(c.fontScale || 100) / 100"
         />
       </div>
-      <EvaluationChart
-        v-else-if="c.type === 'Chart'"
-        :size="c.size"
-        :type="c.chartType"
-        :thema="appSettings.thema"
-        :coefficient-in-sigmoid="appSettings.coefficientInSigmoid"
-        :show-legend="!!c.showLegend"
-      />
-      <RecordComment
-        v-else-if="c.type === 'Comment'"
-        class="full"
-        :show-bookmark="!!c.showBookmark"
-      />
-      <RecordInfo v-else-if="c.type === 'RecordInfo'" class="full" :size="c.size" />
-      <ControlPane
-        v-else-if="c.type === 'ControlGroup1'"
-        class="full"
-        :group="ControlGroup.Group1"
-      />
-      <ControlPane
-        v-else-if="c.type === 'ControlGroup2'"
-        class="full"
-        :group="ControlGroup.Group2"
-      />
-      <ElapsedTimeChart
-        v-else-if="c.type === 'ElapsedTimeChart'"
-        :size="c.size"
-        :thema="appSettings.thema"
-        :record="store.record"
-        :show-legend="!!c.showLegend"
-        @click-ply="(ply) => store.changePly(ply)"
-      />
-      <SimpleBoardView
-        v-else-if="c.type === 'SimpleBoard'"
-        :max-size="c.size"
-        :position="store.record.position"
-        :black-name="getBlackPlayerNamePreferShort(store.record.metadata)"
-        :white-name="getWhitePlayerNamePreferShort(store.record.metadata)"
-        :header="c.bookmark ? store.record.current.bookmark : ''"
-        :footer="store.record.current.comment"
-        :last-move="
-          store.record.current.move instanceof Move ? store.record.current.move : undefined
-        "
-        typeface="mincho"
-        :font-weight="c.fontWeight === PositionImageFontWeight.W700X ? 700 : 400"
-        :text-shadow="c.fontWeight !== PositionImageFontWeight.W400"
-        :font-scale="(c.fontScale || 100) / 100"
-      />
     </div>
   </div>
 </template>
@@ -100,8 +102,9 @@ import {
   BoardLayoutType,
   UIComponent,
   PositionImageFontWeight,
+  calculateLayoutScale,
 } from "@/common/settings/layout";
-import { computed } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref } from "vue";
 import { Rect, RectSize } from "@/common/assets/geometry";
 import { LeftSideControlType, RightSideControlType } from "@/common/settings/app";
 import BoardPane from "./BoardPane.vue";
@@ -122,6 +125,35 @@ const props = defineProps<{ profile: LayoutProfile }>();
 
 const appSettings = useAppSettings();
 const store = useStore();
+const root = ref<HTMLElement>();
+const viewport = ref({ width: 0, height: 0 });
+let resizeObserver: ResizeObserver | undefined;
+
+onMounted(() => {
+  resizeObserver = new ResizeObserver(([entry]) => {
+    viewport.value = {
+      width: entry.contentRect.width,
+      height: entry.contentRect.height,
+    };
+  });
+  if (root.value) {
+    resizeObserver.observe(root.value);
+  }
+});
+
+onBeforeUnmount(() => resizeObserver?.disconnect());
+
+const layoutStyle = computed(() => {
+  if (!props.profile.stretch) {
+    return {};
+  }
+  const scale = calculateLayoutScale(
+    props.profile.components,
+    viewport.value.width,
+    viewport.value.height,
+  );
+  return { transform: `scale(${scale})` };
+});
 
 function componentStyle(c: UIComponent) {
   const rect = new Rect(c.left, c.top, c.width, c.height);
@@ -159,6 +191,13 @@ const components = computed(() => {
 </script>
 
 <style scoped>
+.custom-layout {
+  position: relative;
+  overflow: hidden;
+}
+.layout-content {
+  transform-origin: left top;
+}
 .component {
   position: absolute;
 }

--- a/src/tests/common/settings/layout.spec.ts
+++ b/src/tests/common/settings/layout.spec.ts
@@ -1,5 +1,6 @@
 import {
   appendCustomLayoutProfile,
+  calculateLayoutScale,
   deserializeLayoutProfile,
   duplicateCustomLayoutProfile,
   emptyLayoutProfileList,
@@ -10,6 +11,14 @@ import {
 } from "@/common/settings/layout.js";
 
 describe("common/settings/layout", () => {
+  it("calculateLayoutScale", () => {
+    const components = [{ type: "Record" as const, left: 10, top: 20, width: 190, height: 80 }];
+    expect(calculateLayoutScale(components, 410, 220)).toBe(2);
+    expect(calculateLayoutScale(components, 310, 220)).toBe(1.5);
+    expect(calculateLayoutScale(components, 410, 170)).toBe(1.5);
+    expect(calculateLayoutScale([], 410, 220)).toBe(1);
+  });
+
   it("appendCustomLayout", () => {
     const config = emptyLayoutProfileList();
 

--- a/src/tests/common/settings/layout.spec.ts
+++ b/src/tests/common/settings/layout.spec.ts
@@ -13,10 +13,10 @@ import {
 describe("common/settings/layout", () => {
   it("calculateLayoutScale", () => {
     const components = [{ type: "Record" as const, left: 10, top: 20, width: 190, height: 80 }];
-    expect(calculateLayoutScale(components, 410, 220)).toBe(2);
-    expect(calculateLayoutScale(components, 310, 220)).toBe(1.5);
-    expect(calculateLayoutScale(components, 410, 170)).toBe(1.5);
-    expect(calculateLayoutScale([], 410, 220)).toBe(1);
+    expect(calculateLayoutScale(components, 420, 240)).toBe(2);
+    expect(calculateLayoutScale(components, 315, 240)).toBe(1.5);
+    expect(calculateLayoutScale(components, 420, 180)).toBe(1.5);
+    expect(calculateLayoutScale([], 420, 240)).toBe(1);
   });
 
   it("appendCustomLayout", () => {


### PR DESCRIPTION
#1730 

### Motivation
- カスタムレイアウトを画面サイズに合わせて伸縮できるようにし、縦横比を維持してUIの見た目を崩さないようにするため。
- 既存プロファイルとの互換性を保つため、動作はプロファイル単位のトグル（デフォルトは無効）で切り替えられる必要がある。

### Description
- `LayoutProfile` に `stretch?: boolean` を追加してプロファイルごとに保存できるようにしました（`src/common/settings/layout.ts`）。
- 画面フィット用の倍率計算関数 `calculateLayoutScale(components, width, height)` を実装し、余白 `x0 = max(min(X), 0)`, `y0 = max(min(Y), 0)` を考慮したうえで横・縦の制約のうち先に空間がなくなる側に合わせる（アスペクト比を維持して縮尺は `min(horizontalScale, verticalScale)`）ロジックを追加しました（`src/common/settings/layout.ts`）。
- `CustomLayout.vue` に `ResizeObserver` を追加して表示領域を監視し、`profile.stretch` が有効な場合のみ `calculateLayoutScale` で算出した `transform: scale(...)` をルートのレイアウトコンテナに適用するようにしました（`src/renderer/view/main/CustomLayout.vue`）。
- レイアウト編集画面にプロファイル単位のトグル `stretch` を追加して保存・編集できるようにしました（`src/renderer/view/layout/LayoutManager.vue`）。
- 多言語対応の文言を追加（`stretchCustomLayout`）して各ロケールファイルを更新しました（`src/common/i18n/locales/*.ts` と `src/common/i18n/text_template.ts`）。
- 倍率計算のユニットテスト `calculateLayoutScale` を `src/tests/common/settings/layout.spec.ts` に追加しました。

### Testing
- フォーマット: `npx prettier --write ...` を実行しました（該当ファイルを整形）。
- 単体テスト: `npx vitest run src/tests/common/settings/layout.spec.ts` を実行し、テストスイートは成功（1 ファイル、5 テスト、すべて合格）。
- 型チェック: `npx vue-tsc --noEmit -p tsconfig.lint.json` を実行しエラーなし。
- 変更点はローカルで適用済みで、上記自動チェックはすべて成功しています。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a807e10c640832184e543bf042dc3e2)