### PR TITLE
Add minimum response delay for lightweight engine on mobile web

### DIFF
--- a/src/renderer/helpers/env.ts
+++ b/src/renderer/helpers/env.ts
@@ -3,3 +3,8 @@ export const isIOS = () => {
   const isNewiPadOS = navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1;
   return isOldiOS || isNewiPadOS;
 };
+
+export const hasMobileQueryParam = (): boolean => {
+  const urlParams = new URL(window.location.toString()).searchParams;
+  return urlParams.has("mobile");
+};

--- a/src/renderer/ipc/api.ts
+++ b/src/renderer/ipc/api.ts
@@ -7,6 +7,7 @@ import {
 import { GameSettings } from "@/common/settings/game.js";
 import { AppSettings } from "@/common/settings/app.js";
 import { webAPI } from "./web.js";
+import { hasMobileQueryParam } from "@/renderer/helpers/env.js";
 import { ResearchSettings } from "@/common/settings/research.js";
 import { AppState, ResearchState } from "@/common/control/state.js";
 import { GameResult } from "@/common/game/result.js";
@@ -396,6 +397,5 @@ export function isMobileWebApp(): boolean {
   if (isNative()) {
     return false;
   }
-  const urlParams = new URL(window.location.toString()).searchParams;
-  return urlParams.has("mobile");
+  return hasMobileQueryParam();
 }

--- a/src/renderer/ipc/web.ts
+++ b/src/renderer/ipc/web.ts
@@ -31,6 +31,12 @@ import * as uri from "@/common/uri.js";
 import { basename } from "@/renderer/helpers/path.js";
 import { ProcessArgs } from "@/common/ipc/process";
 import { BookFormat } from "@/common/book.js";
+import { hasMobileQueryParam } from "@/renderer/helpers/env.js";
+
+// モバイルウェブ版では軽量エンジンと人が対局する専用メニューがあるため、
+// 軽量エンジンの着手を 500ms まで強制的に遅らせる。
+const MOBILE_MIN_RESPONSE_TIME_MS = 500;
+const goStartTimes = new Map<number, number>();
 
 enum STORAGE_KEY {
   APP_SETTINGS = "appSetting",
@@ -57,8 +63,19 @@ const usiHandlers: Partial<{
 }> = {};
 
 const usiSessionHandlers: USISessionHandlers = {
-  onUSIBestMove: (sessionID, usi, usiMove, ponder) =>
-    usiHandlers.onUSIBestMove?.(sessionID, usi, usiMove, ponder),
+  onUSIBestMove: (sessionID, usi, usiMove, ponder) => {
+    const goStartTime = goStartTimes.get(sessionID);
+    goStartTimes.delete(sessionID);
+    const notify = () => usiHandlers.onUSIBestMove?.(sessionID, usi, usiMove, ponder);
+    if (hasMobileQueryParam() && goStartTime !== undefined) {
+      const remaining = MOBILE_MIN_RESPONSE_TIME_MS - (Date.now() - goStartTime);
+      if (remaining > 0) {
+        setTimeout(notify, remaining);
+        return;
+      }
+    }
+    notify();
+  },
   onUSICheckmate: (sessionID, usi, usiMoves) =>
     usiHandlers.onUSICheckmate?.(sessionID, usi, usiMoves),
   onUSICheckmateNotImplemented: (sessionID) =>
@@ -494,12 +511,14 @@ export const webAPI: Bridge = {
     usiSessions.setOption(sessionID, name, value);
   },
   async usiGo(sessionID: number, usi: string, timeStatesJSON: string): Promise<void> {
+    goStartTimes.set(sessionID, Date.now());
     usiSessions.go(sessionID, usi, JSON.parse(timeStatesJSON) as TimeStates);
   },
   async usiGoPonder(sessionID: number, usi: string, timeStatesJSON: string): Promise<void> {
     usiSessions.goPonder(sessionID, usi, JSON.parse(timeStatesJSON) as TimeStates);
   },
   async usiPonderHit(sessionID: number): Promise<void> {
+    goStartTimes.set(sessionID, Date.now());
     usiSessions.ponderHit(sessionID);
   },
   async usiGoInfinite(sessionID: number, usi: string): Promise<void> {
@@ -515,6 +534,7 @@ export const webAPI: Bridge = {
     usiSessions.gameover(sessionID, result);
   },
   async usiQuit(sessionID: number): Promise<void> {
+    goStartTimes.delete(sessionID);
     usiSessions.quit(sessionID);
   },
   onUSIBestMove(


### PR DESCRIPTION
# 説明 / Description

This PR adds a minimum response time delay for lightweight engine moves on the mobile web version to improve user experience during gameplay.

## Changes

### `src/renderer/ipc/web.ts`
- Added import of `hasMobileQueryParam` helper
- Introduced `MOBILE_MIN_RESPONSE_TIME_MS` constant (500ms) to enforce minimum engine response time on mobile
- Added `goStartTimes` Map to track when each USI session's `go` command was initiated
- Modified `onUSIBestMove` handler to delay move notifications on mobile if the engine responds faster than 500ms
- Updated `usiGo()` to record the start time when a go command is issued
- Updated `usiPonderHit()` to record the start time when ponder hit occurs
- Updated `usiQuit()` to clean up the start time tracking for the session

### `src/renderer/helpers/env.ts`
- Added `hasMobileQueryParam()` function to check for the `?mobile` query parameter

### `src/renderer/ipc/api.ts`
- Refactored `isMobileWebApp()` to use the new `hasMobileQueryParam()` helper, eliminating duplicate logic

## Rationale

On the mobile web version, lightweight engines can respond very quickly, which can feel jarring to users. By enforcing a minimum 500ms response time, the gameplay feels more natural and gives users time to perceive the engine's move.

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED
  - [ ] unit test added/updated

https://claude.ai/code/session_016afJrLs4XFnN9jFYff2QtD