### PR TITLE
Add omitTotalElapsedTime prop to hide cumulative time in move list

### DIFF
--- a/src/renderer/view/main/RecordPane.vue
+++ b/src/renderer/view/main/RecordPane.vue
@@ -15,6 +15,7 @@
         :show-branches="showBranches"
         :shortcut-keys="getRecordShortcutKeys(appSettings.recordShortcutKeys)"
         :branch-list-mode="appSettings.branchListMode"
+        :omit-total-elapsed-time="omitTotalElapsedTime"
         @go-begin="store.changePly(0)"
         @go-back="store.goBack()"
         @go-forward="store.goForward()"
@@ -57,6 +58,7 @@ import { t } from "@/common/i18n";
 import { computed, onBeforeUnmount, onMounted, ref } from "vue";
 import RecordView from "@/renderer/view/primitive/RecordView.vue";
 import { useStore } from "@/renderer/store";
+import { isMobileWebApp } from "@/renderer/ipc/api";
 import { AppState } from "@/common/control/state.js";
 import {
   installHotKeyForMainWindow,
@@ -100,6 +102,7 @@ defineProps({
 
 const store = useStore();
 const appSettings = useAppSettings();
+const omitTotalElapsedTime = isMobileWebApp();
 const root = ref();
 const duplicatePositionsDialog = ref("");
 

--- a/src/renderer/view/primitive/RecordView.vue
+++ b/src/renderer/view/primitive/RecordView.vue
@@ -29,7 +29,7 @@
             {{ move.ply !== 0 ? move.ply : "" }}
           </div>
           <div class="move-text">{{ move.displayText }}</div>
-          <div v-if="showElapsedTime" class="move-time">{{ move.ply ? move.timeText : "" }}</div>
+          <div v-if="showElapsedTime" class="move-time">{{ moveTimeText(move) }}</div>
           <div v-if="showComment" class="move-comment">
             <button
               v-if="operational && (positionCounts.get(move.sfen) || 0) >= 2"
@@ -147,7 +147,7 @@
 </template>
 
 <script setup lang="ts">
-import { ImmutableRecord, ImmutableNode } from "tsshogi";
+import { ImmutableRecord, ImmutableNode, millisecondsToMSS } from "tsshogi";
 import { computed, ref, PropType, onUpdated, onMounted, onBeforeUnmount, watch } from "vue";
 import Icon from "@/renderer/view/primitive/Icon.vue";
 import { IconType } from "@/renderer/assets/icons";
@@ -215,6 +215,11 @@ const props = defineProps({
     type: String as PropType<BranchListMode>,
     required: false,
     default: BranchListMode.SIBLING,
+  },
+  omitTotalElapsedTime: {
+    type: Boolean,
+    required: false,
+    default: false,
   },
 });
 
@@ -324,6 +329,13 @@ const swapWithNextBranch = () => {
   if (props.operational) {
     emit("swapWithNextBranch");
   }
+};
+
+const moveTimeText = (move: ImmutableNode) => {
+  if (!move.ply) {
+    return "";
+  }
+  return props.omitTotalElapsedTime ? millisecondsToMSS(move.elapsedMs) : move.timeText;
 };
 
 const showDuplicatePositions = (sfen: string) => {

--- a/src/tests/renderer/view/primitive/record-view.spec.ts
+++ b/src/tests/renderer/view/primitive/record-view.spec.ts
@@ -1,0 +1,58 @@
+import { mount } from "@vue/test-utils";
+import { Record } from "tsshogi";
+import RecordView from "@/renderer/view/primitive/RecordView.vue";
+import { getRecordShortcutKeys } from "@/renderer/view/primitive/board/shortcut";
+
+function append(record: Record, usi: string, elapsedMs: number): void {
+  const move = record.position.createMoveByUSI(usi);
+  if (!move || !record.append(move)) {
+    throw new Error(`failed to append move: ${usi}`);
+  }
+  record.current.setElapsedMs(elapsedMs);
+}
+
+function buildRecord(): Record {
+  const record = new Record();
+  append(record, "7g7f", 12000);
+  append(record, "3c3d", 5000);
+  return record;
+}
+
+function mountRecordView(omitTotalElapsedTime: boolean) {
+  return mount(RecordView, {
+    props: {
+      record: buildRecord(),
+      showElapsedTime: true,
+      shortcutKeys: getRecordShortcutKeys("vertical"),
+      omitTotalElapsedTime,
+    },
+  });
+}
+
+describe("RecordView", () => {
+  beforeAll(() => {
+    global.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  });
+
+  it("shows elapsed time with total elapsed time", () => {
+    const wrapper = mountRecordView(false);
+    const times = wrapper.findAll(".move-list .move-time");
+    expect(times).toHaveLength(3);
+    expect(times[0].text()).toBe("");
+    expect(times[1].text()).toBe("0:12 / 00:00:12");
+    expect(times[2].text()).toBe("0:05 / 00:00:05");
+  });
+
+  it("omits total elapsed time when omitTotalElapsedTime is set", () => {
+    const wrapper = mountRecordView(true);
+    const times = wrapper.findAll(".move-list .move-time");
+    expect(times).toHaveLength(3);
+    expect(times[0].text()).toBe("");
+    expect(times[1].text()).toBe("0:12");
+    expect(times[2].text()).toBe("0:05");
+  });
+});


### PR DESCRIPTION
# 説明 / Description

This PR adds support for hiding the cumulative elapsed time display in the move list, controlled by a new `omitTotalElapsedTime` prop on `RecordView`. When enabled, only the elapsed time for each individual move is shown (e.g., "0:12") instead of the full format with cumulative time (e.g., "0:12 / 00:00:12").

## Changes

- **RecordView.vue**: 
  - Added `omitTotalElapsedTime` prop (defaults to `false`)
  - Extracted move time formatting logic into `moveTimeText()` method that conditionally includes cumulative time based on the prop
  - Imported `millisecondsToMSS` from tsshogi for formatting individual move times

- **RecordPane.vue**: 
  - Passes `omitTotalElapsedTime` prop to RecordView, set based on `isMobileWebApp()` detection
  - This automatically hides cumulative time on mobile/web app platforms

- **record-view.spec.ts** (new):
  - Added comprehensive unit tests covering both display modes
  - Tests verify correct formatting with and without cumulative time display

## Motivation

Mobile and web app users benefit from a more compact move list display that omits the cumulative time information, reducing visual clutter while still showing individual move times.

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED
  - [x] unit test added/updated

https://claude.ai/code/session_0133M3sRBmRFzLQPDU5dEmWT