### PR TITLE
Add icon support to HorizontalSelector component

### DIFF
--- a/src/renderer/view/main/MobileLayout.vue
+++ b/src/renderer/view/main/MobileLayout.vue
@@ -41,10 +41,10 @@
           v-if="showRecordViewOnBottom"
           v-model:value="bottomUIType"
           :items="[
-            { label: t.record, value: BottomUIType.RECORD },
-            { label: t.tree, value: BottomUIType.BRANCH_TREE },
-            { label: t.comments, value: BottomUIType.COMMENT },
-            { label: t.recordProperties, value: BottomUIType.INFO },
+            { label: t.record, icon: IconType.DESCRIPTION, value: BottomUIType.RECORD },
+            { label: t.tree, icon: IconType.TREE, value: BottomUIType.BRANCH_TREE },
+            { label: t.comments, icon: IconType.COMMENT, value: BottomUIType.COMMENT },
+            { label: t.recordProperties, icon: IconType.INFO, value: BottomUIType.INFO },
           ]"
           :height="selectorHeight"
         />
@@ -81,9 +81,9 @@
         <HorizontalSelector
           v-model:value="sideUIType"
           :items="[
-            { label: t.record, value: SideUIType.RECORD },
-            { label: t.tree, value: SideUIType.BRANCH_TREE },
-            { label: t.recordProperties, value: SideUIType.INFO },
+            { label: t.record, icon: IconType.DESCRIPTION, value: SideUIType.RECORD },
+            { label: t.tree, icon: IconType.TREE, value: SideUIType.BRANCH_TREE },
+            { label: t.recordProperties, icon: IconType.INFO, value: SideUIType.INFO },
           ]"
           :height="selectorHeight"
         />
@@ -119,6 +119,7 @@ import HorizontalSelector from "@/renderer/view/primitive/HorizontalSelector.vue
 import { t } from "@/common/i18n";
 import RecordInfo from "@/renderer/view/tab/RecordInfo.vue";
 import { isIOS } from "@/renderer/helpers/env";
+import { IconType } from "@/renderer/assets/icons";
 
 const lazyUpdateDelay = 80;
 const selectorHeight = 30;

--- a/src/renderer/view/primitive/HorizontalSelector.vue
+++ b/src/renderer/view/primitive/HorizontalSelector.vue
@@ -7,10 +7,13 @@
           :name="name"
           :checked="item.value === value"
           :value="item.value"
+          :title="item.icon ? item.label : undefined"
+          :aria-label="item.label"
           @change="emit('update:value', item.value)"
         />
-        <div class="button" :style="buttonStyle">
-          <div class="label">{{ item.label }}</div>
+        <div class="button" :style="buttonStyle(item)">
+          <div v-if="item.icon" class="symbol" :style="symbolStyle(item.icon)" />
+          <div v-else class="label">{{ item.label }}</div>
         </div>
       </div>
     </div>
@@ -18,11 +21,14 @@
 </template>
 
 <script setup lang="ts">
+import { IconType, iconSourceMap } from "@/renderer/assets/icons";
 import { issueDOMID } from "@/renderer/helpers/unique";
-import { PropType, Ref, computed, ref } from "vue";
+import { PropType, Ref, ref } from "vue";
 
 type Item = {
   label: string;
+  // アイコンを指定した場合はラベルの代わりにアイコンを表示する。
+  icon?: IconType;
   value: string;
 };
 
@@ -50,17 +56,27 @@ const emit = defineEmits<{
 
 const container = ref() as Ref<HTMLDivElement>;
 const name = issueDOMID();
-const buttonStyle = computed(() => {
+const buttonStyle = (item: Item) => {
   const r = `${props.height * 0.25}px`;
   return {
     height: `${props.height}px`,
-    minWidth: `${props.height * 2.5}px`,
+    minWidth: `${props.height * (item.icon ? 1.6 : 2.5)}px`,
     fontSize: `${props.height * 0.5}px`,
     borderRadius: props.tab ? `${r} ${r} 0 0` : r,
     paddingLeft: r,
     paddingRight: r,
   };
-});
+};
+const symbolStyle = (icon: IconType) => {
+  const size = `${props.height * 0.7}px`;
+  const source = `url(${iconSourceMap[icon]})`;
+  return {
+    width: size,
+    height: size,
+    "-webkit-mask-image": source,
+    "mask-image": source,
+  };
+};
 
 const setValue = (value: string) => {
   for (const input of container.value.querySelectorAll("input")) {
@@ -140,5 +156,18 @@ input:focus ~ .button {
   pointer-events: none;
   text-align: center;
   width: 100%;
+}
+/* アイコンは mask で描画してボタンの文字色を継承させる。 */
+.symbol {
+  pointer-events: none;
+  margin-left: auto;
+  margin-right: auto;
+  background-color: currentColor;
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+  mask-position: center;
+  -webkit-mask-size: contain;
+  mask-size: contain;
 }
 </style>


### PR DESCRIPTION
# 説明 / Description

Enhanced the `HorizontalSelector` component to support displaying icons instead of text labels, improving the mobile UI layout. When an `icon` property is provided in selector items, the component now renders an icon using CSS mask techniques instead of the text label.

## Changes

### HorizontalSelector.vue
- Added optional `icon?: IconType` property to the `Item` type
- Modified button rendering to conditionally display either an icon or text label based on the `icon` property
- Converted `buttonStyle` from a computed property to a function that accepts an `Item` parameter, allowing dynamic `minWidth` calculation (1.6x height for icons vs 2.5x for text)
- Added `symbolStyle` function to generate CSS mask styles for icon rendering
- Added `.symbol` CSS class with mask-image properties to render icons while inheriting button text color
- Added `title` and `aria-label` attributes to radio inputs for accessibility

### MobileLayout.vue
- Updated bottom UI selector items to include icons: `DESCRIPTION`, `TREE`, `COMMENT`, `INFO`
- Updated side UI selector items to include icons: `DESCRIPTION`, `TREE`, `INFO`
- Imported `IconType` from assets

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED
  - [ ] unit test added/updated (existing component tests should cover the changes)

https://claude.ai/code/session_0159Vz57UkbJyT44SDo1aAjM