### PR TITLE
局面編集画面にショートカットキーを追加

### DIFF
--- a/src/renderer/view/dialog/PositionEditingDialog.vue
+++ b/src/renderer/view/dialog/PositionEditingDialog.vue
@@ -76,12 +76,7 @@
               <Icon :icon="IconType.UNDO" />
               <div class="label">{{ t.undo }}</div>
             </button>
-            <button
-              class="icon-button"
-              data-hotkey="Mod+Shift+z"
-              :disabled="!canRedo"
-              @click="redo"
-            >
+            <button class="icon-button" data-hotkey="Mod+y" :disabled="!canRedo" @click="redo">
               <Icon :icon="IconType.REDO" />
               <div class="label">{{ t.redo }}</div>
             </button>
@@ -91,7 +86,7 @@
               <Icon :icon="IconType.REFRESH" />
               <div class="label">{{ t.initializePosition }}</div>
             </button>
-            <button class="icon-button" @click="onChangeTurn">
+            <button class="icon-button" data-hotkey="Mod+t" @click="onChangeTurn">
               <Icon :icon="IconType.SWAP" />
               <div class="label">{{ t.changeTurn }}</div>
             </button>
@@ -102,7 +97,7 @@
             @close="isInitialPositionMenuVisible = false"
           />
           <div class="icon-button-row">
-            <button class="icon-button" @click="onCopySFEN">
+            <button class="icon-button" data-hotkey="Mod+c,Mod+b" @click="onCopySFEN">
               <Icon :icon="IconType.COPY" />
               <div class="label">{{ t.copy }}(SFEN)</div>
             </button>
@@ -110,7 +105,7 @@
               <Icon :icon="IconType.COPY" />
               <div class="label">{{ t.copy }}(BOD)</div>
             </button>
-            <button class="icon-button" @click="onPaste">
+            <button class="icon-button" data-hotkey="Mod+v" @click="onPaste">
               <Icon :icon="IconType.PASTE" />
               <div class="label">{{ t.paste }}</div>
             </button>


### PR DESCRIPTION
# 説明 / Description

- 「やり直し」の `Ctrl+Shift+Z` が機能していなかったので `Ctrl+Y` へ変更
- 「SFEN コピー」に `Ctrl+C` と `Ctrl+B` を割り当て
- 「貼り付け」に `Ctrl+V` を割り当て

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/shogihome/blob/main/CONTRIBUTING.md)
  - [ ] I am human
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n
