### PR TITLE
Add configurable copy formats for record and board

### DIFF
--- a/src/background/window/menu.ts
+++ b/src/background/window/menu.ts
@@ -152,7 +152,10 @@ function createMenuTemplate(window: BrowserWindow) {
         {
           label: t.copyRecordAll,
           submenu: [
-            menuItem(t.asKIF, MenuEvent.COPY_RECORD, null, isMac ? undefined : "CmdOrCtrl+C"),
+            // NOTE: Ctrl/Cmd+C と Ctrl/Cmd+B はコピーする形式をアプリ設定で切り替えられる。
+            //   メニューは起動時に一度だけ構築されるためアクセラレータは付けず、
+            //   レンダラー側 (App.vue) のホットキーで処理する。
+            menuItem(t.asKIF, MenuEvent.COPY_RECORD, null),
             menuItem(t.asKI2, MenuEvent.COPY_RECORD_KI2, null),
             menuItem(t.asCSA, MenuEvent.COPY_RECORD_CSA, null),
             menuItem(t.asUSIUntilCurrentMove, MenuEvent.COPY_RECORD_USI_BEFORE, null),

--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -309,6 +309,8 @@ export const en: Texts = {
   anyTurn: "Any",
   onlyHumanTurn: "Human",
   defaultRecordFileFormat: "Default Record Format",
+  copyRecordFormat: "Record Copy Format",
+  copyPositionFormat: "Position Copy Format",
   textEncoding: "Text Encoding",
   strict: "Strict",
   autoDetect: "Auto Detect",

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -309,6 +309,8 @@ export const ja: Texts = {
   anyTurn: "全ての手番",
   onlyHumanTurn: "人間の手番のみ",
   defaultRecordFileFormat: "デフォルトの保存形式",
+  copyRecordFormat: "棋譜コピーの形式",
+  copyPositionFormat: "局面コピーの形式",
   textEncoding: "文字コード",
   strict: "厳格",
   autoDetect: "自動判定",

--- a/src/common/i18n/locales/vi.ts
+++ b/src/common/i18n/locales/vi.ts
@@ -319,6 +319,8 @@ export const vi: Texts = {
   anyTurn: "Tất cả",
   onlyHumanTurn: "Nước của người chơi",
   defaultRecordFileFormat: "Định dạng kỳ phổ mặc định",
+  copyRecordFormat: "棋譜コピーの形式", // TODO: Translate
+  copyPositionFormat: "局面コピーの形式", // TODO: Translate
   textEncoding: "Bộ mã chữ",
   strict: "Bắt buộc",
   autoDetect: "Tự động",

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -316,6 +316,8 @@ export const zh_tw: Texts = {
   anyTurn: "所有手番",
   onlyHumanTurn: "只有玩家手番",
   defaultRecordFileFormat: "預設保存格式",
+  copyRecordFormat: "棋譜コピーの形式", // TODO: Translate
+  copyPositionFormat: "局面コピーの形式", // TODO: Translate
   textEncoding: "文字編碼",
   strict: "檔案原始編碼",
   autoDetect: "自動判定",

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -301,6 +301,8 @@ export type Texts = {
   anyTurn: string;
   onlyHumanTurn: string;
   defaultRecordFileFormat: string;
+  copyRecordFormat: string;
+  copyPositionFormat: string;
   textEncoding: string;
   strict: string;
   autoDetect: string;

--- a/src/common/settings/app.ts
+++ b/src/common/settings/app.ts
@@ -164,6 +164,22 @@ export enum BranchListMode {
   NEXT_MOVE = "nextMove",
 }
 
+// Ctrl/Cmd+C でコピーする棋譜のフォーマット
+export enum CopyRecordFormat {
+  KIF = "kif",
+  KI2 = "ki2",
+  CSA = "csa",
+  USI = "usi",
+  JKF = "jkf",
+  USEN = "usen",
+}
+
+// Ctrl/Cmd+B でコピーする局面のフォーマット
+export enum CopyPositionFormat {
+  SFEN = "sfen",
+  BOD = "bod",
+}
+
 export type AppSettings = {
   // Language
   language: Language;
@@ -217,6 +233,8 @@ export type AppSettings = {
 
   // Record File
   defaultRecordFileFormat: RecordFileFormat;
+  copyRecordFormat: CopyRecordFormat;
+  copyPositionFormat: CopyPositionFormat;
   textDecodingRule: TextDecodingRule;
   returnCode: string;
   autoSaveDirectory: string; // Deprecated
@@ -387,6 +405,8 @@ export function defaultAppSettings(opt?: {
     topPanePreviousHeightPercentage: 60,
     bottomLeftPaneWidthPercentage: 60,
     defaultRecordFileFormat: RecordFileFormat.KIF,
+    copyRecordFormat: CopyRecordFormat.KIF,
+    copyPositionFormat: CopyPositionFormat.SFEN,
     textDecodingRule: TextDecodingRule.AUTO_DETECT,
     returnCode: opt?.returnCode || "\r\n",
     autoSaveDirectory: opt?.autoSaveDirectory || "",

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -24,7 +24,13 @@ import {
 } from "tsshogi";
 import { reactive, UnwrapNestedRefs } from "vue";
 import { defaultGameSettings, GameSettings } from "@/common/settings/game.js";
-import { ClockSoundTarget, Tab, TextDecodingRule } from "@/common/settings/app.js";
+import {
+  ClockSoundTarget,
+  CopyPositionFormat,
+  CopyRecordFormat,
+  Tab,
+  TextDecodingRule,
+} from "@/common/settings/app.js";
 import { beepShort, beepUnlimited, playPieceBeat, stopBeep } from "@/renderer/devices/audio.js";
 import { SearchInfoSenderType, SearchInfo as SearchInfoParam } from "@/common/record/types.js";
 import {
@@ -1481,6 +1487,40 @@ class Store {
       return this.recordManager.jumpToBookmark(bookmark);
     }
     return false;
+  }
+
+  copyRecord(): void {
+    switch (useAppSettings().copyRecordFormat) {
+      case CopyRecordFormat.KI2:
+        this.copyRecordKI2();
+        break;
+      case CopyRecordFormat.CSA:
+        this.copyRecordCSA();
+        break;
+      case CopyRecordFormat.USI:
+        this.copyRecordUSI("all");
+        break;
+      case CopyRecordFormat.JKF:
+        this.copyRecordJKF();
+        break;
+      case CopyRecordFormat.USEN:
+        this.copyRecordUSEN();
+        break;
+      default:
+        this.copyRecordKIF();
+        break;
+    }
+  }
+
+  copyBoard(): void {
+    switch (useAppSettings().copyPositionFormat) {
+      case CopyPositionFormat.BOD:
+        this.copyBoardBOD();
+        break;
+      default:
+        this.copyBoardSFEN();
+        break;
+    }
   }
 
   copyRecordKIF(options?: { fromCurrentPosition?: boolean }): void {

--- a/src/renderer/store/settings.ts
+++ b/src/renderer/store/settings.ts
@@ -6,6 +6,8 @@ import {
   BoardLabelType,
   BranchListMode,
   ClockSoundTarget,
+  CopyPositionFormat,
+  CopyRecordFormat,
   EvaluationViewFrom,
   HandPieceOrder,
   KingPieceType,
@@ -159,6 +161,12 @@ class AppSettingsStore {
   }
   get defaultRecordFileFormat(): RecordFileFormat {
     return this.merged.defaultRecordFileFormat;
+  }
+  get copyRecordFormat(): CopyRecordFormat {
+    return this.merged.copyRecordFormat;
+  }
+  get copyPositionFormat(): CopyPositionFormat {
+    return this.merged.copyPositionFormat;
   }
   get textDecodingRule(): TextDecodingRule {
     return this.merged.textDecodingRule;

--- a/src/renderer/view/App.vue
+++ b/src/renderer/view/App.vue
@@ -94,6 +94,7 @@
     <!-- https://github.com/sunfish-shogi/shogihome/issues/1114 -->
     <div ref="clipboard" hidden>
       <button data-hotkey="Mod+c" @click="onCopy"></button>
+      <button data-hotkey="Mod+b" @click="onCopyBoard"></button>
       <button data-hotkey="Mod+v" @click="onPaste"></button>
     </div>
   </div>
@@ -164,7 +165,11 @@ const confirmation = useConfirmationStore();
 const nextMoveQuiz = useNextMoveQuizStore();
 
 const onCopy = () => {
-  store.copyRecordKIF();
+  store.copyRecord();
+};
+
+const onCopyBoard = () => {
+  store.copyBoard();
 };
 
 const onPaste = () => {

--- a/src/renderer/view/dialog/AppSettingsDialog.vue
+++ b/src/renderer/view/dialog/AppSettingsDialog.vue
@@ -420,6 +420,38 @@
           ]"
         />
       </div>
+      <!-- 棋譜コピーの形式 -->
+      <div class="form-item">
+        <div class="form-item-label-wide">
+          {{ t.copyRecordFormat }}
+        </div>
+        <HorizontalSelector
+          v-model:value="update.copyRecordFormat"
+          class="selector"
+          :items="[
+            { label: 'KIF', value: CopyRecordFormat.KIF },
+            { label: 'KI2', value: CopyRecordFormat.KI2 },
+            { label: 'CSA', value: CopyRecordFormat.CSA },
+            { label: 'USI', value: CopyRecordFormat.USI },
+            { label: 'JKF', value: CopyRecordFormat.JKF },
+            { label: 'USEN', value: CopyRecordFormat.USEN },
+          ]"
+        />
+      </div>
+      <!-- 局面コピーの形式 -->
+      <div class="form-item">
+        <div class="form-item-label-wide">
+          {{ t.copyPositionFormat }}
+        </div>
+        <HorizontalSelector
+          v-model:value="update.copyPositionFormat"
+          class="selector"
+          :items="[
+            { label: 'SFEN', value: CopyPositionFormat.SFEN },
+            { label: 'BOD', value: CopyPositionFormat.BOD },
+          ]"
+        />
+      </div>
       <!-- 文字コード -->
       <div class="form-item">
         <div class="form-item-label-wide">
@@ -847,6 +879,8 @@ import {
   AppSettingsUpdate,
   NodeCountFormat,
   RecordShortcutKeys,
+  CopyRecordFormat,
+  CopyPositionFormat,
 } from "@/common/settings/app";
 import ImageSelector from "@/renderer/view/dialog/ImageSelector.vue";
 import ToggleButton from "@/renderer/view/primitive/ToggleButton.vue";
@@ -923,6 +957,8 @@ const update = ref({
   clockSoundTarget: org.clockSoundTarget,
   recordShortcutKeys: org.recordShortcutKeys,
   defaultRecordFileFormat: org.defaultRecordFileFormat,
+  copyRecordFormat: org.copyRecordFormat,
+  copyPositionFormat: org.copyPositionFormat,
   textDecodingRule: org.textDecodingRule,
   returnCode: org.returnCode,
   recordFileNameTemplate: org.recordFileNameTemplate,

--- a/src/tests/renderer/store/index.spec.ts
+++ b/src/tests/renderer/store/index.spec.ts
@@ -22,7 +22,7 @@ import { convert } from "encoding-japanese";
 import fs from "node:fs";
 import { Mocked, MockedClass } from "vitest";
 import { useAppSettings } from "@/renderer/store/settings.js";
-import { defaultAppSettings } from "@/common/settings/app.js";
+import { CopyPositionFormat, CopyRecordFormat, defaultAppSettings } from "@/common/settings/app.js";
 import { useMessageStore } from "@/renderer/store/message.js";
 import { useBusyState } from "@/renderer/store/busy.js";
 import { useErrorStore } from "@/renderer/store/error.js";
@@ -787,6 +787,93 @@ describe("store/index", () => {
     );
 
     store.copyBoardBOD();
+    expect(writeText).lastCalledWith(`後手の持駒：なし
+  ９ ８ ７ ６ ５ ４ ３ ２ １
++---------------------------+
+|v香v桂v銀v金v玉v金v銀v桂v香|一
+| ・v飛 ・ ・ ・ ・ ・v角 ・|二
+|v歩v歩v歩v歩v歩v歩v歩v歩v歩|三
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|四
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|五
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|六
+| 歩 歩 歩 歩 歩 歩 歩 歩 歩|七
+| ・ 角 ・ ・ ・ ・ ・ 飛 ・|八
+| 香 桂 銀 金 玉 金 銀 桂 香|九
++---------------------------+
+先手の持駒：なし
+先手番
+手数＝0    まで
+`);
+  });
+
+  it("copyRecord/configuredFormat", async () => {
+    const writeText = vi.fn();
+    vi.spyOn(global, "navigator", "get").mockReturnValueOnce(
+      Object.assign(navigator, {
+        clipboard: {
+          writeText,
+        },
+      }),
+    );
+    const store = createStore();
+    store.pasteRecord("position startpos moves 2g2f 3c3d 7g7f 4a3b");
+    store.changePly(2);
+
+    // 既定値は KIF 形式
+    store.copyRecord();
+    expect(writeText).lastCalledWith(
+      "手合割：平手\r\n" +
+        "手数----指手---------消費時間--\r\n" +
+        "   1 ２六歩(27)   ( 0:00/00:00:00)\r\n" +
+        "   2 ３四歩(33)   ( 0:00/00:00:00)\r\n" +
+        "   3 ７六歩(77)   ( 0:00/00:00:00)\r\n" +
+        "   4 ３二金(41)   ( 0:00/00:00:00)\r\n",
+    );
+
+    await useAppSettings().updateAppSettings({ copyRecordFormat: CopyRecordFormat.KI2 });
+    store.copyRecord();
+    expect(writeText).lastCalledWith("手合割：平手\r\n▲２六歩    △３四歩    ▲７六歩    △３二金");
+
+    await useAppSettings().updateAppSettings({ copyRecordFormat: CopyRecordFormat.CSA });
+    store.copyRecord();
+    expect(writeText).lastCalledWith(
+      "V2.2\r\nPI\r\n+\r\n+2726FU\r\nT0\r\n-3334FU\r\nT0\r\n+7776FU\r\nT0\r\n-4132KI\r\nT0\r\n",
+    );
+
+    // USI 形式は現在の指し手までではなく全ての指し手を出力する。
+    await useAppSettings().updateAppSettings({ copyRecordFormat: CopyRecordFormat.USI });
+    store.copyRecord();
+    expect(writeText).lastCalledWith("position startpos moves 2g2f 3c3d 7g7f 4a3b");
+
+    await useAppSettings().updateAppSettings({ copyRecordFormat: CopyRecordFormat.JKF });
+    store.copyRecord();
+    expect(writeText).lastCalledWith(expect.stringContaining('"preset":"HIRATE"'));
+
+    await useAppSettings().updateAppSettings({ copyRecordFormat: CopyRecordFormat.USEN });
+    store.copyRecord();
+    expect(writeText).lastCalledWith("~0.6y22jm7ku0e4.");
+  });
+
+  it("copyBoard/configuredFormat", async () => {
+    const writeText = vi.fn();
+    vi.spyOn(global, "navigator", "get").mockReturnValueOnce(
+      Object.assign(navigator, {
+        clipboard: {
+          writeText,
+        },
+      }),
+    );
+    const store = createStore();
+    store.pasteRecord(sampleKIF);
+
+    // 既定値は SFEN 形式
+    store.copyBoard();
+    expect(writeText).lastCalledWith(
+      "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1",
+    );
+
+    await useAppSettings().updateAppSettings({ copyPositionFormat: CopyPositionFormat.BOD });
+    store.copyBoard();
     expect(writeText).lastCalledWith(`後手の持駒：なし
   ９ ８ ７ ６ ５ ４ ３ ２ １
 +---------------------------+


### PR DESCRIPTION
# 説明 / Description

This PR adds user-configurable formats for copying game records and board positions via keyboard shortcuts (Ctrl/Cmd+C and Ctrl/Cmd+B).

## Changes

### New Features
- **Record Copy Format**: Users can now choose the format when copying a record via Ctrl/Cmd+C:
  - KIF (default)
  - KI2
  - CSA
  - USI
  - JKF
  - USEN

- **Board Copy Format**: Users can now choose the format when copying a board position via Ctrl/Cmd+B:
  - SFEN (default)
  - BOD

### Implementation Details
- Added `CopyRecordFormat` and `CopyPositionFormat` enums to `src/common/settings/app.ts`
- Added settings fields `copyRecordFormat` and `copyPositionFormat` to `AppSettings` type with defaults
- Implemented `copyRecord()` and `copyBoard()` dispatcher methods in the store that route to the appropriate format-specific method based on user settings
- Added UI controls in `AppSettingsDialog.vue` to configure these formats
- Updated keyboard shortcut handling in `App.vue` to call the new dispatcher methods
- Removed accelerator keys from menu items since format selection is now dynamic (handled via renderer-side hotkeys)
- Added i18n strings for the new settings (with TODO translations for non-English locales per project convention)

### Testing
- Added comprehensive unit tests in `src/tests/renderer/store/index.spec.ts`:
  - `copyRecord/configuredFormat` test verifies all record formats work correctly
  - `copyBoard/configuredFormat` test verifies all board formats work correctly

# チェックリスト / Checklist

- MUST
  - [ ] `npm test` passed
  - [ ] `npm run lint` was applied without warnings
  - [ ] changes of `/docs/webapp` not included (except release branch)
  - [ ] `console.log` not included (except script file)
- RECOMMENDED
  - [x] unit test added/updated
  - [x] i18n

https://claude.ai/code/session_01UnkqauYhSGtdJKanTW8VGt