### PR TITLE
モバイル版のコントロールの縦幅を調整

### DIFF
--- a/src/renderer/view/main/MobileLayout.vue
+++ b/src/renderer/view/main/MobileLayout.vue
@@ -143,9 +143,13 @@ const updateSize = () => {
 };
 
 const showRecordViewOnBottom = computed(() => windowSize.height >= windowSize.width);
-const controlPaneHeight = computed(() =>
-  Math.min(windowSize.height * 0.08, windowSize.width * 0.12),
-);
+const controlPaneHeight = computed(() => {
+  if (showRecordViewOnBottom.value) {
+    return windowSize.height * 0.06;
+  } else {
+    return windowSize.height * 0.1;
+  }
+});
 const boardPaneMaxSize = computed(() => {
   const maxSize = new RectSize(windowSize.width, windowSize.height);
   if (showRecordViewOnBottom.value) {


### PR DESCRIPTION
# 説明 / Description

モバイルのコントロールが他の領域を圧迫しているので、幅を減らす方向に調整する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/shogihome/blob/main/CONTRIBUTING.md)
  - [ ] I am human
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n
