### PR TITLE
SFENコピーにショートカットキーを割り当て

### DIFF
--- a/src/background/window/menu.ts
+++ b/src/background/window/menu.ts
@@ -175,7 +175,7 @@ function createMenuTemplate(window: BrowserWindow) {
         {
           label: t.copyPosition,
           submenu: [
-            menuItem(t.asSFEN, MenuEvent.COPY_BOARD_SFEN, null),
+            menuItem(t.asSFEN, MenuEvent.COPY_BOARD_SFEN, null, "CmdOrCtrl+B"),
             menuItem(t.asBOD, MenuEvent.COPY_BOARD_BOD, null),
           ],
         },

--- a/src/renderer/view/App.vue
+++ b/src/renderer/view/App.vue
@@ -94,6 +94,7 @@
     <!-- https://github.com/sunfish-shogi/shogihome/issues/1114 -->
     <div ref="clipboard" hidden>
       <button data-hotkey="Mod+c" @click="onCopy"></button>
+      <button data-hotkey="Mod+b" @click="onCopyBoard"></button>
       <button data-hotkey="Mod+v" @click="onPaste"></button>
     </div>
   </div>
@@ -165,6 +166,10 @@ const nextMoveQuiz = useNextMoveQuizStore();
 
 const onCopy = () => {
   store.copyRecordKIF();
+};
+
+const onCopyBoard = () => {
+  store.copyBoardSFEN();
 };
 
 const onPaste = () => {


### PR DESCRIPTION
# 説明 / Description

#1738 

Ctrl+B (Cmd+B) を SFEN コピーに割り当てる。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/shogihome/blob/main/CONTRIBUTING.md)
  - [ ] I am human
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n
